### PR TITLE
chore: include docs/ in npm package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
   "sideEffects": false,
   "files": [
     "dist",
+    "docs",
     "README.md",
     "LICENSE",
     "CHANGELOG.md"


### PR DESCRIPTION
## Summary

- Add `docs` to the `files` array in `package.json` so the docs/ reference is shipped with the npm package

## Test plan

- [x] No source changes — package.json only

🤖 Generated with [Claude Code](https://claude.com/claude-code)