### PR TITLE
chore: reduce package size with minification and sideEffects

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "drizzle",
     "cloudflare-workers"
   ],
+  "sideEffects": false,
   "files": [
     "dist",
     "README.md",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
   dts: true,
   clean: true,
   sourcemap: false,
+  minify: true,
   splitting: true,
   treeshake: true,
   external: [


### PR DESCRIPTION
## Summary
- Enable `minify: true` in tsup to reduce JS output (~567 KB → ~304 KB)
- Add `sideEffects: false` to package.json to enable tree-shaking for consumers
- Drops unpacked package size from **~1005 KB to ~698 KB (-30%)**

## Test plan
- [x] `pnpm build` succeeds
- [x] All 687 tests pass
- [x] `npm pack --dry-run` confirms reduced size