### PR TITLE
chore: remove docs/ from npm package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
   "sideEffects": false,
   "files": [
     "dist",
-    "docs",
     "README.md",
     "LICENSE",
     "CHANGELOG.md"


### PR DESCRIPTION
## Summary

- Revert adding `docs` to `files` in `package.json` — it bloated the unpacked size to 768 kB
- Docs remain available on GitHub, no need to ship them in the npm package

## Test plan

- [x] `package.json` only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)