### PR TITLE
docs: rewrite README and create docs/ reference

### DIFF
--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -1,0 +1,881 @@
+# Advanced Features
+
+This document covers all advanced hono-crud features with code examples.
+
+---
+
+## Soft Delete & Restore
+
+Mark records as deleted instead of removing them. Requires a `deletedAt` field in your schema.
+
+```typescript
+const UserSchema = z.object({
+  id: z.uuid(),
+  name: z.string(),
+  deletedAt: z.date().nullable().optional(),
+});
+
+const UserModel = defineModel({
+  tableName: 'users',
+  schema: UserSchema,
+  primaryKeys: ['id'],
+  softDelete: true,
+  // Or with custom config:
+  // softDelete: {
+  //   field: 'deletedAt',
+  //   allowQueryDeleted: true,
+  //   queryParam: 'withDeleted',
+  // },
+});
+```
+
+**Query parameters:**
+- `?withDeleted=true` - Include soft-deleted records
+- `?onlyDeleted=true` - Show only soft-deleted records
+
+**Restore endpoint:**
+
+```typescript
+import { MemoryRestoreEndpoint } from 'hono-crud/adapters/memory';
+
+class UserRestore extends MemoryRestoreEndpoint {
+  _meta = userMeta;
+  schema = { tags: ['Users'], summary: 'Restore a deleted user' };
+}
+
+registerCrud(app, '/users', {
+  // ...other endpoints
+  restore: UserRestore,
+});
+// Registers: POST /users/:id/restore
+```
+
+---
+
+## Relations
+
+Define relationships between models and load them with `?include=`.
+
+```typescript
+const UserModel = defineModel({
+  tableName: 'users',
+  schema: UserSchema,
+  primaryKeys: ['id'],
+  relations: {
+    posts: { type: 'hasMany', model: 'posts', foreignKey: 'authorId' },
+    profile: { type: 'hasOne', model: 'profiles', foreignKey: 'userId' },
+    comments: { type: 'hasMany', model: 'comments', foreignKey: 'authorId' },
+  },
+});
+
+const PostModel = defineModel({
+  tableName: 'posts',
+  schema: PostSchema,
+  primaryKeys: ['id'],
+  relations: {
+    author: { type: 'belongsTo', model: 'users', foreignKey: 'authorId', localKey: 'id' },
+    comments: { type: 'hasMany', model: 'comments', foreignKey: 'postId' },
+  },
+});
+```
+
+**Enable on endpoints:**
+
+```typescript
+class UserList extends MemoryListEndpoint {
+  _meta = userMeta;
+  allowedIncludes = ['posts', 'profile', 'comments'];
+}
+
+class UserRead extends MemoryReadEndpoint {
+  _meta = userMeta;
+  allowedIncludes = ['posts', 'profile'];
+}
+```
+
+**Query:**
+```
+GET /users?include=posts,profile
+GET /users/123?include=posts
+```
+
+### Relation Types
+
+| Type | Description | Example |
+|------|-------------|---------|
+| `hasOne` | One-to-one (parent side) | User has one Profile |
+| `hasMany` | One-to-many (parent side) | User has many Posts |
+| `belongsTo` | Many-to-one (child side) | Post belongs to User |
+
+---
+
+## Nested Writes
+
+Create or update related records in a single request.
+
+```typescript
+class UserCreate extends MemoryCreateEndpoint {
+  _meta = userMeta;
+  allowNestedCreate = ['profile', 'posts'];
+}
+
+class UserUpdate extends MemoryUpdateEndpoint {
+  _meta = userMeta;
+  allowNestedWrites = ['profile'];
+}
+```
+
+**Request:**
+```json
+POST /users
+{
+  "name": "Alice",
+  "email": "alice@example.com",
+  "profile": {
+    "bio": "Developer",
+    "avatar": "https://example.com/alice.jpg"
+  },
+  "posts": [
+    { "title": "Hello World", "content": "My first post" }
+  ]
+}
+```
+
+---
+
+## Batch Operations
+
+Process multiple records in a single request.
+
+```typescript
+import {
+  MemoryBatchCreateEndpoint,
+  MemoryBatchUpdateEndpoint,
+  MemoryBatchDeleteEndpoint,
+  MemoryBatchRestoreEndpoint,
+} from 'hono-crud/adapters/memory';
+
+class UserBatchCreate extends MemoryBatchCreateEndpoint {
+  _meta = userMeta;
+  schema = { tags: ['Users'], summary: 'Batch create users' };
+  maxBatchSize = 100;
+}
+
+class UserBatchUpdate extends MemoryBatchUpdateEndpoint {
+  _meta = userMeta;
+  schema = { tags: ['Users'], summary: 'Batch update users' };
+  maxBatchSize = 100;
+  allowedUpdateFields = ['name', 'role'];
+}
+
+class UserBatchDelete extends MemoryBatchDeleteEndpoint {
+  _meta = userMeta;
+  schema = { tags: ['Users'], summary: 'Batch delete users' };
+  maxBatchSize = 100;
+}
+
+registerCrud(app, '/users', {
+  // ...standard endpoints
+  batchCreate: UserBatchCreate,
+  batchUpdate: UserBatchUpdate,
+  batchDelete: UserBatchDelete,
+  batchRestore: UserBatchRestore,
+});
+```
+
+**Endpoints generated:**
+- `POST /users/batch` - Batch create
+- `PATCH /users/batch` - Batch update
+- `DELETE /users/batch` - Batch delete
+- `POST /users/batch/restore` - Batch restore
+
+**Batch create request:**
+```json
+POST /users/batch
+{
+  "items": [
+    { "name": "Alice", "email": "alice@example.com", "role": "admin" },
+    { "name": "Bob", "email": "bob@example.com", "role": "user" }
+  ]
+}
+```
+
+**Batch update request:**
+```json
+PATCH /users/batch
+{
+  "items": [
+    { "id": "uuid-1", "data": { "role": "admin" } },
+    { "id": "uuid-2", "data": { "role": "user" } }
+  ]
+}
+```
+
+---
+
+## Upsert
+
+Create or update a record based on unique keys.
+
+```typescript
+import { MemoryUpsertEndpoint } from 'hono-crud/adapters/memory';
+
+class CategoryUpsert extends MemoryUpsertEndpoint {
+  _meta = categoryMeta;
+  schema = { tags: ['Categories'], summary: 'Upsert a category' };
+  upsertKeys = ['name']; // Match on these fields
+}
+
+// Register manually (not part of standard CRUD)
+app.put('/categories', CategoryUpsert);
+```
+
+**Request:**
+```json
+PUT /categories
+{ "name": "Technology", "description": "Tech posts", "sortOrder": 1 }
+```
+
+If a category with `name: "Technology"` exists, it's updated. Otherwise, it's created.
+
+---
+
+## Versioning
+
+Track record version history with rollback support.
+
+```typescript
+import {
+  createVersionManager,
+  setVersioningStorage,
+  MemoryVersioningStorage,
+  VersionHistoryEndpoint,
+  VersionReadEndpoint,
+  VersionCompareEndpoint,
+  VersionRollbackEndpoint,
+} from 'hono-crud';
+
+// Setup storage
+setVersioningStorage(new MemoryVersioningStorage());
+
+// Enable in model
+const UserModel = defineModel({
+  tableName: 'users',
+  schema: UserSchema,
+  primaryKeys: ['id'],
+  versioning: true,
+  // Or: versioning: { maxVersions: 50, includeMetadata: true }
+});
+```
+
+**Version endpoints:**
+
+```typescript
+class UserVersionHistory extends VersionHistoryEndpoint {
+  _meta = userMeta;
+  schema = { tags: ['Users'], summary: 'Version history' };
+}
+
+class UserVersionRead extends VersionReadEndpoint {
+  _meta = userMeta;
+  schema = { tags: ['Users'], summary: 'Read specific version' };
+}
+
+class UserVersionCompare extends VersionCompareEndpoint {
+  _meta = userMeta;
+  schema = { tags: ['Users'], summary: 'Compare versions' };
+}
+
+class UserVersionRollback extends VersionRollbackEndpoint {
+  _meta = userMeta;
+  schema = { tags: ['Users'], summary: 'Rollback to version' };
+}
+```
+
+---
+
+## Audit Logging
+
+Track who changed what and when.
+
+```typescript
+import {
+  createAuditLogger,
+  setAuditStorage,
+  MemoryAuditLogStorage,
+} from 'hono-crud';
+
+// Setup storage
+setAuditStorage(new MemoryAuditLogStorage());
+
+// Enable in model
+const UserModel = defineModel({
+  tableName: 'users',
+  schema: UserSchema,
+  primaryKeys: ['id'],
+  audit: true,
+  // Or: audit: { includeChanges: true, includePrevious: true }
+});
+```
+
+Audit entries include: action type, table, record ID, user ID, timestamp, and optionally the field-level changes.
+
+---
+
+## Full-Text Search
+
+Weighted search with highlighting across multiple fields.
+
+```typescript
+import { SearchEndpoint } from 'hono-crud';
+
+class UserSearch extends SearchEndpoint {
+  _meta = userMeta;
+  schema = { tags: ['Users'], summary: 'Search users' };
+}
+
+// Register separately
+app.get('/users/search', UserSearch);
+```
+
+**Query:**
+```
+GET /users/search?q=alice&fields=name,email&highlight=true
+```
+
+For list endpoints, use `searchFields`:
+
+```typescript
+class UserList extends MemoryListEndpoint {
+  _meta = userMeta;
+  searchFields = ['name', 'email'];
+}
+
+// Query: GET /users?search=alice
+```
+
+---
+
+## Aggregation
+
+Compute sum, count, avg, min, max with grouping.
+
+```typescript
+import { AggregateEndpoint } from 'hono-crud';
+
+class UserAggregate extends AggregateEndpoint {
+  _meta = userMeta;
+  schema = { tags: ['Users'], summary: 'Aggregate user data' };
+}
+
+app.get('/users/aggregate', UserAggregate);
+```
+
+**Query:**
+```
+GET /users/aggregate?aggregate=count:id,avg:age&groupBy=role
+```
+
+---
+
+## Export / Import
+
+Export and import records as CSV or JSON.
+
+```typescript
+import { ExportEndpoint, ImportEndpoint } from 'hono-crud';
+
+class UserExport extends ExportEndpoint {
+  _meta = userMeta;
+  schema = { tags: ['Users'], summary: 'Export users' };
+}
+
+class UserImport extends ImportEndpoint {
+  _meta = userMeta;
+  schema = { tags: ['Users'], summary: 'Import users' };
+}
+
+app.get('/users/export', UserExport);
+app.post('/users/import', UserImport);
+```
+
+**Export:**
+```
+GET /users/export?format=csv
+GET /users/export?format=json&fields=id,name,email
+```
+
+**Import modes:**
+- `create` - Create new records only
+- `update` - Update existing records only
+- `upsert` - Create or update
+
+---
+
+## Computed Fields
+
+Virtual fields calculated at runtime, not stored in the database.
+
+```typescript
+import type { ComputedFieldsConfig } from 'hono-crud';
+
+const computedFields: ComputedFieldsConfig = {
+  fullName: {
+    type: 'string',
+    compute: (record) => `${record.firstName} ${record.lastName}`,
+  },
+  age: {
+    type: 'number',
+    compute: (record) => {
+      const birth = new Date(record.birthDate);
+      const today = new Date();
+      return today.getFullYear() - birth.getFullYear();
+    },
+  },
+  isActive: {
+    type: 'boolean',
+    compute: (record) => record.status === 'active' && record.emailVerified,
+  },
+};
+
+const UserModel = defineModel({
+  tableName: 'users',
+  schema: UserSchema,
+  primaryKeys: ['id'],
+  computedFields,
+});
+```
+
+Computed fields are automatically included in read/list responses.
+
+---
+
+## Field Selection
+
+Allow clients to select which fields to return.
+
+```typescript
+class UserList extends MemoryListEndpoint {
+  _meta = userMeta;
+  fieldSelectionEnabled = true;
+}
+
+class UserRead extends MemoryReadEndpoint {
+  _meta = userMeta;
+  fieldSelectionEnabled = true;
+}
+```
+
+**Query:**
+```
+GET /users?fields=id,name,email
+GET /users/123?fields=id,name
+```
+
+---
+
+## Events & Webhooks
+
+Event emitter for CRUD operations with webhook delivery.
+
+### Event Emitter
+
+```typescript
+import { CrudEventEmitter, setEventEmitter, getEventEmitter } from 'hono-crud';
+
+const events = new CrudEventEmitter();
+setEventEmitter(events);
+
+// Subscribe to specific events
+events.on('users', 'created', (event) => {
+  console.log('User created:', event.recordId);
+});
+
+// Subscribe to all events on a table
+events.on('users', '*', (event) => {
+  console.log(`User ${event.type}:`, event.recordId);
+});
+
+// Subscribe to all events
+events.onAny((event) => {
+  console.log(`${event.type} on ${event.table}:`, event.recordId);
+});
+```
+
+### Webhooks
+
+```typescript
+import { registerWebhooks } from 'hono-crud';
+
+registerWebhooks({
+  endpoints: [
+    {
+      url: 'https://hooks.example.com/crud',
+      secret: process.env.WEBHOOK_SECRET,
+      events: ['users:created', 'users:updated'],
+      retries: 2,
+      timeout: 10000,
+    },
+  ],
+});
+```
+
+Webhooks are signed with HMAC-SHA256 using the Web Crypto API (edge-safe). The signature is included in the `X-Webhook-Signature` header.
+
+---
+
+## Encryption
+
+Field-level encryption using AES-GCM via the Web Crypto API.
+
+```typescript
+import {
+  encryptFields,
+  decryptFields,
+  StaticKeyProvider,
+  type FieldEncryptionConfig,
+} from 'hono-crud';
+
+const keyProvider = new StaticKeyProvider(process.env.ENCRYPTION_KEY!);
+
+const encryptionConfig: FieldEncryptionConfig[] = [
+  { field: 'ssn', keyProvider },
+  { field: 'creditCard', keyProvider },
+];
+
+// Encrypt before storing
+class UserCreate extends MemoryCreateEndpoint {
+  _meta = userMeta;
+
+  async before(data) {
+    return encryptFields(data, encryptionConfig);
+  }
+}
+
+// Decrypt after reading
+class UserRead extends MemoryReadEndpoint {
+  _meta = userMeta;
+
+  async after(record) {
+    return decryptFields(record, encryptionConfig);
+  }
+}
+```
+
+---
+
+## Idempotency
+
+Prevent duplicate operations via idempotency keys.
+
+```typescript
+import {
+  idempotency,
+  setIdempotencyStorage,
+  MemoryIdempotencyStorage,
+} from 'hono-crud';
+
+setIdempotencyStorage(new MemoryIdempotencyStorage());
+
+// Apply to mutation endpoints
+app.use('/api/*', idempotency({
+  headerName: 'Idempotency-Key',  // default
+  ttl: 86400,                      // 24 hours (default)
+}));
+```
+
+Clients include `Idempotency-Key: <unique-key>` in the request header. If the same key is seen again within the TTL, the cached response is returned.
+
+---
+
+## Multi-Tenancy
+
+Isolate data by tenant using header, path, query, or JWT extraction.
+
+```typescript
+import { multiTenant } from 'hono-crud';
+
+// Extract tenant from header (default)
+app.use('/api/*', multiTenant({
+  source: 'header',
+  headerName: 'X-Tenant-ID',  // default
+  required: true,               // 400 if missing
+}));
+
+// Extract from JWT claims
+app.use('/api/*', multiTenant({
+  source: 'jwt',
+  jwtClaim: 'tenantId',
+}));
+
+// Extract from path
+app.use('/api/:tenantId/*', multiTenant({
+  source: 'path',
+  pathParam: 'tenantId',
+}));
+
+// Custom extraction
+app.use('/api/*', multiTenant({
+  source: 'custom',
+  extractor: (ctx) => ctx.req.header('X-Org-ID'),
+}));
+```
+
+**Model-level config:**
+
+```typescript
+const UserModel = defineModel({
+  tableName: 'users',
+  schema: UserSchema,
+  primaryKeys: ['id'],
+  multiTenant: {
+    tenantIdField: 'tenantId',
+    enforceOnCreate: true,
+    enforceOnRead: true,
+  },
+});
+```
+
+---
+
+## Health Checks
+
+Liveness and readiness endpoints.
+
+```typescript
+import { createHealthEndpoints } from 'hono-crud';
+
+createHealthEndpoints(app, {
+  version: '1.0.0',
+  path: '/health',       // Liveness (always 200)
+  readyPath: '/ready',   // Readiness (runs checks)
+  checks: [
+    {
+      name: 'database',
+      check: async () => { await db.execute('SELECT 1'); },
+      critical: true,    // Failure = 503 (default)
+    },
+    {
+      name: 'cache',
+      check: async () => { await redis.ping(); },
+      critical: false,   // Failure = degraded, not unhealthy
+      timeout: 3000,     // Per-check timeout
+    },
+  ],
+});
+```
+
+**Response:**
+```json
+{
+  "status": "healthy",
+  "checks": [
+    { "name": "database", "healthy": true, "latency": 12 },
+    { "name": "cache", "healthy": true, "latency": 3 }
+  ],
+  "latency": 15,
+  "version": "1.0.0",
+  "timestamp": "2025-01-15T10:30:00.000Z"
+}
+```
+
+---
+
+## Error Handling
+
+### Built-in Exceptions
+
+```typescript
+import {
+  ApiException,
+  NotFoundException,
+  ConflictException,
+  UnauthorizedException,
+  ForbiddenException,
+  InputValidationException,
+} from 'hono-crud';
+
+// Throw in endpoint hooks
+class UserCreate extends MemoryCreateEndpoint {
+  _meta = userMeta;
+
+  async before(data) {
+    const existing = await findByEmail(data.email);
+    if (existing) {
+      throw new ConflictException('Email already in use');
+    }
+    return data;
+  }
+}
+```
+
+### Custom Error Handler
+
+```typescript
+import { createErrorHandler, zodErrorMapper } from 'hono-crud';
+
+const errorHandler = createErrorHandler({
+  mappers: [zodErrorMapper],
+  defaultStatus: 500,
+  includeStack: process.env.NODE_ENV !== 'production',
+});
+
+app.onError(errorHandler);
+```
+
+### Exception Types
+
+| Exception | Status | Use Case |
+|-----------|--------|----------|
+| `ApiException` | configurable | Base exception class |
+| `NotFoundException` | 404 | Resource not found |
+| `ConflictException` | 409 | Duplicate resource |
+| `UnauthorizedException` | 401 | Authentication required |
+| `ForbiddenException` | 403 | Insufficient permissions |
+| `InputValidationException` | 400 | Invalid input data |
+| `AggregationException` | 400 | Invalid aggregation query |
+| `CacheException` | 500 | Cache operation failure |
+| `ConfigurationException` | 500 | Invalid configuration |
+| `RateLimitExceededException` | 429 | Rate limit exceeded |
+
+---
+
+## Filtering
+
+List endpoints support advanced filtering operators.
+
+### Simple Filters
+
+```typescript
+class UserList extends MemoryListEndpoint {
+  _meta = userMeta;
+  filterFields = ['role', 'status']; // Equality filters
+}
+
+// GET /users?role=admin&status=active
+```
+
+### Advanced Filters
+
+```typescript
+class UserList extends MemoryListEndpoint {
+  _meta = userMeta;
+  filterConfig = {
+    age: ['eq', 'ne', 'gt', 'gte', 'lt', 'lte', 'in', 'between', 'null'] as const,
+    name: ['eq', 'like', 'ilike'] as const,
+    email: ['eq', 'like', 'ilike'] as const,
+  };
+}
+```
+
+**Query syntax:**
+```
+GET /users?age[gte]=18
+GET /users?age[between]=18,30
+GET /users?name[ilike]=%alice%
+GET /users?role[in]=admin,user
+GET /users?age[null]=true
+```
+
+### Filter Operators
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `eq` | Equal (default) | `?role=admin` or `?role[eq]=admin` |
+| `ne` | Not equal | `?status[ne]=inactive` |
+| `gt` | Greater than | `?age[gt]=18` |
+| `gte` | Greater than or equal | `?age[gte]=18` |
+| `lt` | Less than | `?age[lt]=65` |
+| `lte` | Less than or equal | `?age[lte]=65` |
+| `like` | LIKE (case-sensitive) | `?name[like]=%alice%` |
+| `ilike` | ILIKE (case-insensitive) | `?name[ilike]=%alice%` |
+| `in` | In list | `?role[in]=admin,user` |
+| `between` | Between two values | `?age[between]=18,30` |
+| `null` | Is null / is not null | `?age[null]=true` |
+
+---
+
+## Sorting & Pagination
+
+```typescript
+class UserList extends MemoryListEndpoint {
+  _meta = userMeta;
+  orderByFields = ['name', 'createdAt', 'age'];
+  defaultOrderBy = 'createdAt';
+  defaultOrderDirection: 'asc' | 'desc' = 'desc';
+  defaultPerPage = 20;
+  maxPerPage = 100;
+}
+```
+
+**Query:**
+```
+GET /users?order_by=name&order_by_direction=asc
+GET /users?page=2&per_page=50
+```
+
+**Response includes pagination metadata:**
+```json
+{
+  "success": true,
+  "result": [...],
+  "page": 2,
+  "per_page": 50,
+  "total": 150,
+  "page_count": 3
+}
+```
+
+---
+
+## API Versioning
+
+```typescript
+import { apiVersion, getApiVersion, versionedResponse } from 'hono-crud';
+
+app.use('/api/*', apiVersion({
+  strategy: 'header',     // 'header' | 'path' | 'query'
+  headerName: 'API-Version',
+  defaultVersion: '1',
+  supported: ['1', '2'],
+}));
+
+app.get('/api/users', (c) => {
+  const version = getApiVersion(c);
+
+  return versionedResponse(c, userData, {
+    '1': (data) => ({ id: data.id, name: data.name }),
+    '2': (data) => ({ id: data.id, fullName: data.name, email: data.email }),
+  });
+});
+```
+
+---
+
+## Serialization Profiles
+
+Transform response data based on context (e.g., public vs admin views).
+
+```typescript
+import { applyProfile, type SerializationProfile } from 'hono-crud';
+
+const publicProfile: SerializationProfile = {
+  include: ['id', 'name', 'avatar'],
+  exclude: ['email', 'role', 'createdAt'],
+};
+
+const adminProfile: SerializationProfile = {
+  include: ['id', 'name', 'email', 'role', 'createdAt'],
+};
+
+// Apply in endpoint
+class UserRead extends MemoryReadEndpoint {
+  _meta = userMeta;
+
+  async after(record) {
+    const user = this.getContext().var.user;
+    const profile = user?.roles?.includes('admin') ? adminProfile : publicProfile;
+    return applyProfile(record, profile);
+  }
+}
+```

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,285 @@
+# Authentication
+
+hono-crud provides JWT and API Key authentication middleware, plus composable authorization guards.
+
+---
+
+## JWT Middleware
+
+```typescript
+import { Hono } from 'hono';
+import { createJWTMiddleware } from 'hono-crud';
+import type { AuthEnv } from 'hono-crud';
+
+const app = new Hono<AuthEnv>();
+
+app.use('/api/*', createJWTMiddleware({
+  secret: process.env.JWT_SECRET!,
+  algorithm: 'HS256',     // default
+  issuer: 'my-app',       // optional: validate iss claim
+  audience: 'my-api',     // optional: validate aud claim
+  clockTolerance: 30,     // optional: seconds of clock skew tolerance
+}));
+
+// After middleware runs, context variables are available:
+app.get('/api/me', (c) => {
+  return c.json({
+    userId: c.var.userId,
+    user: c.var.user,        // { id, email, roles, permissions, metadata }
+    roles: c.var.roles,      // string[]
+    authType: c.var.authType // 'jwt'
+  });
+});
+```
+
+### Custom Token Extraction
+
+```typescript
+app.use('/api/*', createJWTMiddleware({
+  secret: process.env.JWT_SECRET!,
+  extractToken: (ctx) => {
+    // Extract from cookie instead of Authorization header
+    return ctx.req.header('X-Auth-Token') ?? null;
+  },
+  extractUser: (claims) => ({
+    id: String(claims.sub),
+    email: claims.email as string,
+    roles: claims.realm_access?.roles as string[],
+    permissions: claims.scope?.split(' ') as string[],
+  }),
+}));
+```
+
+### Manual Token Verification
+
+```typescript
+import { verifyJWT, decodeJWT } from 'hono-crud';
+
+// Verify and decode
+const claims = await verifyJWT(token, { secret: process.env.JWT_SECRET! });
+
+// Decode without verification (for debugging)
+const decoded = decodeJWT(token); // { header, payload } | null
+```
+
+---
+
+## API Key Middleware
+
+```typescript
+import {
+  createAPIKeyMiddleware,
+  MemoryAPIKeyStorage,
+  setAPIKeyStorage,
+  generateAPIKey,
+} from 'hono-crud';
+
+// Setup storage
+const apiKeyStorage = new MemoryAPIKeyStorage();
+setAPIKeyStorage(apiKeyStorage);
+
+// Generate and store an API key
+const key = generateAPIKey();
+await apiKeyStorage.store({
+  keyHash: await hashAPIKey(key),
+  name: 'My API Key',
+  userId: 'user-123',
+  roles: ['admin'],
+  permissions: ['users:read', 'users:write'],
+  expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000), // 30 days
+});
+
+// Apply middleware
+app.use('/api/*', createAPIKeyMiddleware({
+  header: 'X-API-Key',     // default
+  // Or: queryParam: 'api_key'
+}));
+```
+
+---
+
+## Combined Auth
+
+Support both JWT and API Key on the same routes:
+
+```typescript
+import { createAuthMiddleware, optionalAuth } from 'hono-crud';
+
+// Require one of JWT or API Key
+app.use('/api/*', createAuthMiddleware({
+  jwt: {
+    secret: process.env.JWT_SECRET!,
+    issuer: 'my-app',
+  },
+  apiKey: {
+    header: 'X-API-Key',
+  },
+}));
+
+// Optional auth: sets user if present, allows anonymous
+app.use('/public/*', optionalAuth({
+  jwt: { secret: process.env.JWT_SECRET! },
+}));
+```
+
+---
+
+## Guards
+
+Guards are Hono middleware that check authorization after authentication.
+
+### Role Guards
+
+```typescript
+import { requireRoles, requireAllRoles, requireAuthenticated } from 'hono-crud';
+
+// Require at least one of the specified roles (OR)
+app.use('/admin/*', requireRoles('admin', 'super-admin'));
+
+// Require ALL of the specified roles (AND)
+app.use('/super/*', requireAllRoles('admin', 'verified'));
+
+// Require any authenticated user (no role check)
+app.use('/api/*', requireAuthenticated());
+```
+
+### Permission Guards
+
+```typescript
+import { requirePermissions, requireAnyPermission } from 'hono-crud';
+
+// Require ALL permissions
+app.use('/users/*', requirePermissions('users:read', 'users:write'));
+
+// Require at least one permission
+app.use('/data/*', requireAnyPermission('data:read', 'data:admin'));
+```
+
+### Custom Guards
+
+```typescript
+import { requireAuth, requireOwnership, requireOwnershipOrRole } from 'hono-crud';
+
+// Custom authorization check
+app.use('/premium/*', requireAuth((user, ctx) => {
+  return user.metadata?.subscription === 'premium';
+}));
+
+// Ownership check
+app.use('/users/:id/*', requireOwnership((ctx) => ctx.req.param('id')));
+
+// Owner OR admin
+app.use('/posts/:id/*', requireOwnershipOrRole(
+  async (ctx) => {
+    const post = await db.posts.findFirst({ where: { id: ctx.req.param('id') } });
+    return post?.authorId ?? '';
+  },
+  'admin'
+));
+```
+
+### Guard Composition
+
+```typescript
+import { allOf, anyOf, denyAll, allowAll } from 'hono-crud';
+
+// ALL guards must pass (AND)
+app.use('/secure/*', allOf(
+  requireRoles('admin'),
+  requirePermissions('secure:access'),
+  requireAuth((user) => user.metadata?.mfaEnabled === true)
+));
+
+// ANY guard must pass (OR)
+app.use('/shared/*', anyOf(
+  requireRoles('admin'),
+  requireOwnership((ctx) => getResourceOwnerId(ctx)),
+  requirePermissions('shared:access')
+));
+
+// Block a route entirely
+app.use('/maintenance/*', denyAll('Service temporarily unavailable'));
+
+// Explicitly mark as public
+app.use('/public/*', allowAll());
+```
+
+### Guards with registerCrud
+
+```typescript
+import { registerCrud, requireAuthenticated, requireRoles } from 'hono-crud';
+
+registerCrud(app, '/users', {
+  create: UserCreate,
+  list: UserList,
+  read: UserRead,
+  update: UserUpdate,
+  delete: UserDelete,
+}, {
+  // Applied to all endpoints
+  middlewares: [requireAuthenticated()],
+  // Applied to specific endpoints
+  endpointMiddlewares: {
+    create: [requireRoles('admin')],
+    delete: [requireRoles('admin')],
+  },
+});
+```
+
+---
+
+## better-auth Integration
+
+[better-auth](https://www.better-auth.com) handles login, signup, OAuth, 2FA, and session management. hono-crud handles CRUD with authorization guards.
+
+```typescript
+import { Hono } from 'hono';
+import { cors } from 'hono/cors';
+import { auth } from './auth'; // your better-auth instance
+
+const app = new Hono<{
+  Variables: {
+    user: typeof auth.$Infer.Session.user | null;
+    session: typeof auth.$Infer.Session.session | null;
+  };
+}>();
+
+// CORS for auth routes
+app.use('/api/auth/*', cors({
+  origin: 'http://localhost:3000',
+  credentials: true,
+}));
+
+// Mount better-auth handler
+app.on(['POST', 'GET'], '/api/auth/*', (c) => auth.handler(c.req.raw));
+
+// Session middleware: inject user into context
+app.use('*', async (c, next) => {
+  const session = await auth.api.getSession({ headers: c.req.raw.headers });
+  c.set('user', session?.user ?? null);
+  c.set('session', session?.session ?? null);
+  await next();
+});
+
+// Protect CRUD routes
+registerCrud(app, '/api/users', {
+  list: UserList,
+  read: UserRead,
+  update: UserUpdate,
+  delete: UserDelete,
+}, {
+  middlewares: [requireAuthenticated()],
+  endpointMiddlewares: {
+    delete: [requireRoles('admin')],
+  },
+});
+```
+
+### Architecture
+
+```
+Request -> CORS -> Session Middleware -> Auth Guards -> CRUD Endpoint
+                        |
+                   better-auth
+                 (validates session)
+```

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -1,0 +1,175 @@
+# Caching
+
+hono-crud provides response caching via mixins (`withCache`, `withCacheInvalidation`) and supports Memory and Redis storage backends.
+
+---
+
+## Setup
+
+```typescript
+import { setCacheStorage, MemoryCacheStorage } from 'hono-crud';
+
+// Use in-memory cache (default if not set)
+setCacheStorage(new MemoryCacheStorage());
+```
+
+### Redis Storage
+
+```typescript
+import { RedisCacheStorage, setCacheStorage } from 'hono-crud/cache';
+
+setCacheStorage(new RedisCacheStorage({
+  client: redisClient,     // Any Redis client with get/set/del/keys
+  prefix: 'cache:',        // Key prefix (default: 'cache:')
+}));
+```
+
+### Context-scoped Storage
+
+For multi-tenant or per-request storage:
+
+```typescript
+import { createCacheStorageMiddleware } from 'hono-crud/storage';
+
+app.use('*', createCacheStorageMiddleware(() => {
+  return new MemoryCacheStorage();
+}));
+```
+
+---
+
+## withCache Mixin
+
+Add caching to read/list endpoints:
+
+```typescript
+import { withCache } from 'hono-crud';
+import { MemoryReadEndpoint, MemoryListEndpoint } from 'hono-crud/adapters/memory';
+
+class UserRead extends withCache(MemoryReadEndpoint) {
+  _meta = userMeta;
+  schema = { tags: ['Users'], summary: 'Get user' };
+
+  cacheConfig = {
+    ttl: 300,           // 5 minutes
+    perUser: false,     // Shared cache (true = per-user cache keys)
+    tags: ['users'],    // Cache tags for targeted invalidation
+  };
+
+  async handle(ctx) {
+    this.setContext(ctx);
+
+    // Try cache first
+    const cached = await this.getCachedResponse();
+    if (cached) {
+      return this.successWithCache(cached);
+    }
+
+    // Fetch from database
+    const response = await super.handle(ctx);
+
+    // Cache successful responses
+    if (response.status === 200) {
+      const data = await response.clone().json();
+      await this.setCachedResponse(data.result);
+    }
+
+    return response;
+  }
+}
+```
+
+### Cache Config Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enabled` | `boolean` | `true` | Enable/disable caching |
+| `ttl` | `number` | `300` | Time to live in seconds |
+| `perUser` | `boolean` | `false` | Include userId in cache key |
+| `tags` | `string[]` | `[]` | Cache tags for targeted invalidation |
+| `keyFields` | `string[]` | - | Additional fields in cache key |
+| `prefix` | `string` | - | Custom key prefix |
+
+### Cache Methods
+
+| Method | Description |
+|--------|-------------|
+| `getCachedResponse<T>()` | Get cached data (returns `null` on miss) |
+| `setCachedResponse<T>(data)` | Store data in cache |
+| `invalidateCache(options?)` | Manually invalidate cache entries |
+| `getCacheStatus()` | Returns `'HIT'` or `'MISS'` |
+| `successWithCache(result)` | Response with `X-Cache` header |
+
+---
+
+## withCacheInvalidation Mixin
+
+Automatically invalidate caches after mutations:
+
+```typescript
+import { withCacheInvalidation } from 'hono-crud';
+
+class UserUpdate extends withCacheInvalidation(MemoryUpdateEndpoint) {
+  _meta = userMeta;
+  schema = { tags: ['Users'], summary: 'Update user' };
+  allowedUpdateFields = ['name', 'role'];
+
+  cacheInvalidation = {
+    strategy: 'all',              // Invalidate all user caches
+    relatedModels: ['posts'],     // Also invalidate posts cache
+  };
+}
+
+class UserDelete extends withCacheInvalidation(MemoryDeleteEndpoint) {
+  _meta = userMeta;
+  schema = { tags: ['Users'], summary: 'Delete user' };
+
+  cacheInvalidation = {
+    strategy: 'single',           // Only invalidate the specific record
+  };
+}
+```
+
+### Invalidation Strategies
+
+| Strategy | Description |
+|----------|-------------|
+| `'all'` | Invalidate all caches for the model (default) |
+| `'single'` | Invalidate only the specific record's cache |
+| `'list'` | Invalidate only list caches |
+| `'pattern'` | Invalidate by custom pattern |
+| `'tags'` | Invalidate by cache tags |
+
+### Invalidation Config
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `strategy` | `InvalidationStrategy` | Invalidation strategy (default: `'all'`) |
+| `pattern` | `string` | Custom pattern (for `'pattern'` strategy) |
+| `tags` | `string[]` | Tags to invalidate (for `'tags'` strategy) |
+| `relatedModels` | `string[]` | Also invalidate these model caches |
+
+---
+
+## ETag Support
+
+Generate and match ETags for conditional requests:
+
+```typescript
+import { generateETag, matchesIfNoneMatch, matchesIfMatch } from 'hono-crud';
+
+// Generate ETag from data
+const etag = await generateETag(userData);
+
+// Check If-None-Match (GET - 304 Not Modified)
+const ifNoneMatch = ctx.req.header('If-None-Match');
+if (ifNoneMatch && matchesIfNoneMatch(ifNoneMatch, etag)) {
+  return new Response(null, { status: 304 });
+}
+
+// Check If-Match (PUT/PATCH - optimistic concurrency)
+const ifMatch = ctx.req.header('If-Match');
+if (ifMatch && !matchesIfMatch(ifMatch, etag)) {
+  return ctx.json({ error: 'Precondition failed' }, 412);
+}
+```

--- a/docs/database-adapters.md
+++ b/docs/database-adapters.md
@@ -1,0 +1,409 @@
+# Database Adapters
+
+hono-crud ships with three adapters: **Memory** (prototyping), **Drizzle** (SQL via Drizzle ORM), and **Prisma** (SQL via Prisma).
+
+All adapters expose the same endpoint class hierarchy: `Create`, `Read`, `Update`, `Delete`, `List`, plus `Restore`, `Upsert`, `BatchCreate`, `BatchUpdate`, `BatchDelete`, `BatchRestore`, `BatchUpsert`, and `BulkPatch`.
+
+---
+
+## Memory Adapter
+
+Zero-dependency, in-memory storage. Ideal for prototyping, testing, and examples.
+
+### Setup
+
+```typescript
+import {
+  MemoryCreateEndpoint,
+  MemoryReadEndpoint,
+  MemoryUpdateEndpoint,
+  MemoryDeleteEndpoint,
+  MemoryListEndpoint,
+  MemoryRestoreEndpoint,
+  MemoryUpsertEndpoint,
+  MemoryBatchCreateEndpoint,
+  MemoryBatchUpdateEndpoint,
+  MemoryBatchDeleteEndpoint,
+  MemoryBatchRestoreEndpoint,
+  clearStorage,
+} from 'hono-crud/adapters/memory';
+```
+
+### Complete Example
+
+```typescript
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { fromHono, registerCrud, defineModel, defineMeta } from 'hono-crud';
+import {
+  MemoryCreateEndpoint,
+  MemoryReadEndpoint,
+  MemoryUpdateEndpoint,
+  MemoryDeleteEndpoint,
+  MemoryListEndpoint,
+  clearStorage,
+} from 'hono-crud/adapters/memory';
+
+clearStorage();
+
+const TaskSchema = z.object({
+  id: z.uuid(),
+  title: z.string().min(1),
+  done: z.boolean().default(false),
+});
+
+const TaskModel = defineModel({
+  tableName: 'tasks',
+  schema: TaskSchema,
+  primaryKeys: ['id'],
+});
+
+const taskMeta = defineMeta({ model: TaskModel });
+
+class TaskCreate extends MemoryCreateEndpoint {
+  _meta = taskMeta;
+  schema = { tags: ['Tasks'], summary: 'Create task' };
+}
+
+class TaskList extends MemoryListEndpoint {
+  _meta = taskMeta;
+  schema = { tags: ['Tasks'], summary: 'List tasks' };
+  filterFields = ['done'];
+  searchFields = ['title'];
+}
+
+class TaskRead extends MemoryReadEndpoint {
+  _meta = taskMeta;
+  schema = { tags: ['Tasks'], summary: 'Get task' };
+}
+
+class TaskUpdate extends MemoryUpdateEndpoint {
+  _meta = taskMeta;
+  schema = { tags: ['Tasks'], summary: 'Update task' };
+  allowedUpdateFields = ['title', 'done'];
+}
+
+class TaskDelete extends MemoryDeleteEndpoint {
+  _meta = taskMeta;
+  schema = { tags: ['Tasks'], summary: 'Delete task' };
+}
+
+const app = fromHono(new Hono());
+
+registerCrud(app, '/tasks', {
+  create: TaskCreate,
+  list: TaskList,
+  read: TaskRead,
+  update: TaskUpdate,
+  delete: TaskDelete,
+});
+```
+
+### Storage Helpers
+
+```typescript
+import { clearStorage, getStorage } from 'hono-crud/adapters/memory';
+
+// Clear all in-memory data
+clearStorage();
+
+// Access raw storage for a table
+const store = getStorage<Task>('tasks');
+store.set('some-id', { id: 'some-id', title: 'Test', done: false });
+```
+
+---
+
+## Drizzle Adapter
+
+For production use with [Drizzle ORM](https://orm.drizzle.team). Supports PostgreSQL, MySQL, SQLite, and Turso.
+
+### Install Dependencies
+
+```bash
+npm install drizzle-orm
+```
+
+### Schema Definition
+
+```typescript
+// schema.ts
+import { pgTable, text, integer, timestamp, uuid, pgEnum } from 'drizzle-orm/pg-core';
+
+export const roleEnum = pgEnum('role', ['admin', 'user', 'guest']);
+
+export const users = pgTable('users', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  email: text('email').notNull().unique(),
+  name: text('name').notNull(),
+  role: roleEnum('role').notNull().default('user'),
+  age: integer('age'),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  deletedAt: timestamp('deleted_at'),
+});
+```
+
+### Factory Pattern (Recommended)
+
+The `createDrizzleCrud` factory pre-configures `db` and `_meta` on all endpoint classes:
+
+```typescript
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { fromHono, registerCrud, defineModel, defineMeta } from 'hono-crud';
+import { createDrizzleCrud } from 'hono-crud/adapters/drizzle';
+import { db } from './db';
+import { users } from './schema';
+
+const UserSchema = z.object({
+  id: z.uuid(),
+  email: z.email(),
+  name: z.string().min(1),
+  role: z.enum(['admin', 'user', 'guest']),
+  age: z.number().int().positive().optional().nullable(),
+  createdAt: z.string().datetime().optional(),
+  deletedAt: z.date().nullable().optional(),
+});
+
+const UserModel = defineModel({
+  tableName: 'users',
+  schema: UserSchema,
+  primaryKeys: ['id'],
+  table: users,           // Drizzle table reference
+  softDelete: true,
+});
+
+const userMeta = defineMeta({ model: UserModel });
+
+// Factory creates base classes with db + meta pre-configured
+const User = createDrizzleCrud(db, userMeta);
+
+class UserCreate extends User.Create {
+  schema = { tags: ['Users'], summary: 'Create user' };
+}
+
+class UserList extends User.List {
+  schema = { tags: ['Users'], summary: 'List users' };
+  filterFields = ['role'];
+  searchFields = ['name', 'email'];
+  orderByFields = ['name', 'createdAt'];
+}
+
+class UserRead extends User.Read {
+  schema = { tags: ['Users'], summary: 'Get user' };
+}
+
+class UserUpdate extends User.Update {
+  schema = { tags: ['Users'], summary: 'Update user' };
+  allowedUpdateFields = ['name', 'role', 'age'];
+}
+
+class UserDelete extends User.Delete {
+  schema = { tags: ['Users'], summary: 'Delete user' };
+}
+
+const app = fromHono(new Hono());
+registerCrud(app, '/users', {
+  create: UserCreate,
+  list: UserList,
+  read: UserRead,
+  update: UserUpdate,
+  delete: UserDelete,
+});
+```
+
+The factory also provides `User.Restore`, `User.Upsert`, `User.BatchCreate`, `User.BatchUpdate`, `User.BatchDelete`, `User.BatchRestore`, and `User.BatchUpsert`.
+
+### Manual Pattern
+
+Set `db` and `_meta` on each endpoint class:
+
+```typescript
+import {
+  DrizzleCreateEndpoint,
+  DrizzleListEndpoint,
+  DrizzleReadEndpoint,
+  DrizzleUpdateEndpoint,
+  DrizzleDeleteEndpoint,
+  type DrizzleDatabase,
+} from 'hono-crud/adapters/drizzle';
+
+const typedDb = db as unknown as DrizzleDatabase;
+
+class UserList extends DrizzleListEndpoint {
+  _meta = userMeta;
+  db = typedDb;
+  schema = { tags: ['Users'], summary: 'List users' };
+  filterFields = ['role'];
+}
+```
+
+### Config-based with Drizzle
+
+```typescript
+import { defineEndpoints } from 'hono-crud';
+import { DrizzleAdapters } from 'hono-crud/adapters/drizzle';
+
+const endpoints = defineEndpoints({
+  meta: userMeta,
+  list: { filtering: { fields: ['role'] } },
+  read: {},
+}, DrizzleAdapters);
+```
+
+---
+
+## Prisma Adapter
+
+For production use with [Prisma](https://www.prisma.io).
+
+### Install Dependencies
+
+```bash
+npm install @prisma/client
+npx prisma init
+```
+
+### Schema Definition
+
+```prisma
+// schema.prisma
+model User {
+  id        String   @id @default(uuid())
+  email     String   @unique
+  name      String
+  role      String   @default("user")
+  age       Int?
+  createdAt DateTime @default(now()) @map("created_at")
+  deletedAt DateTime? @map("deleted_at")
+
+  posts     Post[]
+  profile   Profile?
+
+  @@map("users")
+}
+```
+
+### Complete Example
+
+```typescript
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { fromHono, registerCrud, defineModel, defineMeta } from 'hono-crud';
+import {
+  PrismaCreateEndpoint,
+  PrismaReadEndpoint,
+  PrismaUpdateEndpoint,
+  PrismaDeleteEndpoint,
+  PrismaListEndpoint,
+} from 'hono-crud/adapters/prisma';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const UserSchema = z.object({
+  id: z.uuid(),
+  email: z.email(),
+  name: z.string().min(1),
+  role: z.enum(['admin', 'user', 'guest']),
+  age: z.number().int().positive().optional().nullable(),
+  createdAt: z.string().datetime().optional(),
+  deletedAt: z.date().nullable().optional(),
+});
+
+const UserModel = defineModel({
+  tableName: 'users',
+  schema: UserSchema,
+  primaryKeys: ['id'],
+});
+
+const userMeta = defineMeta({ model: UserModel });
+
+class UserCreate extends PrismaCreateEndpoint {
+  _meta = userMeta;
+  prisma = prisma;
+  schema = { tags: ['Users'], summary: 'Create user' };
+}
+
+class UserList extends PrismaListEndpoint {
+  _meta = userMeta;
+  prisma = prisma;
+  schema = { tags: ['Users'], summary: 'List users' };
+  filterFields = ['role'];
+  searchFields = ['name', 'email'];
+  orderByFields = ['name', 'createdAt'];
+  defaultOrderBy = 'createdAt';
+  defaultOrderDirection: 'asc' | 'desc' = 'desc';
+  defaultPerPage = 20;
+  maxPerPage = 100;
+}
+
+class UserRead extends PrismaReadEndpoint {
+  _meta = userMeta;
+  prisma = prisma;
+  schema = { tags: ['Users'], summary: 'Get user' };
+}
+
+class UserUpdate extends PrismaUpdateEndpoint {
+  _meta = userMeta;
+  prisma = prisma;
+  schema = { tags: ['Users'], summary: 'Update user' };
+  allowedUpdateFields = ['name', 'role', 'age'];
+}
+
+class UserDelete extends PrismaDeleteEndpoint {
+  _meta = userMeta;
+  prisma = prisma;
+  schema = { tags: ['Users'], summary: 'Delete user' };
+}
+
+const app = fromHono(new Hono());
+registerCrud(app, '/users', {
+  create: UserCreate,
+  list: UserList,
+  read: UserRead,
+  update: UserUpdate,
+  delete: UserDelete,
+});
+```
+
+### Model Name Mapping
+
+Prisma uses the model name to determine the table. If your model name differs from the `tableName`, register a mapping:
+
+```typescript
+import { registerPrismaModelMapping } from 'hono-crud/adapters/prisma';
+
+// Map table name to Prisma model name
+registerPrismaModelMapping('users', 'User');
+registerPrismaModelMapping('blog_posts', 'BlogPost');
+```
+
+### Batch Operations
+
+```typescript
+import {
+  PrismaBatchCreateEndpoint,
+  PrismaBatchUpdateEndpoint,
+  PrismaBatchDeleteEndpoint,
+} from 'hono-crud/adapters/prisma';
+
+class UserBatchCreate extends PrismaBatchCreateEndpoint {
+  _meta = userMeta;
+  prisma = prisma;
+  schema = { tags: ['Users'], summary: 'Batch create users' };
+  maxBatchSize = 100;
+}
+```
+
+---
+
+## Choosing an Adapter
+
+| Feature | Memory | Drizzle | Prisma |
+|---------|--------|---------|--------|
+| Setup complexity | None | Low | Medium |
+| Persistence | In-memory only | Full SQL | Full SQL |
+| Edge runtime | Yes | Yes | Partial |
+| Relations support | In-memory joins | SQL joins | Prisma queries |
+| Best for | Prototyping, tests | Production | Production |

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,211 @@
+# Logging
+
+hono-crud provides request/response logging middleware with automatic redaction of sensitive data.
+
+---
+
+## Setup
+
+```typescript
+import {
+  createLoggingMiddleware,
+  setLoggingStorage,
+  MemoryLoggingStorage,
+} from 'hono-crud';
+
+// Set storage (required before middleware runs)
+setLoggingStorage(new MemoryLoggingStorage({ maxEntries: 10000 }));
+```
+
+### Context-scoped Storage
+
+```typescript
+import { createLoggingStorageMiddleware } from 'hono-crud/storage';
+
+app.use('*', createLoggingStorageMiddleware(() => {
+  return new MemoryLoggingStorage();
+}));
+```
+
+---
+
+## Basic Usage
+
+```typescript
+app.use('*', createLoggingMiddleware());
+```
+
+This logs every request and response with:
+- Request ID, method, path, query, headers
+- Client IP, user agent
+- Response status, duration
+- Automatic redaction of sensitive headers and body fields
+
+---
+
+## Configuration
+
+```typescript
+app.use('*', createLoggingMiddleware({
+  // Paths to exclude from logging
+  excludePaths: ['/health', '/docs/*', '/openapi.json'],
+
+  // Headers to redact (added to defaults)
+  redactHeaders: ['authorization', 'cookie', 'x-api-key'],
+
+  // Body fields to redact (added to defaults)
+  redactBodyFields: ['password', 'token', 'secret', 'creditCard'],
+
+  // Request body logging
+  requestBody: {
+    enabled: true,
+    maxSize: 10000,                    // Max body size to log (bytes)
+    allowedContentTypes: ['application/json'],
+  },
+
+  // Response body logging
+  responseBody: {
+    enabled: false,                     // Disabled by default
+    maxSize: 10000,
+    allowedContentTypes: ['application/json'],
+  },
+
+  // Log level
+  level: 'info',                        // 'debug' | 'info' | 'warn' | 'error'
+
+  // Custom request ID generation
+  generateRequestId: () => crypto.randomUUID(),
+}));
+```
+
+### Config Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `excludePaths` | `string[]` | `[]` | Paths to skip (glob patterns) |
+| `redactHeaders` | `string[]` | See below | Headers to redact |
+| `redactBodyFields` | `string[]` | See below | Body fields to redact |
+| `requestBody` | `object` | `{ enabled: true }` | Request body logging config |
+| `responseBody` | `object` | `{ enabled: false }` | Response body logging config |
+| `level` | `LogLevel` | `'info'` | Minimum log level |
+| `generateRequestId` | `function` | UUID generator | Custom request ID function |
+
+### Default Redacted Headers
+
+`authorization`, `cookie`, `x-api-key`, `x-auth-token`
+
+### Default Redacted Body Fields
+
+`password`, `token`, `secret`, `apiKey`, `api_key`, `accessToken`, `access_token`, `refreshToken`, `refresh_token`
+
+---
+
+## Accessing Request Context
+
+```typescript
+import { getRequestId, getRequestStartTime } from 'hono-crud';
+
+app.get('/api/data', (c) => {
+  const requestId = getRequestId(c);       // string
+  const startTime = getRequestStartTime(c); // number (ms)
+
+  return c.json({
+    requestId,
+    processingTime: Date.now() - startTime,
+  });
+});
+```
+
+---
+
+## Custom Storage
+
+Implement the `LoggingStorage` interface for custom backends:
+
+```typescript
+import type { LoggingStorage, LogEntry, LogQueryOptions } from 'hono-crud';
+
+class PostgresLoggingStorage implements LoggingStorage {
+  async store(entry: LogEntry): Promise<void> {
+    await db.insert(logs).values(entry);
+  }
+
+  async query(options: LogQueryOptions): Promise<LogEntry[]> {
+    // Implement query logic
+    return [];
+  }
+
+  async count(options: LogQueryOptions): Promise<number> {
+    // Implement count logic
+    return 0;
+  }
+
+  async clear(): Promise<void> {
+    await db.delete(logs);
+  }
+}
+
+setLoggingStorage(new PostgresLoggingStorage());
+```
+
+---
+
+## Redaction
+
+### How Redaction Works
+
+Sensitive values are replaced with `'[REDACTED]'` in logged output. Redaction applies to:
+
+- **Headers**: Matched case-insensitively against `redactHeaders`
+- **Body fields**: Matched by key name against `redactBodyFields`
+
+### Using Redaction Utilities Directly
+
+```typescript
+import { redactHeaders, redactObject, shouldRedact } from 'hono-crud';
+
+// Redact specific headers
+const safeHeaders = redactHeaders(
+  { authorization: 'Bearer xxx', 'content-type': 'application/json' },
+  ['authorization']
+);
+// { authorization: '[REDACTED]', 'content-type': 'application/json' }
+
+// Redact object fields
+const safeBody = redactObject(
+  { email: 'test@example.com', password: 'secret123' },
+  ['password']
+);
+// { email: 'test@example.com', password: '[REDACTED]' }
+```
+
+---
+
+## Log Entry Structure
+
+Each log entry contains:
+
+```typescript
+interface LogEntry {
+  id: string;           // Request ID
+  timestamp: string;    // ISO 8601
+  level: LogLevel;
+  request: {
+    method: string;
+    path: string;
+    query: Record<string, string>;
+    headers: Record<string, string>;
+    body?: unknown;
+    ip: string;
+    userAgent: string;
+  };
+  response: {
+    status: number;
+    headers: Record<string, string>;
+    body?: unknown;
+    duration: number;   // milliseconds
+  };
+  userId?: string;
+  error?: string;
+}
+```

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -1,0 +1,183 @@
+# Rate Limiting
+
+hono-crud provides rate limiting middleware with fixed-window and sliding-window algorithms, tier-based limits, and Memory/Redis storage.
+
+---
+
+## Setup
+
+```typescript
+import {
+  createRateLimitMiddleware,
+  setRateLimitStorage,
+  MemoryRateLimitStorage,
+} from 'hono-crud';
+
+// Set storage (required before middleware runs)
+setRateLimitStorage(new MemoryRateLimitStorage());
+```
+
+### Redis Storage
+
+```typescript
+import { RedisRateLimitStorage, setRateLimitStorage } from 'hono-crud/rate-limit';
+
+setRateLimitStorage(new RedisRateLimitStorage({
+  client: redisClient,
+  prefix: 'rl:',
+}));
+```
+
+### Context-scoped Storage
+
+```typescript
+import { createRateLimitStorageMiddleware } from 'hono-crud/storage';
+
+app.use('*', createRateLimitStorageMiddleware(() => {
+  return new MemoryRateLimitStorage();
+}));
+```
+
+---
+
+## Basic Usage
+
+```typescript
+// Global: 100 requests per minute per IP
+app.use('/api/*', createRateLimitMiddleware({
+  limit: 100,
+  windowSeconds: 60,
+  keyStrategy: 'ip',
+  skipPaths: ['/health', '/docs/*'],
+}));
+
+// Stricter limit for expensive operations
+app.use('/api/export/*', createRateLimitMiddleware({
+  limit: 5,
+  windowSeconds: 60,
+  keyPrefix: 'rl:export',
+}));
+```
+
+### Response Headers
+
+When `includeHeaders: true` (default), responses include:
+
+```
+X-RateLimit-Limit: 100
+X-RateLimit-Remaining: 95
+X-RateLimit-Reset: 1706140800
+```
+
+When rate limit is exceeded, the response is `429 Too Many Requests` with a `Retry-After` header.
+
+---
+
+## Configuration
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `limit` | `number` | `100` | Maximum requests per window |
+| `windowSeconds` | `number` | `60` | Window size in seconds |
+| `algorithm` | `'fixed-window' \| 'sliding-window'` | `'sliding-window'` | Rate limit algorithm |
+| `keyStrategy` | `KeyStrategy \| function` | `'ip'` | How to identify clients |
+| `keyPrefix` | `string` | `'rl'` | Storage key prefix |
+| `skipPaths` | `string[]` | `[]` | Paths to skip (glob patterns) |
+| `includeHeaders` | `boolean` | `true` | Include rate limit headers |
+| `errorMessage` | `string` | `'Too many requests'` | Error message on 429 |
+| `storage` | `RateLimitStorage` | - | Per-middleware storage override |
+| `ipHeader` | `string` | - | Custom header for client IP |
+| `trustProxy` | `boolean` | - | Trust X-Forwarded-For |
+| `apiKeyHeader` | `string` | - | Header for API key strategy |
+| `getTier` | `function` | - | Dynamic limits per user |
+| `onRateLimitExceeded` | `function` | - | Callback on rate limit hit |
+
+### Key Strategies
+
+| Strategy | Description |
+|----------|-------------|
+| `'ip'` | Client IP address (default) |
+| `'user'` | Authenticated user ID (falls back to IP) |
+| `'api-key'` | API key header (falls back to IP) |
+| `'combined'` | IP + user ID combination |
+| `(ctx) => string` | Custom key extraction function |
+
+---
+
+## Tier-based Limits
+
+Different rate limits based on user type:
+
+```typescript
+app.use('/api/*', createRateLimitMiddleware({
+  keyStrategy: 'user',
+  getTier: async (ctx) => {
+    const user = ctx.get('user');
+
+    if (user?.roles?.includes('premium')) {
+      return { limit: 1000, windowSeconds: 60 };
+    }
+
+    if (user?.roles?.includes('user')) {
+      return { limit: 200, windowSeconds: 60 };
+    }
+
+    // Anonymous / guest
+    return { limit: 50, windowSeconds: 60 };
+  },
+}));
+```
+
+---
+
+## Custom Key Strategy
+
+```typescript
+app.use('/api/*', createRateLimitMiddleware({
+  keyStrategy: (ctx) => {
+    // Rate limit by organization
+    const orgId = ctx.req.header('X-Org-ID');
+    return orgId ? `org:${orgId}` : extractIP(ctx);
+  },
+  limit: 500,
+  windowSeconds: 60,
+}));
+```
+
+---
+
+## Rate Limit Exceeded Callback
+
+```typescript
+app.use('/api/*', createRateLimitMiddleware({
+  limit: 100,
+  windowSeconds: 60,
+  onRateLimitExceeded: async (ctx, result, key) => {
+    console.warn(`Rate limit exceeded for ${key}`, {
+      limit: result.limit,
+      remaining: result.remaining,
+      retryAfter: result.retryAfter,
+    });
+  },
+}));
+```
+
+---
+
+## Reset Rate Limit
+
+```typescript
+import { resetRateLimit } from 'hono-crud';
+
+// Reset a specific key (e.g., after successful verification)
+await resetRateLimit('rl:/api/login:192.168.1.1');
+```
+
+---
+
+## Algorithm Comparison
+
+| Algorithm | Description | Use Case |
+|-----------|-------------|----------|
+| `fixed-window` | Counts requests in fixed time intervals | Simple, less memory |
+| `sliding-window` | Tracks individual request timestamps | Smoother rate limiting, prevents burst at window boundaries |


### PR DESCRIPTION
## Summary

- **Rewrite README.md** to accurately reflect the real API (`defineModel`, `defineMeta`, endpoint classes, `registerCrud`, 4 API patterns)
- **Refresh `docs/alternative-api-patterns.md`** with package-name imports and consistent formatting
- **Create 6 new docs/** files: database-adapters, authentication, caching, rate-limiting, logging, advanced-features

## Changes

| File | Action |
|------|--------|
| `README.md` | Full rewrite — concise gateway with working examples |
| `docs/alternative-api-patterns.md` | Refreshed imports and style |
| `docs/database-adapters.md` | New — Memory, Drizzle (factory pattern), Prisma |
| `docs/authentication.md` | New — JWT, API Key, guards, better-auth |
| `docs/caching.md` | New — withCache, withCacheInvalidation, ETag |
| `docs/rate-limiting.md` | New — middleware, tiers, algorithms |
| `docs/logging.md` | New — middleware, redaction, custom storage |
| `docs/advanced-features.md` | New — soft delete, relations, batch ops, versioning, audit, search, aggregation, export/import, computed fields, events, encryption, idempotency, multi-tenancy, health checks, error handling |

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test run` — 687/687 tests pass
- [x] All docs/ links in README resolve to existing files
- [x] No source code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)