### PR TITLE
chore: improve type safety and code quality

### DIFF
--- a/src/adapters/drizzle/batch.ts
+++ b/src/adapters/drizzle/batch.ts
@@ -1,5 +1,5 @@
 import type { Env } from 'hono';
-import { eq, and, isNull, isNotNull, inArray, sql } from 'drizzle-orm';
+import { eq, and, isNull, isNotNull, inArray } from 'drizzle-orm';
 import type { SQL, Table, Column } from 'drizzle-orm';
 import { BatchCreateEndpoint } from '../../endpoints/batch-create';
 import { BatchUpdateEndpoint, type BatchUpdateItem } from '../../endpoints/batch-update';

--- a/src/adapters/drizzle/crud.ts
+++ b/src/adapters/drizzle/crud.ts
@@ -677,7 +677,7 @@ export abstract class DrizzleDeleteEndpoint<
    */
   protected override async countRelated(
     parentId: string | number,
-    relationName: string,
+    _relationName: string,
     relationConfig: RelationConfig,
     tx?: unknown
   ): Promise<number> {
@@ -700,7 +700,7 @@ export abstract class DrizzleDeleteEndpoint<
    */
   protected override async deleteRelated(
     parentId: string | number,
-    relationName: string,
+    _relationName: string,
     relationConfig: RelationConfig,
     tx?: unknown
   ): Promise<number> {
@@ -723,7 +723,7 @@ export abstract class DrizzleDeleteEndpoint<
    */
   protected override async nullifyRelated(
     parentId: string | number,
-    relationName: string,
+    _relationName: string,
     relationConfig: RelationConfig,
     tx?: unknown
   ): Promise<number> {

--- a/src/adapters/drizzle/factory.ts
+++ b/src/adapters/drizzle/factory.ts
@@ -1,7 +1,7 @@
 import type { Env } from 'hono';
 import type { MetaInput } from '../../core/types';
 import type { AdapterBundle } from '../../config/index';
-import { type DrizzleDatabaseConstraint, type DrizzleDatabase } from './helpers';
+import { type DrizzleDatabaseConstraint } from './helpers';
 import {
   DrizzleCreateEndpoint,
   DrizzleReadEndpoint,

--- a/src/adapters/drizzle/helpers.ts
+++ b/src/adapters/drizzle/helpers.ts
@@ -1,4 +1,4 @@
-import { eq, and, or, ne, gt, gte, lt, lte, like, ilike, inArray, notInArray, isNull, isNotNull, between, sql, getTableColumns } from 'drizzle-orm';
+import { eq, ne, gt, gte, lt, lte, like, ilike, inArray, notInArray, isNull, isNotNull, between, getTableColumns } from 'drizzle-orm';
 import type { SQL, Table, Column } from 'drizzle-orm';
 import type {
   MetaInput,

--- a/src/adapters/drizzle/schema-utils.ts
+++ b/src/adapters/drizzle/schema-utils.ts
@@ -33,8 +33,7 @@ const require = createRequire(import.meta.url);
  * Duck-typed interface for Drizzle tables.
  * This allows compatibility across different drizzle-orm versions and package installations.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type DrizzleTable = { _: { name: string; columns: Record<string, any> } };
+type DrizzleTable = { _: { name: string; columns: Record<string, unknown> } };
 
 // Type definitions for drizzle-zod functions
 // These allow the module to compile even without drizzle-zod installed

--- a/src/adapters/memory/advanced.ts
+++ b/src/adapters/memory/advanced.ts
@@ -193,7 +193,7 @@ export abstract class MemoryUpsertEndpoint<
    */
   protected async nativeUpsert(
     data: Partial<ModelObject<M['model']>>,
-    tx?: unknown
+    _tx?: unknown
   ): Promise<{ data: ModelObject<M['model']>; created: boolean }> {
     const store = getStore<ModelObject<M['model']>>(this._meta.model.tableName);
     const upsertKeys = this.getUpsertKeys();
@@ -270,7 +270,7 @@ export abstract class MemoryUpsertEndpoint<
    */
   protected async processNestedWrites(
     parentId: string | number,
-    relationName: string,
+    _relationName: string,
     relationConfig: RelationConfig,
     operations: NestedUpdateInput
   ): Promise<NestedWriteResult> {

--- a/src/adapters/memory/batch.ts
+++ b/src/adapters/memory/batch.ts
@@ -275,7 +275,7 @@ export abstract class MemoryBatchUpsertEndpoint<
    */
   protected async nativeBatchUpsert(
     items: Partial<ModelObject<M['model']>>[],
-    tx?: unknown
+    _tx?: unknown
   ): Promise<{
     items: Array<{ data: ModelObject<M['model']>; created: boolean; index: number }>;
     createdCount: number;

--- a/src/adapters/memory/crud.ts
+++ b/src/adapters/memory/crud.ts
@@ -55,7 +55,7 @@ export abstract class MemoryCreateEndpoint<
    */
   protected async createNested(
     parentId: string | number,
-    relationName: string,
+    _relationName: string,
     relationConfig: RelationConfig,
     data: unknown
   ): Promise<unknown[]> {
@@ -211,7 +211,7 @@ export abstract class MemoryUpdateEndpoint<
    */
   protected async processNestedWrites(
     parentId: string | number,
-    relationName: string,
+    _relationName: string,
     relationConfig: RelationConfig,
     operations: NestedUpdateInput
   ): Promise<NestedWriteResult> {
@@ -380,7 +380,7 @@ export abstract class MemoryDeleteEndpoint<
    */
   protected async countRelated(
     parentId: string | number,
-    relationName: string,
+    _relationName: string,
     relationConfig: RelationConfig
   ): Promise<number> {
     const relatedStore = getStore<Record<string, unknown>>(relationConfig.model);
@@ -400,7 +400,7 @@ export abstract class MemoryDeleteEndpoint<
    */
   protected async deleteRelated(
     parentId: string | number,
-    relationName: string,
+    _relationName: string,
     relationConfig: RelationConfig
   ): Promise<number> {
     const relatedStore = getStore<Record<string, unknown>>(relationConfig.model);
@@ -422,7 +422,7 @@ export abstract class MemoryDeleteEndpoint<
    */
   protected async nullifyRelated(
     parentId: string | number,
-    relationName: string,
+    _relationName: string,
     relationConfig: RelationConfig
   ): Promise<number> {
     const relatedStore = getStore<Record<string, unknown>>(relationConfig.model);

--- a/src/adapters/prisma/advanced.ts
+++ b/src/adapters/prisma/advanced.ts
@@ -358,7 +358,7 @@ export abstract class PrismaUpsertEndpoint<
    */
   protected override async nativeUpsert(
     data: Partial<ModelObject<M['model']>>,
-    tx?: unknown
+    _tx?: unknown
   ): Promise<{ data: ModelObject<M['model']>; created: boolean }> {
     const model = this.getModel();
     const upsertKeys = this.getUpsertKeys();

--- a/src/adapters/prisma/batch.ts
+++ b/src/adapters/prisma/batch.ts
@@ -82,7 +82,6 @@ export abstract class PrismaBatchCreateEndpoint<
   override async batchCreate(
     items: Partial<ModelObject<M['model']>>[]
   ): Promise<ModelObject<M['model']>[]> {
-    const model = this.getModel();
     const primaryKey = this._meta.model.primaryKeys[0];
 
     // Generate IDs for items that don't have them
@@ -403,7 +402,7 @@ export abstract class PrismaBatchUpsertEndpoint<
    */
   protected override async nativeBatchUpsert(
     items: Partial<ModelObject<M['model']>>[],
-    tx?: unknown
+    _tx?: unknown
   ): Promise<{
     items: Array<{ data: ModelObject<M['model']>; created: boolean; index: number }>;
     createdCount: number;

--- a/src/api-version/types.ts
+++ b/src/api-version/types.ts
@@ -1,4 +1,4 @@
-import type { Context, Env, MiddlewareHandler } from 'hono';
+import type { Context, MiddlewareHandler } from 'hono';
 
 /**
  * Strategy for extracting the API version from requests.

--- a/src/auth/guards.ts
+++ b/src/auth/guards.ts
@@ -1,5 +1,5 @@
 import type { MiddlewareHandler } from 'hono';
-import type { AuthEnv, AuthUser, AuthorizationCheck, OwnershipExtractor, Guard } from './types';
+import type { AuthEnv, AuthorizationCheck, OwnershipExtractor, Guard } from './types';
 import { ForbiddenException, UnauthorizedException } from '../core/exceptions';
 
 // ============================================================================
@@ -332,7 +332,7 @@ export function denyAll<E extends AuthEnv = AuthEnv>(
  * ```
  */
 export function allowAll<E extends AuthEnv = AuthEnv>(): MiddlewareHandler<E> {
-  return async (ctx, next) => {
+  return async (_ctx, next) => {
     await next();
   };
 }

--- a/src/auth/middleware/combined.ts
+++ b/src/auth/middleware/combined.ts
@@ -1,5 +1,5 @@
-import type { Context, MiddlewareHandler } from 'hono';
-import type { AuthEnv, AuthConfig, PathPattern, AuthType } from '../types';
+import type { MiddlewareHandler } from 'hono';
+import type { AuthEnv, AuthConfig, PathPattern } from '../types';
 import { UnauthorizedException } from '../../core/exceptions';
 import { createJWTMiddleware } from './jwt';
 import { createAPIKeyMiddleware } from './api-key';

--- a/src/builder/index.ts
+++ b/src/builder/index.ts
@@ -111,8 +111,7 @@ export class CreateBuilder<M extends MetaInput, E extends Env = Env> {
    * @param BaseClass - The adapter-specific base class to extend
    * @returns A class that can be used with registerCrud
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  build<B extends abstract new () => any>(BaseClass: B): B {
+  build<B extends abstract new () => unknown>(BaseClass: B): B {
     const config = {
       meta: this.meta,
       schema: this._schema,
@@ -124,7 +123,7 @@ export class CreateBuilder<M extends MetaInput, E extends Env = Env> {
     };
     const middlewares = this._middlewares;
 
-    // @ts-expect-error - Dynamic class creation
+    // @ts-expect-error - TS cannot resolve members of dynamically-provided abstract base class (TS#4628)
     const GeneratedClass = class extends BaseClass {
       static _middlewares = middlewares;
       _meta = config.meta;
@@ -289,8 +288,7 @@ export class ListBuilder<M extends MetaInput, E extends Env = Env> {
    * @param BaseClass - The adapter-specific base class to extend
    * @returns A class that can be used with registerCrud
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  build<B extends abstract new () => any>(BaseClass: B): B {
+  build<B extends abstract new () => unknown>(BaseClass: B): B {
     const config = {
       meta: this.meta,
       schema: this._schema,
@@ -313,7 +311,7 @@ export class ListBuilder<M extends MetaInput, E extends Env = Env> {
     };
     const middlewares = this._middlewares;
 
-    // @ts-expect-error - Dynamic class creation
+    // @ts-expect-error - TS cannot resolve members of dynamically-provided abstract base class (TS#4628)
     const GeneratedClass = class extends BaseClass {
       static _middlewares = middlewares;
       _meta = config.meta;
@@ -450,8 +448,7 @@ export class ReadBuilder<M extends MetaInput, E extends Env = Env> {
    * @param BaseClass - The adapter-specific base class to extend
    * @returns A class that can be used with registerCrud
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  build<B extends abstract new () => any>(BaseClass: B): B {
+  build<B extends abstract new () => unknown>(BaseClass: B): B {
     const config = {
       meta: this.meta,
       schema: this._schema,
@@ -468,7 +465,7 @@ export class ReadBuilder<M extends MetaInput, E extends Env = Env> {
     };
     const middlewares = this._middlewares;
 
-    // @ts-expect-error - Dynamic class creation
+    // @ts-expect-error - TS cannot resolve members of dynamically-provided abstract base class (TS#4628)
     const GeneratedClass = class extends BaseClass {
       static _middlewares = middlewares;
       _meta = config.meta;
@@ -614,8 +611,7 @@ export class UpdateBuilder<M extends MetaInput, E extends Env = Env> {
    * @param BaseClass - The adapter-specific base class to extend
    * @returns A class that can be used with registerCrud
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  build<B extends abstract new () => any>(BaseClass: B): B {
+  build<B extends abstract new () => unknown>(BaseClass: B): B {
     const config = {
       meta: this.meta,
       schema: this._schema,
@@ -632,7 +628,7 @@ export class UpdateBuilder<M extends MetaInput, E extends Env = Env> {
     };
     const middlewares = this._middlewares;
 
-    // @ts-expect-error - Dynamic class creation
+    // @ts-expect-error - TS cannot resolve members of dynamically-provided abstract base class (TS#4628)
     const GeneratedClass = class extends BaseClass {
       static _middlewares = middlewares;
       _meta = config.meta;
@@ -763,8 +759,7 @@ export class DeleteBuilder<M extends MetaInput, E extends Env = Env> {
    * @param BaseClass - The adapter-specific base class to extend
    * @returns A class that can be used with registerCrud
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  build<B extends abstract new () => any>(BaseClass: B): B {
+  build<B extends abstract new () => unknown>(BaseClass: B): B {
     const config = {
       meta: this.meta,
       schema: this._schema,
@@ -778,7 +773,7 @@ export class DeleteBuilder<M extends MetaInput, E extends Env = Env> {
     };
     const middlewares = this._middlewares;
 
-    // @ts-expect-error - Dynamic class creation
+    // @ts-expect-error - TS cannot resolve members of dynamically-provided abstract base class (TS#4628)
     const GeneratedClass = class extends BaseClass {
       static _middlewares = middlewares;
       _meta = config.meta;

--- a/src/cache/mixin.ts
+++ b/src/cache/mixin.ts
@@ -1,6 +1,6 @@
 import type { Context, Env } from 'hono';
 import type { OpenAPIRoute } from '../core/route';
-import type { MetaInput } from '../core/types';
+import type { MetaInput, Constructor } from '../core/types';
 import { getLogger } from '../core/logger';
 import type {
   CacheConfig,
@@ -54,11 +54,6 @@ export function getCacheStorage(): CacheStorage {
 // ============================================================================
 // Type Helpers
 // ============================================================================
-
-/**
- * Constructor type for classes.
- */
-type Constructor<T = object> = new (...args: unknown[]) => T;
 
 /**
  * Interface for cacheable endpoint methods added by withCache mixin.
@@ -127,7 +122,7 @@ export interface CacheInvalidationMethods {
 export function withCache<TBase extends Constructor<OpenAPIRoute>>(
   Base: TBase
 ): TBase & Constructor<CacheEndpointMethods> {
-  // @ts-expect-error - TypeScript has issues with mixin patterns and protected members
+  // @ts-expect-error - TS mixin limitation: cannot access protected members of generic base class (TS#17744)
   class CachedRoute extends Base implements CacheEndpointMethods {
     /**
      * Cache configuration for this endpoint.
@@ -320,7 +315,7 @@ export function withCache<TBase extends Constructor<OpenAPIRoute>>(
 export function withCacheInvalidation<TBase extends Constructor<OpenAPIRoute>>(
   Base: TBase
 ): TBase & Constructor<CacheInvalidationMethods> {
-  // @ts-expect-error - TypeScript has issues with mixin patterns and protected members
+  // @ts-expect-error - TS mixin limitation: cannot access protected members of generic base class (TS#17744)
   class InvalidatingRoute extends Base implements CacheInvalidationMethods {
     /**
      * Cache invalidation configuration.
@@ -397,7 +392,7 @@ export function withCacheInvalidation<TBase extends Constructor<OpenAPIRoute>>(
      * Override handle to perform invalidation after the mutation.
      */
     async handle(): Promise<Response> {
-      // @ts-expect-error - TypeScript can't see that Base has a concrete handle implementation
+      // @ts-expect-error - TS mixin limitation: super.handle() not visible through generic base (TS#17744)
       const response = await super.handle();
 
       // Only invalidate on success

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -32,9 +32,9 @@
  * ```
  */
 
-import type { Env } from 'hono';
 import type { MetaInput, HookMode } from '../core/types';
 import type { ModelObject } from '../endpoints/types';
+
 
 // Import memory adapters for the MemoryAdapters bundle
 import {
@@ -242,32 +242,22 @@ export interface EndpointsConfig<M extends MetaInput> {
  * Adapter bundle containing base classes for all CRUD operations.
  */
 export interface AdapterBundle {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  CreateEndpoint: abstract new () => any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ListEndpoint: abstract new () => any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ReadEndpoint: abstract new () => any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  UpdateEndpoint: abstract new () => any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  DeleteEndpoint: abstract new () => any;
+  CreateEndpoint: abstract new () => unknown;
+  ListEndpoint: abstract new () => unknown;
+  ReadEndpoint: abstract new () => unknown;
+  UpdateEndpoint: abstract new () => unknown;
+  DeleteEndpoint: abstract new () => unknown;
 }
 
 /**
  * Generated endpoints object compatible with registerCrud.
  */
 export interface GeneratedEndpoints {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  create?: new () => any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  list?: new () => any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  read?: new () => any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  update?: new () => any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  delete?: new () => any;
+  create?: new () => unknown;
+  list?: new () => unknown;
+  read?: new () => unknown;
+  update?: new () => unknown;
+  delete?: new () => unknown;
 }
 
 // ============================================================================
@@ -338,6 +328,7 @@ export function defineEndpoints<M extends MetaInput>(
     const createConfig = config.create;
     const BaseCreate = adapters.CreateEndpoint;
 
+    // @ts-expect-error - Dynamic class creation: BaseCreate is typed as abstract new () => unknown for flexibility
     result.create = class extends BaseCreate {
       _meta = config.meta;
       schema = createConfig.openapi || {};
@@ -366,6 +357,7 @@ export function defineEndpoints<M extends MetaInput>(
     const listConfig = config.list;
     const BaseList = adapters.ListEndpoint;
 
+    // @ts-expect-error - Dynamic class creation: BaseList is typed as abstract new () => unknown for flexibility
     result.list = class extends BaseList {
       _meta = config.meta;
       schema = listConfig.openapi || {};
@@ -407,6 +399,7 @@ export function defineEndpoints<M extends MetaInput>(
     const readConfig = config.read;
     const BaseRead = adapters.ReadEndpoint;
 
+    // @ts-expect-error - Dynamic class creation: BaseRead is typed as abstract new () => unknown for flexibility
     result.read = class extends BaseRead {
       _meta = config.meta;
       schema = readConfig.openapi || {};
@@ -440,6 +433,7 @@ export function defineEndpoints<M extends MetaInput>(
     const updateConfig = config.update;
     const BaseUpdate = adapters.UpdateEndpoint;
 
+    // @ts-expect-error - Dynamic class creation: BaseUpdate is typed as abstract new () => unknown for flexibility
     result.update = class extends BaseUpdate {
       _meta = config.meta;
       schema = updateConfig.openapi || {};
@@ -479,6 +473,7 @@ export function defineEndpoints<M extends MetaInput>(
     const deleteConfig = config.delete;
     const BaseDelete = adapters.DeleteEndpoint;
 
+    // @ts-expect-error - Dynamic class creation: BaseDelete is typed as abstract new () => unknown for flexibility
     result.delete = class extends BaseDelete {
       _meta = config.meta;
       schema = deleteConfig.openapi || {};

--- a/src/core/audit.ts
+++ b/src/core/audit.ts
@@ -2,7 +2,6 @@ import type { Context, Env } from 'hono';
 import type {
   AuditAction,
   AuditLogEntry,
-  AuditFieldChange,
   NormalizedAuditConfig,
 } from './types';
 import { calculateChanges, getAuditConfig, type AuditConfig } from './types';

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1539,3 +1539,8 @@ export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
  * Make specific fields of a type required.
  */
 export type RequiredBy<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;
+
+/**
+ * Constructor type for classes. Used in mixin patterns (withCache, withAuth, etc.).
+ */
+export type Constructor<T = object> = new (...args: unknown[]) => T;

--- a/src/endpoints/aggregate.ts
+++ b/src/endpoints/aggregate.ts
@@ -10,7 +10,6 @@ import type {
   AggregateResult,
   AggregateConfig,
   NormalizedSoftDeleteConfig,
-  FilterCondition,
 } from '../core/types';
 import { getSoftDeleteConfig, parseAggregateQuery } from '../core/types';
 

--- a/src/endpoints/batch-create.ts
+++ b/src/endpoints/batch-create.ts
@@ -182,8 +182,8 @@ export abstract class BatchCreateEndpoint<
    */
   async before(
     data: Partial<ModelObject<M['model']>>,
-    index: number,
-    tx?: unknown
+    _index: number,
+    _tx?: unknown
   ): Promise<Partial<ModelObject<M['model']>>> {
     return data;
   }
@@ -194,8 +194,8 @@ export abstract class BatchCreateEndpoint<
    */
   async after(
     data: ModelObject<M['model']>,
-    index: number,
-    tx?: unknown
+    _index: number,
+    _tx?: unknown
   ): Promise<ModelObject<M['model']>> {
     return data;
   }

--- a/src/endpoints/batch-delete.ts
+++ b/src/endpoints/batch-delete.ts
@@ -205,8 +205,8 @@ export abstract class BatchDeleteEndpoint<
    * Override to perform checks or side effects.
    */
   async before(
-    id: string,
-    tx?: unknown
+    _id: string,
+    _tx?: unknown
   ): Promise<void> {
     // Override in subclass
   }
@@ -217,7 +217,7 @@ export abstract class BatchDeleteEndpoint<
    */
   async after(
     data: ModelObject<M['model']>,
-    tx?: unknown
+    _tx?: unknown
   ): Promise<ModelObject<M['model']>> {
     return data;
   }

--- a/src/endpoints/batch-restore.ts
+++ b/src/endpoints/batch-restore.ts
@@ -203,8 +203,8 @@ export abstract class BatchRestoreEndpoint<
    * Override to perform checks or side effects.
    */
   async before(
-    id: string,
-    tx?: unknown
+    _id: string,
+    _tx?: unknown
   ): Promise<void> {
     // Override in subclass
   }
@@ -215,7 +215,7 @@ export abstract class BatchRestoreEndpoint<
    */
   async after(
     data: ModelObject<M['model']>,
-    tx?: unknown
+    _tx?: unknown
   ): Promise<ModelObject<M['model']>> {
     return data;
   }

--- a/src/endpoints/batch-update.ts
+++ b/src/endpoints/batch-update.ts
@@ -245,9 +245,9 @@ export abstract class BatchUpdateEndpoint<
    * Override to transform data before update.
    */
   async before(
-    id: string,
+    _id: string,
     data: Partial<ModelObject<M['model']>>,
-    tx?: unknown
+    _tx?: unknown
   ): Promise<Partial<ModelObject<M['model']>>> {
     return data;
   }
@@ -258,7 +258,7 @@ export abstract class BatchUpdateEndpoint<
    */
   async after(
     data: ModelObject<M['model']>,
-    tx?: unknown
+    _tx?: unknown
   ): Promise<ModelObject<M['model']>> {
     return data;
   }

--- a/src/endpoints/batch-upsert.ts
+++ b/src/endpoints/batch-upsert.ts
@@ -304,9 +304,9 @@ export abstract class BatchUpsertEndpoint<
    */
   async beforeItem(
     data: Partial<ModelObject<M['model']>>,
-    index: number,
-    isCreate: boolean,
-    tx?: unknown
+    _index: number,
+    _isCreate: boolean,
+    _tx?: unknown
   ): Promise<Partial<ModelObject<M['model']>>> {
     return data;
   }
@@ -317,9 +317,9 @@ export abstract class BatchUpsertEndpoint<
    */
   async afterItem(
     data: ModelObject<M['model']>,
-    index: number,
-    created: boolean,
-    tx?: unknown
+    _index: number,
+    _created: boolean,
+    _tx?: unknown
   ): Promise<ModelObject<M['model']>> {
     return data;
   }
@@ -329,7 +329,7 @@ export abstract class BatchUpsertEndpoint<
    */
   async beforeBatch(
     items: Partial<ModelObject<M['model']>>[],
-    tx?: unknown
+    _tx?: unknown
   ): Promise<Partial<ModelObject<M['model']>>[]> {
     return items;
   }
@@ -339,7 +339,7 @@ export abstract class BatchUpsertEndpoint<
    */
   async afterBatch(
     result: BatchUpsertResult<ModelObject<M['model']>>,
-    tx?: unknown
+    _tx?: unknown
   ): Promise<BatchUpsertResult<ModelObject<M['model']>>> {
     return result;
   }

--- a/src/endpoints/create.ts
+++ b/src/endpoints/create.ts
@@ -8,11 +8,10 @@ import type {
   OpenAPIRouteSchema,
   HookMode,
   RelationConfig,
-  NestedWriteResult,
   NormalizedAuditConfig,
   NormalizedMultiTenantConfig,
 } from '../core/types';
-import { applyComputedFields, extractNestedData, isDirectNestedData, getAuditConfig, getMultiTenantConfig, extractTenantId } from '../core/types';
+import { applyComputedFields, extractNestedData, getAuditConfig, getMultiTenantConfig, extractTenantId } from '../core/types';
 import { getSchemaFields, type ModelObject } from './types';
 import { createAuditLogger, type AuditLogger } from '../core/audit';
 
@@ -307,7 +306,7 @@ export abstract class CreateEndpoint<
    */
   async before(
     data: ModelObject<M['model']>,
-    tx?: unknown
+    _tx?: unknown
   ): Promise<ModelObject<M['model']>> {
     return data;
   }
@@ -318,7 +317,7 @@ export abstract class CreateEndpoint<
    */
   async after(
     data: ModelObject<M['model']>,
-    tx?: unknown
+    _tx?: unknown
   ): Promise<ModelObject<M['model']>> {
     return data;
   }
@@ -363,11 +362,11 @@ export abstract class CreateEndpoint<
    * @returns The created nested records
    */
   protected async createNested(
-    parentId: string | number,
+    _parentId: string | number,
     relationName: string,
-    relationConfig: RelationConfig,
-    data: unknown,
-    tx?: unknown
+    _relationConfig: RelationConfig,
+    _data: unknown,
+    _tx?: unknown
   ): Promise<unknown[]> {
     // Default implementation does nothing - override in adapter
     getLogger().warn(`Nested writes not implemented for ${relationName}. Override createNested() in your adapter.`);

--- a/src/endpoints/delete.ts
+++ b/src/endpoints/delete.ts
@@ -317,8 +317,8 @@ export abstract class DeleteEndpoint<
    * Override to perform checks or side effects before deleting.
    */
   async before(
-    lookupValue: string,
-    tx?: unknown
+    _lookupValue: string,
+    _tx?: unknown
   ): Promise<void> {
     // Override in subclass
   }
@@ -328,9 +328,9 @@ export abstract class DeleteEndpoint<
    * Override to perform cleanup or side effects after deleting.
    */
   async after(
-    deletedItem: ModelObject<M['model']>,
-    cascadeResult?: CascadeResult,
-    tx?: unknown
+    _deletedItem: ModelObject<M['model']>,
+    _cascadeResult?: CascadeResult,
+    _tx?: unknown
   ): Promise<void> {
     // Override in subclass
   }
@@ -341,10 +341,10 @@ export abstract class DeleteEndpoint<
    * Must be implemented by ORM-specific subclasses.
    */
   protected async countRelated(
-    parentId: string | number,
+    _parentId: string | number,
     relationName: string,
-    relationConfig: RelationConfig,
-    tx?: unknown
+    _relationConfig: RelationConfig,
+    _tx?: unknown
   ): Promise<number> {
     // Default implementation returns 0 - override in adapter
     getLogger().warn(`countRelated not implemented for ${relationName}. Override in your adapter for restrict cascade to work.`);
@@ -356,10 +356,10 @@ export abstract class DeleteEndpoint<
    * Must be implemented by ORM-specific subclasses.
    */
   protected async deleteRelated(
-    parentId: string | number,
+    _parentId: string | number,
     relationName: string,
-    relationConfig: RelationConfig,
-    tx?: unknown
+    _relationConfig: RelationConfig,
+    _tx?: unknown
   ): Promise<number> {
     // Default implementation returns 0 - override in adapter
     getLogger().warn(`deleteRelated not implemented for ${relationName}. Override in your adapter for cascade delete to work.`);
@@ -371,10 +371,10 @@ export abstract class DeleteEndpoint<
    * Must be implemented by ORM-specific subclasses.
    */
   protected async nullifyRelated(
-    parentId: string | number,
+    _parentId: string | number,
     relationName: string,
-    relationConfig: RelationConfig,
-    tx?: unknown
+    _relationConfig: RelationConfig,
+    _tx?: unknown
   ): Promise<number> {
     // Default implementation returns 0 - override in adapter
     getLogger().warn(`nullifyRelated not implemented for ${relationName}. Override in your adapter for setNull cascade to work.`);

--- a/src/endpoints/export.ts
+++ b/src/endpoints/export.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import type { Env } from 'hono';
 import { stream } from 'hono/streaming';
 import { ListEndpoint } from './list';
-import type { MetaInput, OpenAPIRouteSchema, ListFilters, PaginatedResult } from '../core/types';
+import type { MetaInput, OpenAPIRouteSchema, ListFilters } from '../core/types';
 import type { ModelObject } from './types';
 import {
   generateCsv,

--- a/src/endpoints/import.ts
+++ b/src/endpoints/import.ts
@@ -1,12 +1,12 @@
-import { z, type ZodObject, type ZodRawShape, type ZodError } from 'zod';
+import { z, type ZodObject, type ZodRawShape } from 'zod';
 import type { Env } from 'hono';
 import { OpenAPIRoute } from '../core/route';
 import type { MetaInput, OpenAPIRouteSchema, NormalizedAuditConfig } from '../core/types';
 import { getAuditConfig, getSoftDeleteConfig, type NormalizedSoftDeleteConfig } from '../core/types';
 import type { ModelObject } from './types';
 import { createAuditLogger, type AuditLogger } from '../core/audit';
-import { parseCsv, validateCsvHeaders, type CsvParseOptions, type CsvParseResult } from '../utils/csv';
-import { InputValidationException, ConflictException } from '../core/exceptions';
+import { parseCsv, validateCsvHeaders, type CsvParseOptions } from '../utils/csv';
+import { InputValidationException } from '../core/exceptions';
 
 // ============================================================================
 // Import Types
@@ -450,7 +450,7 @@ export abstract class ImportEndpoint<
    */
   protected validateRow(
     data: Partial<ModelObject<M['model']>>,
-    rowNumber: number
+    _rowNumber: number
   ): { valid: boolean; errors?: Array<{ path: string; message: string }> } {
     const schema = this._meta.fields || this._meta.model.schema;
 
@@ -511,9 +511,9 @@ export abstract class ImportEndpoint<
    */
   async before(
     data: Partial<ModelObject<M['model']>>,
-    rowNumber: number,
-    mode: ImportMode,
-    tx?: unknown
+    _rowNumber: number,
+    _mode: ImportMode,
+    _tx?: unknown
   ): Promise<Partial<ModelObject<M['model']>>> {
     return data;
   }
@@ -524,9 +524,9 @@ export abstract class ImportEndpoint<
    */
   async after(
     result: ImportRowResult<ModelObject<M['model']>>,
-    rowNumber: number,
-    mode: ImportMode,
-    tx?: unknown
+    _rowNumber: number,
+    _mode: ImportMode,
+    _tx?: unknown
   ): Promise<ImportRowResult<ModelObject<M['model']>>> {
     return result;
   }

--- a/src/endpoints/list.ts
+++ b/src/endpoints/list.ts
@@ -3,7 +3,7 @@ import type { Env } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import { OpenAPIRoute } from '../core/route';
 import type { MetaInput, OpenAPIRouteSchema, PaginatedResult, NormalizedSoftDeleteConfig, NormalizedMultiTenantConfig } from '../core/types';
-import { getSoftDeleteConfig, applyComputedFieldsToArray, getMultiTenantConfig, extractTenantId, decodeCursor, encodeCursor } from '../core/types';
+import { getSoftDeleteConfig, applyComputedFieldsToArray, getMultiTenantConfig, extractTenantId } from '../core/types';
 import {
   parseListFilters,
   applyFieldSelectionToArray,

--- a/src/endpoints/read.ts
+++ b/src/endpoints/read.ts
@@ -5,7 +5,7 @@ import { OpenAPIRoute } from '../core/route';
 import type { MetaInput, OpenAPIRouteSchema, NormalizedSoftDeleteConfig, NormalizedMultiTenantConfig, IncludeOptions } from '../core/types';
 import { getSoftDeleteConfig, applyComputedFields, getMultiTenantConfig, extractTenantId } from '../core/types';
 import { NotFoundException } from '../core/exceptions';
-import { applyFieldSelection, type SingleEndpointConfig, type ModelObject, type FieldSelection } from './types';
+import { applyFieldSelection, type ModelObject, type FieldSelection } from './types';
 import { generateETag, matchesIfNoneMatch } from '../core/etag';
 
 /**

--- a/src/endpoints/restore.ts
+++ b/src/endpoints/restore.ts
@@ -178,8 +178,8 @@ export abstract class RestoreEndpoint<
    * Override to perform checks or side effects before restoring.
    */
   async before(
-    lookupValue: string,
-    tx?: unknown
+    _lookupValue: string,
+    _tx?: unknown
   ): Promise<void> {
     // Override in subclass
   }
@@ -190,7 +190,7 @@ export abstract class RestoreEndpoint<
    */
   async after(
     restoredItem: ModelObject<M['model']>,
-    tx?: unknown
+    _tx?: unknown
   ): Promise<ModelObject<M['model']>> {
     return restoredItem;
   }

--- a/src/endpoints/update.ts
+++ b/src/endpoints/update.ts
@@ -424,7 +424,7 @@ export abstract class UpdateEndpoint<
    */
   async before(
     data: Partial<ModelObject<M['model']>>,
-    tx?: unknown
+    _tx?: unknown
   ): Promise<Partial<ModelObject<M['model']>>> {
     return data;
   }
@@ -435,7 +435,7 @@ export abstract class UpdateEndpoint<
    */
   async after(
     data: ModelObject<M['model']>,
-    tx?: unknown
+    _tx?: unknown
   ): Promise<ModelObject<M['model']>> {
     return data;
   }
@@ -475,9 +475,9 @@ export abstract class UpdateEndpoint<
    * Override in ORM-specific subclasses if audit logging is enabled.
    */
   protected async findExisting(
-    lookupValue: string,
-    additionalFilters?: Record<string, string>,
-    tx?: unknown
+    _lookupValue: string,
+    _additionalFilters?: Record<string, string>,
+    _tx?: unknown
   ): Promise<ModelObject<M['model']> | null> {
     // Default implementation returns null - override in adapter
     return null;
@@ -495,11 +495,11 @@ export abstract class UpdateEndpoint<
    * @returns The result of nested operations
    */
   protected async processNestedWrites(
-    parentId: string | number,
+    _parentId: string | number,
     relationName: string,
-    relationConfig: RelationConfig,
-    operations: NestedUpdateInput,
-    tx?: unknown
+    _relationConfig: RelationConfig,
+    _operations: NestedUpdateInput,
+    _tx?: unknown
   ): Promise<NestedWriteResult> {
     // Default implementation does nothing - override in adapter
     getLogger().warn(`Nested writes not implemented for ${relationName}. Override processNestedWrites() in your adapter.`);

--- a/src/endpoints/upsert.ts
+++ b/src/endpoints/upsert.ts
@@ -405,8 +405,8 @@ export abstract class UpsertEndpoint<
    */
   async before(
     data: Partial<ModelObject<M['model']>>,
-    isCreate: boolean,
-    tx?: unknown
+    _isCreate: boolean,
+    _tx?: unknown
   ): Promise<Partial<ModelObject<M['model']>>> {
     return data;
   }
@@ -416,7 +416,7 @@ export abstract class UpsertEndpoint<
    */
   async beforeCreate(
     data: Partial<ModelObject<M['model']>>,
-    tx?: unknown
+    _tx?: unknown
   ): Promise<Partial<ModelObject<M['model']>>> {
     return data;
   }
@@ -426,8 +426,8 @@ export abstract class UpsertEndpoint<
    */
   async beforeUpdate(
     data: Partial<ModelObject<M['model']>>,
-    existing: ModelObject<M['model']>,
-    tx?: unknown
+    _existing: ModelObject<M['model']>,
+    _tx?: unknown
   ): Promise<Partial<ModelObject<M['model']>>> {
     return data;
   }
@@ -438,8 +438,8 @@ export abstract class UpsertEndpoint<
    */
   async after(
     data: ModelObject<M['model']>,
-    created: boolean,
-    tx?: unknown
+    _created: boolean,
+    _tx?: unknown
   ): Promise<ModelObject<M['model']>> {
     return data;
   }
@@ -549,11 +549,11 @@ export abstract class UpsertEndpoint<
    * Override in ORM-specific subclasses to implement nested writes.
    */
   protected async processNestedWrites(
-    parentId: string | number,
+    _parentId: string | number,
     relationName: string,
-    relationConfig: RelationConfig,
-    operations: NestedUpdateInput,
-    tx?: unknown
+    _relationConfig: RelationConfig,
+    _operations: NestedUpdateInput,
+    _tx?: unknown
   ): Promise<NestedWriteResult> {
     getLogger().warn(`Nested writes not implemented for ${relationName}. Override processNestedWrites() in your adapter.`);
     return {

--- a/src/endpoints/version-history.ts
+++ b/src/endpoints/version-history.ts
@@ -4,9 +4,7 @@ import { OpenAPIRoute } from '../core/route';
 import type {
   MetaInput,
   OpenAPIRouteSchema,
-  VersionHistoryEntry,
   NormalizedVersioningConfig,
-  AuditFieldChange,
 } from '../core/types';
 import { getVersioningConfig } from '../core/types';
 import { ApiException, NotFoundException } from '../core/exceptions';
@@ -186,7 +184,7 @@ export abstract class VersionHistoryEndpoint<
    * Override in ORM-specific subclasses.
    */
   protected async recordExists(
-    lookupValue: string
+    _lookupValue: string
   ): Promise<boolean> {
     // Default implementation - override in adapter
     return true;

--- a/src/functional/index.ts
+++ b/src/functional/index.ts
@@ -222,8 +222,7 @@ export interface DeleteConfig<M extends MetaInput, E extends Env = Env> {
 export function createCreate<
   M extends MetaInput,
   E extends Env = Env,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  B extends abstract new () => any = abstract new () => any,
+  B extends abstract new () => unknown = abstract new () => unknown,
 >(
   config: CreateConfig<M, E>,
   BaseClass: B
@@ -232,7 +231,7 @@ export function createCreate<
   const afterFn = config.after;
   const middlewares = config.middlewares || [];
 
-  // @ts-expect-error - Dynamic class creation
+  // @ts-expect-error - TS cannot resolve members of dynamically-provided abstract base class (TS#4628)
   const GeneratedClass = class extends BaseClass {
     static _middlewares = middlewares;
     _meta = config.meta;
@@ -280,8 +279,7 @@ export function createCreate<
 export function createList<
   M extends MetaInput,
   E extends Env = Env,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  B extends abstract new () => any = abstract new () => any,
+  B extends abstract new () => unknown = abstract new () => unknown,
 >(
   config: ListConfig<M, E>,
   BaseClass: B
@@ -290,7 +288,7 @@ export function createList<
   const transformFn = config.transform;
   const middlewares = config.middlewares || [];
 
-  // @ts-expect-error - Dynamic class creation
+  // @ts-expect-error - TS cannot resolve members of dynamically-provided abstract base class (TS#4628)
   const GeneratedClass = class extends BaseClass {
     static _middlewares = middlewares;
     _meta = config.meta;
@@ -347,8 +345,7 @@ export function createList<
 export function createRead<
   M extends MetaInput,
   E extends Env = Env,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  B extends abstract new () => any = abstract new () => any,
+  B extends abstract new () => unknown = abstract new () => unknown,
 >(
   config: ReadConfig<M, E>,
   BaseClass: B
@@ -357,7 +354,7 @@ export function createRead<
   const transformFn = config.transform;
   const middlewares = config.middlewares || [];
 
-  // @ts-expect-error - Dynamic class creation
+  // @ts-expect-error - TS cannot resolve members of dynamically-provided abstract base class (TS#4628)
   const GeneratedClass = class extends BaseClass {
     static _middlewares = middlewares;
     _meta = config.meta;
@@ -409,8 +406,7 @@ export function createRead<
 export function createUpdate<
   M extends MetaInput,
   E extends Env = Env,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  B extends abstract new () => any = abstract new () => any,
+  B extends abstract new () => unknown = abstract new () => unknown,
 >(
   config: UpdateConfig<M, E>,
   BaseClass: B
@@ -420,7 +416,7 @@ export function createUpdate<
   const transformFn = config.transform;
   const middlewares = config.middlewares || [];
 
-  // @ts-expect-error - Dynamic class creation
+  // @ts-expect-error - TS cannot resolve members of dynamically-provided abstract base class (TS#4628)
   const GeneratedClass = class extends BaseClass {
     static _middlewares = middlewares;
     _meta = config.meta;
@@ -477,8 +473,7 @@ export function createUpdate<
 export function createDelete<
   M extends MetaInput,
   E extends Env = Env,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  B extends abstract new () => any = abstract new () => any,
+  B extends abstract new () => unknown = abstract new () => unknown,
 >(
   config: DeleteConfig<M, E>,
   BaseClass: B
@@ -487,7 +482,7 @@ export function createDelete<
   const afterFn = config.after;
   const middlewares = config.middlewares || [];
 
-  // @ts-expect-error - Dynamic class creation
+  // @ts-expect-error - TS cannot resolve members of dynamically-provided abstract base class (TS#4628)
   const GeneratedClass = class extends BaseClass {
     static _middlewares = middlewares;
     _meta = config.meta;

--- a/src/health/endpoint.ts
+++ b/src/health/endpoint.ts
@@ -48,7 +48,6 @@ async function runAllChecks(
   checks: HealthCheck[],
   defaultTimeout: number
 ): Promise<{ results: HealthCheckResult[]; status: HealthResponse['status'] }> {
-  const start = Date.now();
   const results = await Promise.all(
     checks.map((c) => runCheck(c, defaultTimeout))
   );

--- a/src/openapi/utils.ts
+++ b/src/openapi/utils.ts
@@ -148,7 +148,7 @@ export function createOneOfErrorSchema<T extends z.ZodSchema[]>(
 /**
  * Type for the validation hook result.
  */
-export interface ValidationHookResult<E extends Env = Env> {
+export interface ValidationHookResult<_E extends Env = Env> {
   success: false;
   error: z.ZodError;
 }

--- a/src/rate-limit/middleware.ts
+++ b/src/rate-limit/middleware.ts
@@ -6,8 +6,6 @@ import type {
   RateLimitStorage,
   KeyStrategy,
   KeyExtractor,
-  FixedWindowEntry,
-  SlidingWindowEntry,
 } from './types';
 import { RateLimitExceededException } from './exceptions';
 import { extractIP, extractUserId, extractAPIKey, shouldSkipPath, generateKey } from './utils';

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -313,21 +313,6 @@ export function createCsvStream<T extends Record<string, unknown>>(
 // ============================================================================
 
 /**
- * Parses a CSV value, handling quoted strings.
- */
-function parseCsvField(field: string, delimiter: string): string {
-  field = field.trim();
-
-  // Check if field is quoted
-  if (field.startsWith('"') && field.endsWith('"')) {
-    // Remove surrounding quotes and unescape doubled quotes
-    return field.slice(1, -1).replace(/""/g, '"');
-  }
-
-  return field;
-}
-
-/**
  * Parses a CSV line into fields, handling quoted values with embedded delimiters.
  */
 function parseCsvLine(line: string, delimiter: string): string[] {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,10 @@
     "rootDir": "src",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "noEmit": true
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary

- **Remove all `any` type violations** — replaced with `unknown` + `@ts-expect-error` where dynamic class creation requires it (config, builder, functional APIs)
- **Improve type safety** — replaced `Function` casts, `as never` patterns, documented `as unknown as Response` Hono cast rationale, added TS issue references to all `@ts-expect-error` comments
- **Enable stricter tsconfig** — added `noUnusedLocals`, `noUnusedParameters`, `noFallthroughCasesInSwitch` and fixed all resulting errors (~80 fixes across 44 files)
- **Code cleanup** — deduplicated filter parsing logic (`coerceFilterValue`), centralized `Constructor<T>` type, removed dead code (`parseCsvField`, unused imports)
- **Wire up `RouterOptions`** — `setupDocs()` now falls back to `options.openapi_url` when no path is provided

## Test plan

- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm test` — 28 test files, 689 tests passing
- [x] `pnpm build` — ESM + DTS build successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)