### PR TITLE
Implement strict edge quality cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,10 @@
     "./ui": {
       "types": "./dist/ui.d.ts",
       "import": "./dist/ui.js"
+    },
+    "./cloudflare": {
+      "types": "./dist/types/cloudflare.d.ts",
+      "import": "./dist/types/cloudflare.js"
     }
   },
   "scripts": {
@@ -69,9 +73,10 @@
     "db:up": "cd examples && docker compose up -d",
     "db:down": "cd examples && docker compose down",
     "test": "vitest",
+    "test:workers": "vitest --config vitest.config.workers.ts",
     "typecheck": "tsc --noEmit",
     "prepare": "tsup",
-    "prepublishOnly": "pnpm run typecheck && pnpm run test run"
+    "prepublishOnly": "pnpm run typecheck && pnpm run test run && pnpm run test:workers"
   },
   "keywords": [
     "hono",
@@ -99,11 +104,11 @@
   "dependencies": {
     "@hono/swagger-ui": "^0.5.3",
     "@hono/zod-openapi": "^1.2.0",
-    "@scalar/hono-api-reference": "^0.9.19",
-    "fastest-levenshtein": "^1.0.16",
-    "pluralize": "^8.0.0"
+    "@scalar/hono-api-reference": "^0.9.19"
   },
   "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.12.21",
+    "@cloudflare/workers-types": "^4.20260426.1",
     "@hono/node-server": "^1.19.9",
     "@libsql/client": "^0.15.4",
     "@prisma/client": "^7.2.0",
@@ -126,7 +131,9 @@
     "@prisma/client": ">=5.0.0",
     "drizzle-orm": ">=0.30.0",
     "drizzle-zod": ">=0.8.0",
+    "fastest-levenshtein": ">=1.0.0",
     "hono": ">=4.0.0",
+    "pluralize": ">=8.0.0",
     "zod": ">=4.0.0"
   },
   "peerDependenciesMeta": {
@@ -140,6 +147,12 @@
       "optional": true
     },
     "drizzle-zod": {
+      "optional": true
+    },
+    "fastest-levenshtein": {
+      "optional": true
+    },
+    "pluralize": {
       "optional": true
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,12 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0
     devDependencies:
+      '@cloudflare/vitest-pool-workers':
+        specifier: ^0.12.21
+        version: 0.12.21(@cloudflare/workers-types@4.20260426.1)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(vitest@3.2.4(@types/node@22.19.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@cloudflare/workers-types':
+        specifier: ^4.20260426.1
+        version: 4.20260426.1
       '@hono/node-server':
         specifier: ^1.19.9
         version: 1.19.9(hono@4.11.7)
@@ -47,10 +53,10 @@ importers:
         version: 0.0.33
       drizzle-orm:
         specifier: ^0.45.1
-        version: 0.45.1(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@7.3.0(prisma@7.3.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.16.0)(mysql2@3.15.3)(pg@8.17.2)(postgres@3.4.7)(prisma@7.3.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))
+        version: 0.45.1(@cloudflare/workers-types@4.20260426.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@7.3.0(prisma@7.3.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.16.0)(mysql2@3.15.3)(pg@8.17.2)(postgres@3.4.7)(prisma@7.3.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))
       drizzle-zod:
         specifier: ^0.8.3
-        version: 0.8.3(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@7.3.0(prisma@7.3.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.16.0)(mysql2@3.15.3)(pg@8.17.2)(postgres@3.4.7)(prisma@7.3.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)))(zod@4.3.6)
+        version: 0.8.3(drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260426.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@7.3.0(prisma@7.3.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.16.0)(mysql2@3.15.3)(pg@8.17.2)(postgres@3.4.7)(prisma@7.3.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)))(zod@4.3.6)
       hono:
         specifier: ^4.11.4
         version: 4.11.7
@@ -95,6 +101,63 @@ packages:
   '@chevrotain/utils@10.5.0':
     resolution: {integrity: sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==}
 
+  '@cloudflare/kv-asset-handler@0.4.2':
+    resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@cloudflare/unenv-preset@2.15.0':
+    resolution: {integrity: sha512-EGYmJaGZKWl+X8tXxcnx4v2bOZSjQeNI5dWFeXivgX9+YCT69AkzHHwlNbVpqtEUTbew8eQurpyOpeN8fg00nw==}
+    peerDependencies:
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/vitest-pool-workers@0.12.21':
+    resolution: {integrity: sha512-xqvqVR+qAhekXWaTNY36UtFFmHrz13yGUoWVGOu6LDC2ABiQqI1E1lQ3eUZY8KVB+1FXY/mP5dB6oD07XUGnPg==}
+    peerDependencies:
+      '@vitest/runner': 2.0.x - 3.2.x
+      '@vitest/snapshot': 2.0.x - 3.2.x
+      vitest: 2.0.x - 3.2.x
+
+  '@cloudflare/workerd-darwin-64@1.20260310.1':
+    resolution: {integrity: sha512-hF2VpoWaMb1fiGCQJqCY6M8I+2QQqjkyY4LiDYdTL5D/w6C1l5v1zhc0/jrjdD1DXfpJtpcSMSmEPjHse4p9Ig==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260310.1':
+    resolution: {integrity: sha512-h/Vl3XrYYPI6yFDE27XO1QPq/1G1lKIM8tzZGIWYpntK3IN5XtH3Ee/sLaegpJ49aIJoqhF2mVAZ6Yw+Vk2gJw==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20260310.1':
+    resolution: {integrity: sha512-XzQ0GZ8G5P4d74bQYOIP2Su4CLdNPpYidrInaSOuSxMw+HamsHaFrjVsrV2mPy/yk2hi6SY2yMbgKFK9YjA7vw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20260310.1':
+    resolution: {integrity: sha512-sxv4CxnN4ZR0uQGTFVGa0V4KTqwdej/czpIc5tYS86G8FQQoGIBiAIs2VvU7b8EROPcandxYHDBPTb+D9HIMPw==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20260310.1':
+    resolution: {integrity: sha512-+1ZTViWKJypLfgH/luAHCqkent0DEBjAjvO40iAhOMHRLYP/SPphLvr4Jpi6lb+sIocS8Q1QZL4uM5Etg1Wskg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workers-types@4.20260426.1':
+    resolution: {integrity: sha512-cBYeQaWwv/jFV8ualmwp6wIxmAf0rDe2DPPQwPbslKmPHqgv861YpAvm45r05K40QboZgxNQVIPgNkmtHqZeJQ==}
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
   '@electric-sql/pglite-socket@0.0.20':
     resolution: {integrity: sha512-J5nLGsicnD9wJHnno9r+DGxfcZWh+YJMCe0q/aCgtG6XOm9Z7fKeite8IZSNXgZeGltSigM9U/vAWZQWdgcSFg==}
     hasBin: true
@@ -109,8 +172,17 @@ packages:
   '@electric-sql/pglite@0.3.15':
     resolution: {integrity: sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==}
 
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
   '@esbuild/aix-ppc64@0.27.2':
     resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
@@ -121,8 +193,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm@0.27.2':
     resolution: {integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
@@ -133,8 +217,20 @@ packages:
     cpu: [x64]
     os: [android]
 
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/darwin-arm64@0.27.2':
     resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
@@ -145,8 +241,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
   '@esbuild/freebsd-arm64@0.27.2':
     resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
@@ -157,8 +265,20 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
   '@esbuild/linux-arm64@0.27.2':
     resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
@@ -169,8 +289,20 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.2':
     resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
@@ -181,8 +313,20 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.2':
     resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
@@ -193,8 +337,20 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.2':
     resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
@@ -205,8 +361,20 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.2':
     resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
@@ -217,8 +385,20 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.27.2':
     resolution: {integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
@@ -229,8 +409,20 @@ packages:
     cpu: [arm64]
     os: [openbsd]
 
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-x64@0.27.2':
     resolution: {integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
@@ -241,8 +433,20 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/sunos-x64@0.27.2':
     resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
@@ -253,14 +457,32 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.2':
     resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.27.2':
     resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -289,6 +511,143 @@ packages:
       hono: '>=3.9.0'
       zod: ^3.25.0 || ^4.0.0
 
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -301,6 +660,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
   '@libsql/client@0.15.15':
     resolution: {integrity: sha512-twC0hQxPNHPKfeOv3sNT6u2pturQjLcI+CnpTM0SjRpocEGgfiZ7DWKXLNnsothjyJmDqEsBQJ5ztq9Wlu470w==}
@@ -369,6 +731,15 @@ packages:
 
   '@neon-rs/load@0.0.4':
     resolution: {integrity: sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==}
+
+  '@poppinss/colors@4.1.6':
+    resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
+
+  '@poppinss/dumper@0.6.5':
+    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
+
+  '@poppinss/exception@1.2.3':
+    resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
   '@prisma/adapter-pg@7.3.0':
     resolution: {integrity: sha512-iuYQMbIPO6i9O45Fv8TB7vWu00BXhCaNAShenqF7gLExGDbnGp5BfFB4yz1K59zQ59jF6tQ9YHrg0P6/J3OoLg==}
@@ -571,6 +942,13 @@ packages:
     resolution: {integrity: sha512-s+KRRM1NBC/6q74DtxhlkJQgO/POQQXj1k3PuJ54V1IrsS9R6eloxed1uDJLYcG2qKugZdyyDYaEU90lzJB8uw==}
     engines: {node: '>=20'}
 
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
+  '@speed-highlight/core@1.2.15':
+    resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -643,6 +1021,9 @@ packages:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
     engines: {node: '>= 6.0.0'}
 
+  blake3-wasm@2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -682,6 +1063,9 @@ packages:
   citty@0.2.0:
     resolution: {integrity: sha512-8csy5IBFI2ex2hTVpaHN2j+LNE199AgiI7y4dMintrr8i0lQiFn+0AWMZrWdHKIgMOer65f8IThysYhoReqjWA==}
 
+  cjs-module-lexer@1.4.3:
+    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -695,6 +1079,10 @@ packages:
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -736,6 +1124,10 @@ packages:
 
   detect-libc@2.0.2:
     resolution: {integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==}
+    engines: {node: '>=8'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   dotenv@16.6.1:
@@ -847,11 +1239,19 @@ packages:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
     engines: {node: '>=14'}
 
+  error-stack-parser-es@1.0.5:
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   esbuild@0.27.2:
     resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -959,6 +1359,10 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+
   libsql@0.5.22:
     resolution: {integrity: sha512-NscWthMQt7fpU8lqd7LXMvT9pi+KhhmTHAJWUB/Lj6MWa0MKFv0F2V4C6WKKpjCVZl0VwcDz4nOI3CyaT1DDiA==}
     os: [darwin, linux, win32]
@@ -993,6 +1397,11 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  miniflare@4.20260310.0:
+    resolution: {integrity: sha512-uC5vNPenFpDSj5aUU3wGSABG6UUqMr+Xs1m4AkCrTHo37F4Z6xcQw5BXqViTfPDVT/zcYH1UgTVoXhr1l6ZMXw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
@@ -1051,6 +1460,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1229,8 +1641,17 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   seq-queue@0.0.5:
     resolution: {integrity: sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==}
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1280,6 +1701,10 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
 
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
@@ -1324,6 +1749,9 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   tsup@8.5.1:
     resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
     engines: {node: '>=18'}
@@ -1362,6 +1790,13 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.18.2:
+    resolution: {integrity: sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==}
+    engines: {node: '>=20.18.1'}
+
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
   valibot@1.2.0:
     resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
@@ -1458,6 +1893,33 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  workerd@1.20260310.1:
+    resolution: {integrity: sha512-yawXhypXXHtArikJj15HOMknNGikpBbSg2ZDe6lddUbqZnJXuCVSkgc/0ArUeVMG1jbbGvpst+REFtKwILvRTQ==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.72.0:
+    resolution: {integrity: sha512-bKkb8150JGzJZJWiNB2nu/33smVfawmfYiecA6rW4XH7xS23/jqMbgpdelM34W/7a1IhR66qeQGVqTRXROtAZg==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20260310.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
+  ws@8.18.0:
+    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   ws@8.19.0:
     resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
     engines: {node: '>=10.0.0'}
@@ -1478,6 +1940,12 @@ packages:
     resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  youch-core@0.3.3:
+    resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
+
+  youch@4.1.0-beta.10:
+    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
   zeptomatch@2.1.0:
     resolution: {integrity: sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==}
@@ -1507,6 +1975,49 @@ snapshots:
 
   '@chevrotain/utils@10.5.0': {}
 
+  '@cloudflare/kv-asset-handler@0.4.2': {}
+
+  '@cloudflare/unenv-preset@2.15.0(unenv@2.0.0-rc.24)(workerd@1.20260310.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260310.1
+
+  '@cloudflare/vitest-pool-workers@0.12.21(@cloudflare/workers-types@4.20260426.1)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(vitest@3.2.4(@types/node@22.19.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      cjs-module-lexer: 1.4.3
+      esbuild: 0.27.3
+      miniflare: 4.20260310.0
+      vitest: 3.2.4(@types/node@22.19.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      wrangler: 4.72.0(@cloudflare/workers-types@4.20260426.1)
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - bufferutil
+      - utf-8-validate
+
+  '@cloudflare/workerd-darwin-64@1.20260310.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260310.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260310.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20260310.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260310.1':
+    optional: true
+
+  '@cloudflare/workers-types@4.20260426.1': {}
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
   '@electric-sql/pglite-socket@0.0.20(@electric-sql/pglite@0.3.15)':
     dependencies:
       '@electric-sql/pglite': 0.3.15
@@ -1517,82 +2028,165 @@ snapshots:
 
   '@electric-sql/pglite@0.3.15': {}
 
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.2':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.3':
     optional: true
 
   '@esbuild/android-arm64@0.27.2':
     optional: true
 
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
   '@esbuild/android-arm@0.27.2':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
     optional: true
 
   '@esbuild/android-x64@0.27.2':
     optional: true
 
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
     optional: true
 
   '@esbuild/darwin-x64@0.27.2':
     optional: true
 
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.2':
     optional: true
 
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
     optional: true
 
   '@esbuild/linux-arm@0.27.2':
     optional: true
 
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
     optional: true
 
   '@esbuild/linux-loong64@0.27.2':
     optional: true
 
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.2':
     optional: true
 
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
     optional: true
 
   '@esbuild/linux-s390x@0.27.2':
     optional: true
 
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
   '@esbuild/linux-x64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.2':
     optional: true
 
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.2':
     optional: true
 
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
   '@esbuild/openbsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.2':
     optional: true
 
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
     optional: true
 
   '@esbuild/win32-arm64@0.27.2':
     optional: true
 
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.2':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
   '@esbuild/win32-x64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
     optional: true
 
   '@hono/node-server@1.19.9(hono@4.11.4)':
@@ -1620,6 +2214,102 @@ snapshots:
       hono: 4.11.7
       zod: 4.3.6
 
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.10.0
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -1630,6 +2320,11 @@ snapshots:
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -1702,6 +2397,18 @@ snapshots:
       lilconfig: 2.1.0
 
   '@neon-rs/load@0.0.4': {}
+
+  '@poppinss/colors@4.1.6':
+    dependencies:
+      kleur: 4.1.5
+
+  '@poppinss/dumper@0.6.5':
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@sindresorhus/is': 7.2.0
+      supports-color: 10.2.2
+
+  '@poppinss/exception@1.2.3': {}
 
   '@prisma/adapter-pg@7.3.0':
     dependencies:
@@ -1883,6 +2590,10 @@ snapshots:
       type-fest: 5.4.2
       zod: 4.3.6
 
+  '@sindresorhus/is@7.2.0': {}
+
+  '@speed-highlight/core@1.2.15': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@types/chai@5.2.3':
@@ -1964,6 +2675,8 @@ snapshots:
 
   aws-ssl-profiles@1.1.2: {}
 
+  blake3-wasm@2.1.5: {}
+
   bundle-require@5.1.0(esbuild@0.27.2):
     dependencies:
       esbuild: 0.27.2
@@ -2015,6 +2728,8 @@ snapshots:
 
   citty@0.2.0: {}
 
+  cjs-module-lexer@1.4.3: {}
+
   commander@4.1.1: {}
 
   confbox@0.1.8: {}
@@ -2022,6 +2737,8 @@ snapshots:
   confbox@0.2.2: {}
 
   consola@3.4.2: {}
+
+  cookie@1.1.1: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -2049,10 +2766,13 @@ snapshots:
 
   detect-libc@2.0.2: {}
 
+  detect-libc@2.1.2: {}
+
   dotenv@16.6.1: {}
 
-  drizzle-orm@0.45.1(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@7.3.0(prisma@7.3.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.16.0)(mysql2@3.15.3)(pg@8.17.2)(postgres@3.4.7)(prisma@7.3.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)):
+  drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260426.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@7.3.0(prisma@7.3.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.16.0)(mysql2@3.15.3)(pg@8.17.2)(postgres@3.4.7)(prisma@7.3.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)):
     optionalDependencies:
+      '@cloudflare/workers-types': 4.20260426.1
       '@electric-sql/pglite': 0.3.15
       '@libsql/client': 0.15.15
       '@prisma/client': 7.3.0(prisma@7.3.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
@@ -2062,9 +2782,9 @@ snapshots:
       postgres: 3.4.7
       prisma: 7.3.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
 
-  drizzle-zod@0.8.3(drizzle-orm@0.45.1(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@7.3.0(prisma@7.3.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.16.0)(mysql2@3.15.3)(pg@8.17.2)(postgres@3.4.7)(prisma@7.3.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)))(zod@4.3.6):
+  drizzle-zod@0.8.3(drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260426.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@7.3.0(prisma@7.3.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.16.0)(mysql2@3.15.3)(pg@8.17.2)(postgres@3.4.7)(prisma@7.3.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)))(zod@4.3.6):
     dependencies:
-      drizzle-orm: 0.45.1(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@7.3.0(prisma@7.3.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.16.0)(mysql2@3.15.3)(pg@8.17.2)(postgres@3.4.7)(prisma@7.3.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))
+      drizzle-orm: 0.45.1(@cloudflare/workers-types@4.20260426.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@7.3.0(prisma@7.3.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.16.0)(mysql2@3.15.3)(pg@8.17.2)(postgres@3.4.7)(prisma@7.3.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))
       zod: 4.3.6
 
   effect@3.18.4:
@@ -2073,6 +2793,8 @@ snapshots:
       fast-check: 3.23.2
 
   empathic@2.0.0: {}
+
+  error-stack-parser-es@1.0.5: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -2104,6 +2826,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.2
       '@esbuild/win32-ia32': 0.27.2
       '@esbuild/win32-x64': 0.27.2
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
 
   estree-walker@3.0.3:
     dependencies:
@@ -2193,6 +2944,8 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
+  kleur@4.1.5: {}
+
   libsql@0.5.22:
     dependencies:
       '@neon-rs/load': 0.0.4
@@ -2227,6 +2980,18 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  miniflare@4.20260310.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.18.2
+      workerd: 1.20260310.1
+      ws: 8.18.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   mlly@1.8.0:
     dependencies:
@@ -2288,6 +3053,8 @@ snapshots:
       yaml: 2.8.2
 
   path-key@3.1.1: {}
+
+  path-to-regexp@6.3.0: {}
 
   pathe@2.0.3: {}
 
@@ -2464,7 +3231,40 @@ snapshots:
 
   scheduler@0.27.0: {}
 
+  semver@7.7.4: {}
+
   seq-queue@0.0.5: {}
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
 
   shebang-command@2.0.0:
     dependencies:
@@ -2504,6 +3304,8 @@ snapshots:
       tinyglobby: 0.2.15
       ts-interface-checker: 0.1.13
 
+  supports-color@10.2.2: {}
+
   tagged-tag@1.0.0: {}
 
   thenify-all@1.6.0:
@@ -2534,6 +3336,9 @@ snapshots:
   tree-kill@1.2.2: {}
 
   ts-interface-checker@0.1.13: {}
+
+  tslib@2.8.1:
+    optional: true
 
   tsup@8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2):
     dependencies:
@@ -2579,6 +3384,12 @@ snapshots:
   ufo@1.6.3: {}
 
   undici-types@6.21.0: {}
+
+  undici@7.18.2: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
 
   valibot@1.2.0(typescript@5.9.3):
     optionalDependencies:
@@ -2672,11 +3483,51 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  workerd@1.20260310.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260310.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260310.1
+      '@cloudflare/workerd-linux-64': 1.20260310.1
+      '@cloudflare/workerd-linux-arm64': 1.20260310.1
+      '@cloudflare/workerd-windows-64': 1.20260310.1
+
+  wrangler@4.72.0(@cloudflare/workers-types@4.20260426.1):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.4.2
+      '@cloudflare/unenv-preset': 2.15.0(unenv@2.0.0-rc.24)(workerd@1.20260310.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.27.3
+      miniflare: 4.20260310.0
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260310.1
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260426.1
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  ws@8.18.0: {}
+
   ws@8.19.0: {}
 
   xtend@4.0.2: {}
 
   yaml@2.8.2: {}
+
+  youch-core@0.3.3:
+    dependencies:
+      '@poppinss/exception': 1.2.3
+      error-stack-parser-es: 1.0.5
+
+  youch@4.1.0-beta.10:
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@poppinss/dumper': 0.6.5
+      '@speed-highlight/core': 1.2.15
+      cookie: 1.1.1
+      youch-core: 0.3.3
 
   zeptomatch@2.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,10 +21,10 @@ importers:
         specifier: ^0.9.19
         version: 0.9.38(hono@4.11.7)
       fastest-levenshtein:
-        specifier: ^1.0.16
+        specifier: '>=1.0.0'
         version: 1.0.16
       pluralize:
-        specifier: ^8.0.0
+        specifier: '>=8.0.0'
         version: 8.0.0
     devDependencies:
       '@cloudflare/vitest-pool-workers':
@@ -1365,6 +1365,7 @@ packages:
 
   libsql@0.5.22:
     resolution: {integrity: sha512-NscWthMQt7fpU8lqd7LXMvT9pi+KhhmTHAJWUB/Lj6MWa0MKFv0F2V4C6WKKpjCVZl0VwcDz4nOI3CyaT1DDiA==}
+    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lilconfig@2.1.0:

--- a/src/adapters/prisma/advanced.ts
+++ b/src/adapters/prisma/advanced.ts
@@ -43,7 +43,7 @@ export abstract class PrismaSearchEndpoint<
 > extends SearchEndpoint<E, M> {
   abstract prisma: PrismaClient;
 
-  protected getModel(): PrismaModelOperations {
+  protected async getModel(): Promise<PrismaModelOperations> {
     return getPrismaModel(this.prisma, this._meta.model.tableName);
   }
 
@@ -100,7 +100,7 @@ export abstract class PrismaSearchEndpoint<
     options: SearchOptions,
     filters: ListFilters
   ): Promise<SearchResult<ModelObject<M['model']>>> {
-    const model = this.getModel();
+    const model = await this.getModel();
 
     // Build WHERE clause with search conditions and soft delete filtering
     const where = this.buildSearchWhere(options, filters);
@@ -165,14 +165,14 @@ export abstract class PrismaExportEndpoint<
 > extends ExportEndpoint<E, M> {
   abstract prisma: PrismaClient;
 
-  protected getModel(): PrismaModelOperations {
+  protected async getModel(): Promise<PrismaModelOperations> {
     return getPrismaModel(this.prisma, this._meta.model.tableName);
   }
 
   override async list(filters: ListFilters): Promise<PaginatedResult<ModelObject<M['model']>>> {
     // Execute common query logic
     const queryResult = await executePrismaQuery({
-      model: this.getModel(),
+      model: await this.getModel(),
       filters,
       searchFields: this.searchFields,
       softDeleteConfig: this.getSoftDeleteConfig(),
@@ -205,7 +205,7 @@ export abstract class PrismaImportEndpoint<
 > extends ImportEndpoint<E, M> {
   abstract prisma: PrismaClient;
 
-  protected getModel(): PrismaModelOperations {
+  protected async getModel(): Promise<PrismaModelOperations> {
     return getPrismaModel(this.prisma, this._meta.model.tableName);
   }
 
@@ -215,7 +215,7 @@ export abstract class PrismaImportEndpoint<
   override async findExisting(
     data: Partial<ModelObject<M['model']>>
   ): Promise<ModelObject<M['model']> | null> {
-    const model = this.getModel();
+    const model = await this.getModel();
     const upsertKeys = this.getUpsertKeys();
 
     // Build where clause from upsert keys
@@ -241,7 +241,7 @@ export abstract class PrismaImportEndpoint<
   override async create(
     data: Partial<ModelObject<M['model']>>
   ): Promise<ModelObject<M['model']>> {
-    const model = this.getModel();
+    const model = await this.getModel();
     const primaryKey = this._meta.model.primaryKeys[0];
 
     // Generate UUID if not provided
@@ -261,7 +261,7 @@ export abstract class PrismaImportEndpoint<
     existing: ModelObject<M['model']>,
     data: Partial<ModelObject<M['model']>>
   ): Promise<ModelObject<M['model']>> {
-    const model = this.getModel();
+    const model = await this.getModel();
     const primaryKey = this._meta.model.primaryKeys[0];
 
     const result = await model.update({
@@ -286,7 +286,7 @@ export abstract class PrismaUpsertEndpoint<
   abstract prisma: PrismaClient;
   protected useTransaction: boolean = false;
 
-  protected getModel(): PrismaModelOperations {
+  protected async getModel(): Promise<PrismaModelOperations> {
     return getPrismaModel(this.prisma, this._meta.model.tableName);
   }
 
@@ -296,7 +296,7 @@ export abstract class PrismaUpsertEndpoint<
   override async findExisting(
     data: Partial<ModelObject<M['model']>>
   ): Promise<ModelObject<M['model']> | null> {
-    const model = this.getModel();
+    const model = await this.getModel();
     const upsertKeys = this.getUpsertKeys();
 
     // Build where clause from upsert keys
@@ -322,7 +322,7 @@ export abstract class PrismaUpsertEndpoint<
   override async create(
     data: Partial<ModelObject<M['model']>>
   ): Promise<ModelObject<M['model']>> {
-    const model = this.getModel();
+    const model = await this.getModel();
     const primaryKey = this._meta.model.primaryKeys[0];
 
     // Generate UUID if not provided
@@ -342,7 +342,7 @@ export abstract class PrismaUpsertEndpoint<
     existing: ModelObject<M['model']>,
     data: Partial<ModelObject<M['model']>>
   ): Promise<ModelObject<M['model']>> {
-    const model = this.getModel();
+    const model = await this.getModel();
     const primaryKey = this._meta.model.primaryKeys[0];
 
     const result = await model.update({
@@ -360,7 +360,7 @@ export abstract class PrismaUpsertEndpoint<
     data: Partial<ModelObject<M['model']>>,
     _tx?: unknown
   ): Promise<{ data: ModelObject<M['model']>; created: boolean }> {
-    const model = this.getModel();
+    const model = await this.getModel();
     const upsertKeys = this.getUpsertKeys();
     const primaryKey = this._meta.model.primaryKeys[0];
 
@@ -412,12 +412,12 @@ export abstract class PrismaVersionHistoryEndpoint<
 > extends VersionHistoryEndpoint<E, M> {
   abstract prisma: PrismaClient;
 
-  protected getModel(): PrismaModelOperations {
+  protected async getModel(): Promise<PrismaModelOperations> {
     return getPrismaModel(this.prisma, this._meta.model.tableName);
   }
 
   protected override async recordExists(lookupValue: string): Promise<boolean> {
-    const model = this.getModel();
+    const model = await this.getModel();
 
     const count = await model.count({
       where: { [this.lookupField]: lookupValue },
@@ -455,7 +455,7 @@ export abstract class PrismaVersionRollbackEndpoint<
 > extends VersionRollbackEndpoint<E, M> {
   abstract prisma: PrismaClient;
 
-  protected getModel(): PrismaModelOperations {
+  protected async getModel(): Promise<PrismaModelOperations> {
     return getPrismaModel(this.prisma, this._meta.model.tableName);
   }
 
@@ -464,7 +464,7 @@ export abstract class PrismaVersionRollbackEndpoint<
     versionData: Record<string, unknown>,
     newVersion: number
   ): Promise<ModelObject<M['model']>> {
-    const model = this.getModel();
+    const model = await this.getModel();
     const versionField = this.getVersioningConfig().field;
     const primaryKey = this._meta.model.primaryKeys[0];
 
@@ -507,7 +507,7 @@ export abstract class PrismaAggregateEndpoint<
    */
   protected useNativeAggregation: boolean = true;
 
-  protected getModel(): PrismaModelOperations {
+  protected async getModel(): Promise<PrismaModelOperations> {
     return getPrismaModel(this.prisma, this._meta.model.tableName);
   }
 
@@ -576,7 +576,7 @@ export abstract class PrismaAggregateEndpoint<
   }
 
   override async aggregate(options: AggregateOptions): Promise<AggregateResult> {
-    const model = this.getModel();
+    const model = await this.getModel();
     const where = await this.buildAggregateWhere(options);
 
     // Fall back to in-memory computation if native aggregation is disabled
@@ -688,7 +688,7 @@ export abstract class PrismaAggregateEndpoint<
     }
 
     // Execute native aggregation
-    const modelName = getModelName(this._meta.model.tableName);
+    const modelName = await getModelName(this._meta.model.tableName);
     const prismaModel = this.prisma[modelName] as unknown as {
       aggregate: (args: Record<string, unknown>) => Promise<Record<string, unknown>>;
     };
@@ -787,7 +787,7 @@ export abstract class PrismaAggregateEndpoint<
     }
 
     // Execute native groupBy
-    const modelName = getModelName(this._meta.model.tableName);
+    const modelName = await getModelName(this._meta.model.tableName);
     const prismaModel = this.prisma[modelName] as unknown as {
       groupBy: (args: Record<string, unknown>) => Promise<Record<string, unknown>[]>;
     };

--- a/src/adapters/prisma/batch.ts
+++ b/src/adapters/prisma/batch.ts
@@ -29,7 +29,7 @@ export abstract class PrismaRestoreEndpoint<
   abstract prisma: PrismaClient;
   protected useTransaction: boolean = false;
 
-  protected getModel(): PrismaModelOperations {
+  protected async getModel(): Promise<PrismaModelOperations> {
     return getPrismaModel(this.prisma, this._meta.model.tableName);
   }
 
@@ -37,7 +37,7 @@ export abstract class PrismaRestoreEndpoint<
     lookupValue: string,
     additionalFilters?: Record<string, string>
   ): Promise<ModelObject<M['model']> | null> {
-    const model = this.getModel();
+    const model = await this.getModel();
     const softDeleteConfig = this.getSoftDeleteConfig();
 
     // Build where clause
@@ -75,7 +75,7 @@ export abstract class PrismaBatchCreateEndpoint<
 > extends BatchCreateEndpoint<E, M> {
   abstract prisma: PrismaClient;
 
-  protected getModel(): PrismaModelOperations {
+  protected async getModel(): Promise<PrismaModelOperations> {
     return getPrismaModel(this.prisma, this._meta.model.tableName);
   }
 
@@ -95,7 +95,7 @@ export abstract class PrismaBatchCreateEndpoint<
     const created: ModelObject<M['model']>[] = [];
 
     await this.prisma.$transaction(async (tx) => {
-      const txModel = tx[getModelName(this._meta.model.tableName)];
+      const txModel = tx[await getModelName(this._meta.model.tableName)];
       for (const record of records) {
         const result = await txModel.create({ data: record });
         created.push(result as ModelObject<M['model']>);
@@ -118,14 +118,14 @@ export abstract class PrismaBatchUpdateEndpoint<
 > extends BatchUpdateEndpoint<E, M> {
   abstract prisma: PrismaClient;
 
-  protected getModel(): PrismaModelOperations {
+  protected async getModel(): Promise<PrismaModelOperations> {
     return getPrismaModel(this.prisma, this._meta.model.tableName);
   }
 
   override async batchUpdate(
     items: BatchUpdateItem<ModelObject<M['model']>>[]
   ): Promise<{ updated: ModelObject<M['model']>[]; notFound: string[] }> {
-    const model = this.getModel();
+    const model = await this.getModel();
     const softDeleteConfig = this.getSoftDeleteConfig();
     const primaryKey = this._meta.model.primaryKeys[0];
     const updated: ModelObject<M['model']>[] = [];
@@ -187,14 +187,14 @@ export abstract class PrismaBatchDeleteEndpoint<
 > extends BatchDeleteEndpoint<E, M> {
   abstract prisma: PrismaClient;
 
-  protected getModel(): PrismaModelOperations {
+  protected async getModel(): Promise<PrismaModelOperations> {
     return getPrismaModel(this.prisma, this._meta.model.tableName);
   }
 
   override async batchDelete(
     ids: string[]
   ): Promise<{ deleted: ModelObject<M['model']>[]; notFound: string[] }> {
-    const model = this.getModel();
+    const model = await this.getModel();
     const softDeleteConfig = this.getSoftDeleteConfig();
     const primaryKey = this._meta.model.primaryKeys[0];
     const deleted: ModelObject<M['model']>[] = [];
@@ -265,14 +265,14 @@ export abstract class PrismaBatchRestoreEndpoint<
 > extends BatchRestoreEndpoint<E, M> {
   abstract prisma: PrismaClient;
 
-  protected getModel(): PrismaModelOperations {
+  protected async getModel(): Promise<PrismaModelOperations> {
     return getPrismaModel(this.prisma, this._meta.model.tableName);
   }
 
   override async batchRestore(
     ids: string[]
   ): Promise<{ restored: ModelObject<M['model']>[]; notFound: string[] }> {
-    const model = this.getModel();
+    const model = await this.getModel();
     const softDeleteConfig = this.getSoftDeleteConfig();
     const primaryKey = this._meta.model.primaryKeys[0];
     const restored: ModelObject<M['model']>[] = [];
@@ -330,7 +330,7 @@ export abstract class PrismaBatchUpsertEndpoint<
   abstract prisma: PrismaClient;
   protected useTransaction: boolean = true;
 
-  protected getModel(): PrismaModelOperations {
+  protected async getModel(): Promise<PrismaModelOperations> {
     return getPrismaModel(this.prisma, this._meta.model.tableName);
   }
 
@@ -340,7 +340,7 @@ export abstract class PrismaBatchUpsertEndpoint<
   override async findExisting(
     data: Partial<ModelObject<M['model']>>
   ): Promise<ModelObject<M['model']> | null> {
-    const model = this.getModel();
+    const model = await this.getModel();
     const upsertKeys = this.getUpsertKeys();
 
     // Build where clause from upsert keys
@@ -366,7 +366,7 @@ export abstract class PrismaBatchUpsertEndpoint<
   override async create(
     data: Partial<ModelObject<M['model']>>
   ): Promise<ModelObject<M['model']>> {
-    const model = this.getModel();
+    const model = await this.getModel();
     const primaryKey = this._meta.model.primaryKeys[0];
 
     // Generate UUID if not provided
@@ -386,7 +386,7 @@ export abstract class PrismaBatchUpsertEndpoint<
     existing: ModelObject<M['model']>,
     data: Partial<ModelObject<M['model']>>
   ): Promise<ModelObject<M['model']>> {
-    const model = this.getModel();
+    const model = await this.getModel();
     const primaryKey = this._meta.model.primaryKeys[0];
 
     const result = await model.update({
@@ -423,7 +423,7 @@ export abstract class PrismaBatchUpsertEndpoint<
     const primaryKey = this._meta.model.primaryKeys[0];
 
     const executeUpserts = async (prismaClient: PrismaClient) => {
-      const model = prismaClient[getModelName(this._meta.model.tableName)];
+      const model = prismaClient[await getModelName(this._meta.model.tableName)];
       const results: Array<{ data: ModelObject<M['model']>; created: boolean; index: number }> = [];
       const errors: Array<{ index: number; error: string }> = [];
 

--- a/src/adapters/prisma/crud.ts
+++ b/src/adapters/prisma/crud.ts
@@ -31,12 +31,12 @@ export abstract class PrismaCreateEndpoint<
   abstract prisma: PrismaClient;
   protected useTransaction: boolean = false;
 
-  protected getModel(): PrismaModelOperations {
+  protected async getModel(): Promise<PrismaModelOperations> {
     return getPrismaModel(this.prisma, this._meta.model.tableName);
   }
 
   override async create(data: ModelObject<M['model']>): Promise<ModelObject<M['model']>> {
-    const model = this.getModel();
+    const model = await this.getModel();
     const primaryKey = this._meta.model.primaryKeys[0];
 
     // Generate UUID if not provided
@@ -59,7 +59,7 @@ export abstract class PrismaReadEndpoint<
 > extends ReadEndpoint<E, M> {
   abstract prisma: PrismaClient;
 
-  protected getModel(): PrismaModelOperations {
+  protected async getModel(): Promise<PrismaModelOperations> {
     return getPrismaModel(this.prisma, this._meta.model.tableName);
   }
 
@@ -68,7 +68,7 @@ export abstract class PrismaReadEndpoint<
     additionalFilters?: Record<string, string>,
     includeOptions?: IncludeOptions
   ): Promise<ModelObject<M['model']> | null> {
-    const model = this.getModel();
+    const model = await this.getModel();
 
     const where: Record<string, unknown> = {
       [this.lookupField]: lookupValue,
@@ -103,7 +103,7 @@ export abstract class PrismaUpdateEndpoint<
   abstract prisma: PrismaClient;
   protected useTransaction: boolean = false;
 
-  protected getModel(): PrismaModelOperations {
+  protected async getModel(): Promise<PrismaModelOperations> {
     return getPrismaModel(this.prisma, this._meta.model.tableName);
   }
 
@@ -112,7 +112,7 @@ export abstract class PrismaUpdateEndpoint<
     data: Partial<ModelObject<M['model']>>,
     additionalFilters?: Record<string, string>
   ): Promise<ModelObject<M['model']> | null> {
-    const model = this.getModel();
+    const model = await this.getModel();
 
     // First find the record
     const where: Record<string, unknown> = {
@@ -146,7 +146,7 @@ export abstract class PrismaDeleteEndpoint<
   abstract prisma: PrismaClient;
   protected useTransaction: boolean = false;
 
-  protected getModel(): PrismaModelOperations {
+  protected async getModel(): Promise<PrismaModelOperations> {
     return getPrismaModel(this.prisma, this._meta.model.tableName);
   }
 
@@ -157,7 +157,7 @@ export abstract class PrismaDeleteEndpoint<
     lookupValue: string,
     additionalFilters?: Record<string, string>
   ): Promise<ModelObject<M['model']> | null> {
-    const model = this.getModel();
+    const model = await this.getModel();
     const softDeleteConfig = this.getSoftDeleteConfig();
 
     const where: Record<string, unknown> = {
@@ -178,7 +178,7 @@ export abstract class PrismaDeleteEndpoint<
     lookupValue: string,
     additionalFilters?: Record<string, string>
   ): Promise<ModelObject<M['model']> | null> {
-    const model = this.getModel();
+    const model = await this.getModel();
     const softDeleteConfig = this.getSoftDeleteConfig();
 
     // Build where clause
@@ -226,14 +226,14 @@ export abstract class PrismaListEndpoint<
 > extends ListEndpoint<E, M> {
   abstract prisma: PrismaClient;
 
-  protected getModel(): PrismaModelOperations {
+  protected async getModel(): Promise<PrismaModelOperations> {
     return getPrismaModel(this.prisma, this._meta.model.tableName);
   }
 
   override async list(filters: ListFilters): Promise<PaginatedResult<ModelObject<M['model']>>> {
     // Execute common query logic
     const queryResult = await executePrismaQuery({
-      model: this.getModel(),
+      model: await this.getModel(),
       filters,
       searchFields: this.searchFields,
       softDeleteConfig: this.getSoftDeleteConfig(),

--- a/src/adapters/prisma/helpers.ts
+++ b/src/adapters/prisma/helpers.ts
@@ -203,7 +203,7 @@ export function clearPrismaModelMappings(): void {
  * Handles irregular plurals (people→person, children→child, etc.) and
  * common English pluralization patterns automatically.
  */
-function pluralToSingular(word: string): string {
+async function pluralToSingular(word: string): Promise<string> {
   return inlineSingular(word);
 }
 
@@ -216,7 +216,7 @@ function pluralToSingular(word: string): string {
  * @param tableName - The table name (e.g., 'users', 'user_profiles', 'order-items')
  * @returns The Prisma model name (e.g., 'user', 'userProfile', 'orderItem')
  */
-export function getModelName(tableName: string): string {
+export async function getModelName(tableName: string): Promise<string> {
   // Check cache first
   const cached = modelNameCache.get(tableName);
   if (cached) {
@@ -236,7 +236,7 @@ export function getModelName(tableName: string): string {
     .replace(/^./, (char) => char.toLowerCase());
 
   // Convert plural to singular
-  name = pluralToSingular(name);
+  name = await pluralToSingular(name);
 
   // Cache the result
   cacheModelName(tableName, name);
@@ -266,20 +266,22 @@ function getAvailablePrismaModels(prisma: PrismaClient): string[] {
 /**
  * Finds similar model names for error suggestions using Levenshtein distance.
  */
-function findSimilarModelNames(target: string, available: string[], maxSuggestions = 3): string[] {
+async function findSimilarModelNames(target: string, available: string[], maxSuggestions = 3): Promise<string[]> {
   if (available.length === 0) return [];
 
   const targetLower = target.toLowerCase();
-  const scored = available
-    .map(name => ({
+  const scored = await Promise.all(
+    available.map(async (name) => ({
       name,
-      distance: levenshteinDistance(targetLower, name.toLowerCase()),
+      distance: await levenshteinDistance(targetLower, name.toLowerCase()),
     }))
+  );
+
+  return scored
     .filter(item => item.distance <= Math.max(3, target.length / 2))
     .sort((a, b) => a.distance - b.distance)
-    .slice(0, maxSuggestions);
-
-  return scored.map(item => item.name);
+    .slice(0, maxSuggestions)
+    .map(item => item.name);
 }
 
 /**
@@ -291,13 +293,13 @@ function findSimilarModelNames(target: string, available: string[], maxSuggestio
  * @returns The Prisma model operations
  * @throws Error if the model is not found in the Prisma client
  */
-export function getPrismaModel(prisma: PrismaClient, tableName: string): PrismaModelOperations {
-  const modelName = getModelName(tableName);
+export async function getPrismaModel(prisma: PrismaClient, tableName: string): Promise<PrismaModelOperations> {
+  const modelName = await getModelName(tableName);
   const model = prisma[modelName];
 
   if (!model || typeof model.create !== 'function') {
     const availableModels = getAvailablePrismaModels(prisma);
-    const suggestions = findSimilarModelNames(modelName, availableModels);
+    const suggestions = await findSimilarModelNames(modelName, availableModels);
 
     let errorMessage = `Model '${modelName}' not found in Prisma client. ` +
       `Table name: '${tableName}'. `;
@@ -327,7 +329,7 @@ export async function loadPrismaRelation<T extends Record<string, unknown>>(
   relationName: string,
   relationConfig: RelationConfig
 ): Promise<T> {
-  const relatedModelName = getModelName(relationConfig.model);
+  const relatedModelName = await getModelName(relationConfig.model);
   const relatedModel = prisma[relatedModelName];
 
   if (!relatedModel) {
@@ -424,7 +426,7 @@ export async function batchLoadPrismaRelations<T extends Record<string, unknown>
       continue;
     }
 
-    const relatedModelName = getModelName(relationConfig.model);
+    const relatedModelName = await getModelName(relationConfig.model);
     const relatedModel = prisma[relatedModelName];
 
     if (!relatedModel) {

--- a/src/adapters/prisma/helpers.ts
+++ b/src/adapters/prisma/helpers.ts
@@ -199,15 +199,6 @@ export function clearPrismaModelMappings(): void {
 }
 
 /**
- * Converts a plural word to singular.
- * Handles irregular plurals (people→person, children→child, etc.) and
- * common English pluralization patterns automatically.
- */
-async function pluralToSingular(word: string): Promise<string> {
-  return inlineSingular(word);
-}
-
-/**
  * Gets the model name for Prisma from the table name.
  * Prisma uses singular camelCase model names (e.g., 'users' -> 'user').
  *
@@ -217,30 +208,24 @@ async function pluralToSingular(word: string): Promise<string> {
  * @returns The Prisma model name (e.g., 'user', 'userProfile', 'orderItem')
  */
 export async function getModelName(tableName: string): Promise<string> {
-  // Check cache first
   const cached = modelNameCache.get(tableName);
   if (cached) {
     return cached;
   }
 
-  // Check custom mappings
   const custom = customModelMappings.get(tableName.toLowerCase());
   if (custom) {
     cacheModelName(tableName, custom);
     return custom;
   }
 
-  // Convert snake_case or kebab-case to camelCase
+  // snake_case / kebab-case → camelCase, then plural → singular
   let name = tableName
     .replace(/[-_](.)/g, (_, char) => char.toUpperCase())
     .replace(/^./, (char) => char.toLowerCase());
+  name = await inlineSingular(name);
 
-  // Convert plural to singular
-  name = await pluralToSingular(name);
-
-  // Cache the result
   cacheModelName(tableName, name);
-
   return name;
 }
 

--- a/src/adapters/prisma/pluralize.ts
+++ b/src/adapters/prisma/pluralize.ts
@@ -1,10 +1,40 @@
-import pluralize from 'pluralize';
-import { distance } from 'fastest-levenshtein';
+let _pluralize: typeof import('pluralize') | undefined;
+let _distance: typeof import('fastest-levenshtein').distance | undefined;
 
-export function inlineSingular(word: string): string {
+async function loadPluralize() {
+  if (!_pluralize) {
+    try {
+      _pluralize = (await import('pluralize')).default;
+    } catch {
+      throw new Error(
+        'The "pluralize" package is required by the Prisma adapter. ' +
+        'Install it with: npm install pluralize'
+      );
+    }
+  }
+  return _pluralize;
+}
+
+async function loadDistance() {
+  if (!_distance) {
+    try {
+      _distance = (await import('fastest-levenshtein')).distance;
+    } catch {
+      throw new Error(
+        'The "fastest-levenshtein" package is required by the Prisma adapter. ' +
+        'Install it with: npm install fastest-levenshtein'
+      );
+    }
+  }
+  return _distance;
+}
+
+export async function inlineSingular(word: string): Promise<string> {
+  const pluralize = await loadPluralize();
   return pluralize.singular(word);
 }
 
-export function levenshteinDistance(a: string, b: string): number {
+export async function levenshteinDistance(a: string, b: string): Promise<number> {
+  const distance = await loadDistance();
   return distance(a, b);
 }

--- a/src/auth/middleware/combined.ts
+++ b/src/auth/middleware/combined.ts
@@ -57,7 +57,7 @@ function shouldSkipPath(path: string, skipPaths: PathPattern[]): boolean {
  * const app = new Hono<AuthEnv>();
  *
  * app.use('*', createAuthMiddleware({
- *   jwt: { secret: process.env.JWT_SECRET! },
+ *   jwt: { secret: c.env.JWT_SECRET },
  *   apiKey: {
  *     lookupKey: async (hash) => await db.apiKeys.findByHash(hash),
  *   },
@@ -150,7 +150,7 @@ export function createAuthMiddleware<E extends AuthEnv = AuthEnv>(
  * @example
  * ```ts
  * app.use('*', optionalAuth({
- *   jwt: { secret: process.env.JWT_SECRET! },
+ *   jwt: { secret: c.env.JWT_SECRET },
  * }));
  *
  * app.get('/public', (c) => {

--- a/src/auth/middleware/jwt.ts
+++ b/src/auth/middleware/jwt.ts
@@ -72,7 +72,7 @@ function defaultExtractUser(claims: JWTClaims): AuthUser {
  * const app = new Hono<AuthEnv>();
  *
  * app.use('*', createJWTMiddleware({
- *   secret: process.env.JWT_SECRET!,
+ *   secret: c.env.JWT_SECRET,
  *   issuer: 'my-app',
  * }));
  *

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -24,6 +24,8 @@ export {
 export { MemoryCacheStorage } from './storage/memory';
 export { RedisCacheStorage } from './storage/redis';
 export type { RedisClient, RedisCacheStorageOptions } from './storage/redis';
+export { KVCacheStorage } from './storage/cloudflare-kv';
+export type { KVCacheStorageOptions } from './storage/cloudflare-kv';
 
 // Mixins and global storage
 export {

--- a/src/cache/mixin.ts
+++ b/src/cache/mixin.ts
@@ -19,8 +19,8 @@ import { createRegistryWithDefault } from '../storage/registry';
 
 /**
  * Global cache storage registry.
- * Uses lazy initialization -- the default MemoryCacheStorage is only
- * created when first accessed.
+ * Compatibility registry. Request-time cache helpers use explicit/context
+ * storage and do not create this default automatically.
  */
 export const cacheStorageRegistry = createRegistryWithDefault<CacheStorage>(
   'cacheStorage',
@@ -36,7 +36,7 @@ export const cacheStorageRegistry = createRegistryWithDefault<CacheStorage>(
  * import { RedisCacheStorage, setCacheStorage } from 'hono-crud/cache';
  *
  * setCacheStorage(new RedisCacheStorage({
- *   client: new Redis({ url: process.env.REDIS_URL }),
+ *   client: new Redis({ url: c.env.REDIS_URL }),
  * }));
  * ```
  */
@@ -196,6 +196,10 @@ export function withCache<TBase extends Constructor<OpenAPIRoute>>(
       const key = await this.generateCacheKey();
       const ctx = this.getContext();
       const storage = resolveCacheStorage(ctx);
+      if (!storage) {
+        this._cacheHit = false;
+        return null;
+      }
       const entry = await storage.get<T>(key);
 
       this._cacheHit = entry !== null;
@@ -249,6 +253,9 @@ export function withCache<TBase extends Constructor<OpenAPIRoute>>(
       const key = await this.generateCacheKey();
       const ctx = this.getContext();
       const storage = resolveCacheStorage(ctx);
+      if (!storage) {
+        return;
+      }
 
       // Build tags
       const tags: string[] = config.tags ? [...config.tags] : [];
@@ -271,6 +278,9 @@ export function withCache<TBase extends Constructor<OpenAPIRoute>>(
     async invalidateCache(options?: { pattern?: string; tags?: string[] }): Promise<void> {
       const ctx = this.getContext();
       const storage = resolveCacheStorage(ctx);
+      if (!storage) {
+        return;
+      }
       const config = this.getCacheConfig();
 
       if (options?.pattern) {
@@ -340,6 +350,9 @@ export function withCacheInvalidation<TBase extends Constructor<OpenAPIRoute>>(
       const config = this.getCacheInvalidationConfig();
       const ctx = this.getContext();
       const storage = resolveCacheStorage(ctx);
+      if (!storage) {
+        return;
+      }
 
       const meta = (this as unknown as { _meta?: MetaInput })._meta;
       const tableName = meta?.model?.tableName ?? 'unknown';

--- a/src/cache/storage/cloudflare-kv.ts
+++ b/src/cache/storage/cloudflare-kv.ts
@@ -1,0 +1,209 @@
+import type { CacheEntry, CacheSetOptions, CacheStats, CacheStorage } from '../types';
+import type { KVNamespace } from '../../shared/kv-types';
+
+/**
+ * Options for Cloudflare KV cache storage.
+ */
+export interface KVCacheStorageOptions {
+  /** KV namespace binding. */
+  kv: KVNamespace;
+  /** Key prefix for all cache entries. @default 'cache:' */
+  prefix?: string;
+  /** Default TTL in seconds. @default 300 */
+  defaultTtl?: number;
+}
+
+/**
+ * Cloudflare KV cache storage implementation.
+ *
+ * Uses KV's native TTL for expiration and stores tag indices as JSON arrays.
+ * Best used with the `createCrudMiddleware` since KV bindings are only
+ * available inside request handlers.
+ *
+ * **Caveats:**
+ * - Tag indices use read-modify-write (not atomic) — concurrent writes to
+ *   the same tag may lose entries. Acceptable for cache invalidation.
+ * - KV is eventually consistent (~60s stale reads possible).
+ * - `deletePattern()` uses KV `list()` which may be slow for large keyspaces.
+ *
+ * @example
+ * ```ts
+ * import { KVCacheStorage, createCrudMiddleware } from 'hono-crud';
+ *
+ * app.use('*', async (c, next) => {
+ *   const cache = new KVCacheStorage({ kv: c.env.CACHE_KV });
+ *   return createCrudMiddleware({ cache })(c, next);
+ * });
+ * ```
+ */
+export class KVCacheStorage implements CacheStorage {
+  private kv: KVNamespace;
+  private prefix: string;
+  private defaultTtl: number;
+
+  private stats: CacheStats = { hits: 0, misses: 0, size: 0 };
+
+  constructor(options: KVCacheStorageOptions) {
+    this.kv = options.kv;
+    this.prefix = options.prefix ?? 'cache:';
+    this.defaultTtl = options.defaultTtl ?? 300;
+  }
+
+  private getKey(key: string): string {
+    return `${this.prefix}${key}`;
+  }
+
+  private getTagKey(tag: string): string {
+    return `${this.prefix}_tag:${tag}`;
+  }
+
+  private getExpirationTtl(ttl: number): number {
+    return Math.max(60, ttl);
+  }
+
+  async get<T>(key: string): Promise<CacheEntry<T> | null> {
+    const raw = await this.kv.get(this.getKey(key));
+    if (!raw) {
+      this.stats.misses++;
+      return null;
+    }
+
+    try {
+      const entry = JSON.parse(raw) as CacheEntry<T>;
+
+      // Check expiration (KV TTL handles this, but guard against clock skew)
+      if (entry.expiresAt && entry.expiresAt < Date.now()) {
+        this.stats.misses++;
+        return null;
+      }
+
+      this.stats.hits++;
+      return entry;
+    } catch {
+      this.stats.misses++;
+      return null;
+    }
+  }
+
+  async set<T>(key: string, data: T, options?: CacheSetOptions): Promise<void> {
+    const ttl = options?.ttl ?? this.defaultTtl;
+    const tags = options?.tags;
+    const now = Date.now();
+
+    const entry: CacheEntry<T> = {
+      data,
+      createdAt: now,
+      expiresAt: ttl > 0 ? now + ttl * 1000 : null,
+      tags,
+    };
+
+    const kvOptions = ttl > 0 ? { expirationTtl: this.getExpirationTtl(ttl) } : undefined;
+    await this.kv.put(this.getKey(key), JSON.stringify(entry), kvOptions);
+
+    // Update tag indices
+    if (tags) {
+      for (const tag of tags) {
+        const tagKey = this.getTagKey(tag);
+        const existing = await this.kv.get(tagKey);
+        const keys: string[] = existing ? JSON.parse(existing) : [];
+        if (!keys.includes(key)) {
+          keys.push(key);
+          // Tag indices expire after 24h to prevent unbounded growth
+          await this.kv.put(tagKey, JSON.stringify(keys), { expirationTtl: 86400 });
+        }
+      }
+    }
+  }
+
+  async delete(key: string): Promise<boolean> {
+    const fullKey = this.getKey(key);
+
+    // Clean up tags
+    const raw = await this.kv.get(fullKey);
+    if (raw) {
+      try {
+        const entry = JSON.parse(raw) as CacheEntry<unknown>;
+        if (entry.tags) {
+          for (const tag of entry.tags) {
+            const tagKey = this.getTagKey(tag);
+            const existing = await this.kv.get(tagKey);
+            if (existing) {
+              const keys: string[] = JSON.parse(existing);
+              const filtered = keys.filter((k) => k !== key);
+              if (filtered.length > 0) {
+                await this.kv.put(tagKey, JSON.stringify(filtered), { expirationTtl: 86400 });
+              } else {
+                await this.kv.delete(tagKey);
+              }
+            }
+          }
+        }
+      } catch {
+        // Ignore parse errors
+      }
+    }
+
+    await this.kv.delete(fullKey);
+    return raw !== null;
+  }
+
+  async deletePattern(pattern: string): Promise<number> {
+    // Convert glob pattern to prefix for KV list
+    const prefixEnd = pattern.indexOf('*');
+    const searchPrefix = prefixEnd >= 0
+      ? this.getKey(pattern.substring(0, prefixEnd))
+      : this.getKey(pattern);
+
+    let count = 0;
+    let cursor: string | undefined;
+
+    do {
+      const result = await this.kv.list({
+        prefix: searchPrefix,
+        limit: 100,
+        cursor,
+      });
+
+      for (const { name } of result.keys) {
+        const originalKey = name.substring(this.prefix.length);
+        await this.delete(originalKey);
+        count++;
+      }
+
+      cursor = result.list_complete ? undefined : result.cursor;
+    } while (cursor);
+
+    return count;
+  }
+
+  async deleteByTag(tag: string): Promise<number> {
+    const tagKey = this.getTagKey(tag);
+    const existing = await this.kv.get(tagKey);
+    if (!existing) return 0;
+
+    const keys: string[] = JSON.parse(existing);
+    let count = 0;
+
+    for (const key of keys) {
+      await this.kv.delete(this.getKey(key));
+      count++;
+    }
+
+    await this.kv.delete(tagKey);
+    return count;
+  }
+
+  async has(key: string): Promise<boolean> {
+    const raw = await this.kv.get(this.getKey(key));
+    return raw !== null;
+  }
+
+  async clear(): Promise<void> {
+    await this.deletePattern('*');
+    this.stats = { hits: 0, misses: 0, size: 0 };
+  }
+
+  getStats(): CacheStats {
+    return { ...this.stats };
+  }
+}

--- a/src/cache/storage/cloudflare-kv.ts
+++ b/src/cache/storage/cloudflare-kv.ts
@@ -1,6 +1,14 @@
 import type { CacheEntry, CacheSetOptions, CacheStats, CacheStorage } from '../types';
 import type { KVNamespace } from '../../shared/kv-types';
 
+const KV_BATCH_CONCURRENCY = 50;
+
+async function runBatched<T>(items: T[], fn: (item: T) => Promise<unknown>): Promise<void> {
+  for (let i = 0; i < items.length; i += KV_BATCH_CONCURRENCY) {
+    await Promise.all(items.slice(i, i + KV_BATCH_CONCURRENCY).map(fn));
+  }
+}
+
 /**
  * Options for Cloudflare KV cache storage.
  */
@@ -71,6 +79,18 @@ export class KVCacheStorage implements CacheStorage {
     try {
       const entry = JSON.parse(raw) as CacheEntry<T>;
 
+      // Migration guard: convert legacy Date strings to epoch ms
+      const legacyCreatedAt = entry.createdAt as unknown;
+      if (typeof legacyCreatedAt === 'string') {
+        const parsed = Date.parse(legacyCreatedAt);
+        entry.createdAt = Number.isNaN(parsed) ? Date.now() : parsed;
+      }
+      const legacyExpiresAt = entry.expiresAt as unknown;
+      if (typeof legacyExpiresAt === 'string') {
+        const parsed = Date.parse(legacyExpiresAt);
+        entry.expiresAt = Number.isNaN(parsed) ? null : parsed;
+      }
+
       // Check expiration (KV TTL handles this, but guard against clock skew)
       if (entry.expiresAt && entry.expiresAt < Date.now()) {
         this.stats.misses++;
@@ -102,7 +122,7 @@ export class KVCacheStorage implements CacheStorage {
 
     // Update tag indices
     if (tags) {
-      for (const tag of tags) {
+      await runBatched(tags, async (tag) => {
         const tagKey = this.getTagKey(tag);
         const existing = await this.kv.get(tagKey);
         const keys: string[] = existing ? JSON.parse(existing) : [];
@@ -111,7 +131,7 @@ export class KVCacheStorage implements CacheStorage {
           // Tag indices expire after 24h to prevent unbounded growth
           await this.kv.put(tagKey, JSON.stringify(keys), { expirationTtl: 86400 });
         }
-      }
+      });
     }
   }
 
@@ -124,19 +144,18 @@ export class KVCacheStorage implements CacheStorage {
       try {
         const entry = JSON.parse(raw) as CacheEntry<unknown>;
         if (entry.tags) {
-          for (const tag of entry.tags) {
+          await runBatched(entry.tags, async (tag) => {
             const tagKey = this.getTagKey(tag);
             const existing = await this.kv.get(tagKey);
-            if (existing) {
-              const keys: string[] = JSON.parse(existing);
-              const filtered = keys.filter((k) => k !== key);
-              if (filtered.length > 0) {
-                await this.kv.put(tagKey, JSON.stringify(filtered), { expirationTtl: 86400 });
-              } else {
-                await this.kv.delete(tagKey);
-              }
+            if (!existing) return;
+            const keys: string[] = JSON.parse(existing);
+            const filtered = keys.filter((k) => k !== key);
+            if (filtered.length > 0) {
+              await this.kv.put(tagKey, JSON.stringify(filtered), { expirationTtl: 86400 });
+            } else {
+              await this.kv.delete(tagKey);
             }
-          }
+          });
         }
       } catch {
         // Ignore parse errors
@@ -164,11 +183,9 @@ export class KVCacheStorage implements CacheStorage {
         cursor,
       });
 
-      for (const { name } of result.keys) {
-        const originalKey = name.substring(this.prefix.length);
-        await this.delete(originalKey);
-        count++;
-      }
+      const keys = result.keys.map(({ name }) => name.substring(this.prefix.length));
+      await runBatched(keys, (k) => this.delete(k));
+      count += keys.length;
 
       cursor = result.list_complete ? undefined : result.cursor;
     } while (cursor);
@@ -182,15 +199,9 @@ export class KVCacheStorage implements CacheStorage {
     if (!existing) return 0;
 
     const keys: string[] = JSON.parse(existing);
-    let count = 0;
-
-    for (const key of keys) {
-      await this.kv.delete(this.getKey(key));
-      count++;
-    }
-
+    await runBatched(keys, (k) => this.kv.delete(this.getKey(k)));
     await this.kv.delete(tagKey);
-    return count;
+    return keys.length;
   }
 
   async has(key: string): Promise<boolean> {

--- a/src/cache/storage/memory.ts
+++ b/src/cache/storage/memory.ts
@@ -61,7 +61,7 @@ export class MemoryCacheStorage implements CacheStorage {
     }
 
     // Check expiration
-    if (entry.expiresAt && entry.expiresAt < new Date()) {
+    if (entry.expiresAt && entry.expiresAt < Date.now()) {
       // Entry has expired, delete it
       await this.delete(key);
       this.stats.misses++;
@@ -84,10 +84,11 @@ export class MemoryCacheStorage implements CacheStorage {
       this.evictOldest();
     }
 
+    const now = Date.now();
     const entry: CacheEntry<T> = {
       data,
-      createdAt: new Date(),
-      expiresAt: ttl > 0 ? new Date(Date.now() + ttl * 1000) : null,
+      createdAt: now,
+      expiresAt: ttl > 0 ? now + ttl * 1000 : null,
       tags,
     };
 
@@ -99,7 +100,10 @@ export class MemoryCacheStorage implements CacheStorage {
       }
     }
 
-    // Add to storage
+    // Delete and re-insert to move to newest position (Map insertion order)
+    if (oldEntry) {
+      this.storage.delete(key);
+    }
     this.storage.set(key, entry);
     this.stats.size = this.storage.size;
 
@@ -196,7 +200,7 @@ export class MemoryCacheStorage implements CacheStorage {
     }
 
     // Check expiration
-    if (entry.expiresAt && entry.expiresAt < new Date()) {
+    if (entry.expiresAt && entry.expiresAt < Date.now()) {
       await this.delete(key);
       return false;
     }
@@ -244,20 +248,11 @@ export class MemoryCacheStorage implements CacheStorage {
 
   /**
    * Evict oldest entry when at capacity.
+   * Uses Map insertion order for O(1) lookup instead of scanning all entries.
    */
   private evictOldest(): void {
-    let oldestKey: string | null = null;
-    let oldestTime = Infinity;
-
-    for (const [key, entry] of this.storage.entries()) {
-      const time = entry.createdAt.getTime();
-      if (time < oldestTime) {
-        oldestTime = time;
-        oldestKey = key;
-      }
-    }
-
-    if (oldestKey) {
+    const oldestKey = this.storage.keys().next().value;
+    if (oldestKey !== undefined) {
       this.delete(oldestKey).catch(() => {});
     }
   }
@@ -266,7 +261,7 @@ export class MemoryCacheStorage implements CacheStorage {
    * Clean up expired entries (manual garbage collection).
    */
   async cleanup(): Promise<number> {
-    const now = new Date();
+    const now = Date.now();
     let count = 0;
     const keysToDelete: string[] = [];
 

--- a/src/cache/storage/redis.ts
+++ b/src/cache/storage/redis.ts
@@ -129,11 +129,15 @@ export class RedisCacheStorage implements CacheStorage {
       const entry = JSON.parse(value) as CacheEntry<T>;
 
       // Migration guard: convert legacy Date strings to epoch ms
-      if (typeof entry.createdAt === 'string') {
-        entry.createdAt = new Date(entry.createdAt).getTime();
+      const legacyCreatedAt = entry.createdAt as unknown;
+      if (typeof legacyCreatedAt === 'string') {
+        const parsed = Date.parse(legacyCreatedAt);
+        entry.createdAt = Number.isNaN(parsed) ? Date.now() : parsed;
       }
-      if (entry.expiresAt !== null && typeof entry.expiresAt === 'string') {
-        entry.expiresAt = new Date(entry.expiresAt as unknown as string).getTime();
+      const legacyExpiresAt = entry.expiresAt as unknown;
+      if (typeof legacyExpiresAt === 'string') {
+        const parsed = Date.parse(legacyExpiresAt);
+        entry.expiresAt = Number.isNaN(parsed) ? null : parsed;
       }
 
       // Redis handles TTL, but check just in case

--- a/src/cache/storage/redis.ts
+++ b/src/cache/storage/redis.ts
@@ -16,6 +16,14 @@ export interface RedisClient {
   smembers?(key: string): Promise<string[]>;
   srem?(key: string, ...members: string[]): Promise<number>;
   flushdb?(): Promise<string>;
+  /** Pipeline support for batching commands (supported by @upstash/redis and ioredis). */
+  pipeline?(): {
+    set(key: string, value: string, options?: { ex?: number }): unknown;
+    del(...keys: string[]): unknown;
+    sadd(key: string, ...members: string[]): unknown;
+    srem(key: string, ...members: string[]): unknown;
+    exec(): Promise<unknown[]>;
+  };
 }
 
 /**
@@ -51,8 +59,8 @@ export interface RedisCacheStorageOptions {
  *
  * const cache = new RedisCacheStorage({
  *   client: new Redis({
- *     url: process.env.REDIS_URL,
- *     token: process.env.REDIS_TOKEN,
+ *     url: c.env.REDIS_URL,
+ *     token: c.env.REDIS_TOKEN,
  *   }),
  * });
  * setCacheStorage(cache);
@@ -64,7 +72,7 @@ export interface RedisCacheStorageOptions {
  * import { RedisCacheStorage, setCacheStorage } from 'hono-crud/cache';
  *
  * const cache = new RedisCacheStorage({
- *   client: new Redis(process.env.REDIS_URL),
+ *   client: new Redis(c.env.REDIS_URL),
  * });
  * setCacheStorage(cache);
  * ```
@@ -120,14 +128,16 @@ export class RedisCacheStorage implements CacheStorage {
     try {
       const entry = JSON.parse(value) as CacheEntry<T>;
 
-      // Convert date strings back to Date objects
-      entry.createdAt = new Date(entry.createdAt);
-      if (entry.expiresAt) {
-        entry.expiresAt = new Date(entry.expiresAt);
+      // Migration guard: convert legacy Date strings to epoch ms
+      if (typeof entry.createdAt === 'string') {
+        entry.createdAt = new Date(entry.createdAt).getTime();
+      }
+      if (entry.expiresAt !== null && typeof entry.expiresAt === 'string') {
+        entry.expiresAt = new Date(entry.expiresAt as unknown as string).getTime();
       }
 
       // Redis handles TTL, but check just in case
-      if (entry.expiresAt && entry.expiresAt < new Date()) {
+      if (entry.expiresAt && entry.expiresAt < Date.now()) {
         this.stats.misses++;
         return null;
       }
@@ -148,26 +158,37 @@ export class RedisCacheStorage implements CacheStorage {
     const ttl = options?.ttl ?? this.defaultTtl;
     const tags = options?.tags;
 
+    const now = Date.now();
     const entry: CacheEntry<T> = {
       data,
-      createdAt: new Date(),
-      expiresAt: ttl > 0 ? new Date(Date.now() + ttl * 1000) : null,
+      createdAt: now,
+      expiresAt: ttl > 0 ? now + ttl * 1000 : null,
       tags,
     };
 
     const value = JSON.stringify(entry);
 
-    // Set with TTL
-    if (ttl > 0) {
-      await this.client.set(fullKey, value, { ex: ttl });
-    } else {
-      await this.client.set(fullKey, value);
-    }
-
-    // Update tag index
-    if (tags && this.client.sadd) {
+    // Use pipeline when tags exist and pipeline is available (single round-trip)
+    if (tags && tags.length > 0 && this.client.pipeline) {
+      const pipe = this.client.pipeline();
+      ttl > 0 ? pipe.set(fullKey, value, { ex: ttl }) : pipe.set(fullKey, value);
       for (const tag of tags) {
-        await this.client.sadd(this.getTagKey(tag), key);
+        pipe.sadd(this.getTagKey(tag), key);
+      }
+      await pipe.exec();
+    } else {
+      // Sequential fallback
+      if (ttl > 0) {
+        await this.client.set(fullKey, value, { ex: ttl });
+      } else {
+        await this.client.set(fullKey, value);
+      }
+
+      // Update tag index
+      if (tags && this.client.sadd) {
+        for (const tag of tags) {
+          await this.client.sadd(this.getTagKey(tag), key);
+        }
       }
     }
   }
@@ -256,9 +277,19 @@ export class RedisCacheStorage implements CacheStorage {
       return 0;
     }
 
-    let count = 0;
+    // Use pipeline for batch deletes if available
+    if (this.client.pipeline) {
+      const pipe = this.client.pipeline();
+      for (const key of keys) {
+        pipe.del(this.getKey(key));
+      }
+      pipe.del(tagKey);
+      await pipe.exec();
+      return keys.length;
+    }
 
-    // Delete each key
+    // Sequential fallback
+    let count = 0;
     for (const key of keys) {
       const deleted = await this.delete(key);
       if (deleted) {

--- a/src/cache/types.ts
+++ b/src/cache/types.ts
@@ -3,8 +3,10 @@
  */
 export interface CacheEntry<T = unknown> {
   data: T;
-  createdAt: Date;
-  expiresAt: Date | null;
+  /** Epoch milliseconds when the entry was created. */
+  createdAt: number;
+  /** Epoch milliseconds when the entry expires, or null for no expiration. */
+  expiresAt: number | null;
   tags?: string[];
 }
 

--- a/src/core/audit.ts
+++ b/src/core/audit.ts
@@ -115,9 +115,9 @@ export class MemoryAuditLogStorage implements AuditLogStorage {
 
 /**
  * Global audit log storage registry.
- * Uses lazy initialization -- the default MemoryAuditLogStorage is only
- * created when first accessed, avoiding unnecessary allocations on
- * edge runtimes where audit may not be used.
+ * Compatibility getters can still create a MemoryAuditLogStorage lazily, but
+ * request-time audit resolution requires explicit, context, or configured
+ * global storage.
  */
 export const auditStorageRegistry = createRegistryWithDefault<AuditLogStorage>(
   'auditStorage',
@@ -143,12 +143,20 @@ export function getAuditStorage(): AuditLogStorage {
  */
 export class AuditLogger {
   private config: NormalizedAuditConfig;
-  private storage: AuditLogStorage;
+  private storage: AuditLogStorage | null;
 
   constructor(config: AuditConfig | undefined, storage?: AuditLogStorage, ctx?: Context<Env>) {
     this.config = getAuditConfig(config);
-    // Resolve storage with priority: explicit > context > global (via registry)
-    this.storage = auditStorageRegistry.resolve(ctx, storage) ?? auditStorageRegistry.getRequired();
+    this.storage = auditStorageRegistry.resolve(ctx, storage);
+  }
+
+  private getStorage(): AuditLogStorage {
+    if (!this.storage) {
+      throw new Error(
+        'Audit storage not configured. Pass storage explicitly or inject auditStorage with createCrudMiddleware().'
+      );
+    }
+    return this.storage;
   }
 
   /**
@@ -182,7 +190,7 @@ export class AuditLogger {
       entry.record = this.filterFields(record);
     }
 
-    await this.storage.store(entry);
+    await this.getStorage().store(entry);
   }
 
   /**
@@ -222,7 +230,7 @@ export class AuditLogger {
       );
     }
 
-    await this.storage.store(entry);
+    await this.getStorage().store(entry);
   }
 
   /**
@@ -249,7 +257,7 @@ export class AuditLogger {
       entry.previousRecord = this.filterFields(previousRecord);
     }
 
-    await this.storage.store(entry);
+    await this.getStorage().store(entry);
   }
 
   /**
@@ -276,7 +284,7 @@ export class AuditLogger {
       entry.record = this.filterFields(record);
     }
 
-    await this.storage.store(entry);
+    await this.getStorage().store(entry);
   }
 
   /**
@@ -317,7 +325,7 @@ export class AuditLogger {
       );
     }
 
-    await this.storage.store(entry);
+    await this.getStorage().store(entry);
   }
 
   /**
@@ -361,7 +369,7 @@ export class AuditLogger {
         );
       }
 
-      await this.storage.store(entry);
+      await this.getStorage().store(entry);
     }
   }
 
@@ -416,7 +424,7 @@ export class AuditLogger {
  *
  * @example
  * ```ts
- * // Using global storage
+ * // Using compatibility global storage
  * const logger = createAuditLogger(config);
  *
  * // Using context-based storage

--- a/src/core/versioning.ts
+++ b/src/core/versioning.ts
@@ -201,8 +201,9 @@ export class MemoryVersioningStorage implements VersioningStorage {
 
 /**
  * Global versioning storage registry.
- * Uses lazy initialization -- the default MemoryVersioningStorage is only
- * created when first accessed.
+ * Compatibility getters can still create a MemoryVersioningStorage lazily, but
+ * request-time versioning resolution requires explicit, context, or configured
+ * global storage.
  */
 export const versioningStorageRegistry = createRegistryWithDefault<VersioningStorage>(
   'versioningStorage',
@@ -228,7 +229,7 @@ export function getVersioningStorage(): VersioningStorage {
  */
 export class VersionManager {
   private config: NormalizedVersioningConfig;
-  private storage: VersioningStorage;
+  private storage: VersioningStorage | null;
   private tableName: string;
 
   constructor(
@@ -239,8 +240,16 @@ export class VersionManager {
   ) {
     this.config = getVersioningConfig(config, tableName);
     this.tableName = tableName;
-    // Resolve storage with priority: explicit > context > global (via registry)
-    this.storage = versioningStorageRegistry.resolve(ctx, storage) ?? versioningStorageRegistry.getRequired();
+    this.storage = versioningStorageRegistry.resolve(ctx, storage);
+  }
+
+  private getStorage(): VersioningStorage {
+    if (!this.storage) {
+      throw new Error(
+        'Versioning storage not configured. Pass storage explicitly or inject versioningStorage with createCrudMiddleware().'
+      );
+    }
+    return this.storage;
   }
 
   /**
@@ -311,15 +320,16 @@ export class VersionManager {
     }
 
     // Save to storage
-    if ('store' in this.storage && typeof this.storage.store === 'function') {
-      await (this.storage as MemoryVersioningStorage).store(this.tableName, entry);
+    const storage = this.getStorage();
+    if ('store' in storage && typeof storage.store === 'function') {
+      await (storage as MemoryVersioningStorage).store(this.tableName, entry);
     } else {
-      await this.storage.save(entry);
+      await storage.save(entry);
     }
 
     // Prune old versions if maxVersions is set
-    if (this.config.maxVersions && this.storage.pruneVersions) {
-      await this.storage.pruneVersions(
+    if (this.config.maxVersions && storage.pruneVersions) {
+      await storage.pruneVersions(
         this.tableName,
         recordId,
         this.config.maxVersions
@@ -336,7 +346,7 @@ export class VersionManager {
     recordId: string | number,
     options?: { limit?: number; offset?: number }
   ): Promise<VersionHistoryEntry[]> {
-    return this.storage.getByRecordId(this.tableName, recordId, options);
+    return this.getStorage().getByRecordId(this.tableName, recordId, options);
   }
 
   /**
@@ -346,7 +356,7 @@ export class VersionManager {
     recordId: string | number,
     version: number
   ): Promise<VersionHistoryEntry | null> {
-    return this.storage.getVersion(this.tableName, recordId, version);
+    return this.getStorage().getVersion(this.tableName, recordId, version);
   }
 
   /**
@@ -364,7 +374,7 @@ export class VersionManager {
    * Get the latest version number for a record.
    */
   async getLatestVersion(recordId: string | number): Promise<number> {
-    return this.storage.getLatestVersion(this.tableName, recordId);
+    return this.getStorage().getLatestVersion(this.tableName, recordId);
   }
 
   /**
@@ -395,8 +405,9 @@ export class VersionManager {
    * Delete all versions for a record.
    */
   async deleteAllVersions(recordId: string | number): Promise<number> {
-    if (this.storage.deleteAllVersions) {
-      return this.storage.deleteAllVersions(this.tableName, recordId);
+    const storage = this.getStorage();
+    if (storage.deleteAllVersions) {
+      return storage.deleteAllVersions(this.tableName, recordId);
     }
     return 0;
   }
@@ -430,7 +441,7 @@ export class VersionManager {
  *
  * @example
  * ```ts
- * // Using global storage
+ * // Using compatibility global storage
  * const manager = createVersionManager(config, 'users');
  *
  * // Using context-based storage

--- a/src/endpoints/export.ts
+++ b/src/endpoints/export.ts
@@ -6,7 +6,7 @@ import type { MetaInput, OpenAPIRouteSchema, ListFilters } from '../core/types';
 import type { ModelObject } from './types';
 import {
   generateCsv,
-  createCsvStream,
+  escapeCsvValue,
   type CsvGenerateOptions,
 } from '../utils/csv';
 
@@ -51,14 +51,10 @@ export interface ExportResult<T> {
 
 /**
  * Base endpoint for exporting resources in CSV or JSON format.
- * Extends ListEndpoint to leverage existing filtering, sorting, pagination, and field selection.
+ * Extends ListEndpoint to leverage filtering, sorting, pagination, and field selection.
+ * Edge-runtime compatible (Web APIs only); CSV streaming uses Web `ReadableStream`.
  *
- * Features:
- * - CSV and JSON export formats
- * - Streaming support for large exports via Web ReadableStream
- * - Uses all ListEndpoint features (filters, sort, field selection)
- * - Configurable max records and excluded fields
- * - Edge runtime compatible (Web APIs only)
+ * Query params: `format=json|csv`, `stream=true|false` (see `getExportQuerySchema`).
  *
  * @example
  * ```ts
@@ -71,13 +67,6 @@ export interface ExportResult<T> {
  *   protected filterFields = ['status', 'role'];
  * }
  * ```
- *
- * API Usage:
- * - `GET /users/export` - Export as JSON (default)
- * - `GET /users/export?format=csv` - Export as CSV
- * - `GET /users/export?format=csv&status=active` - Export with filters
- * - `GET /users/export?format=json&fields=id,name,email` - Export with field selection
- * - `GET /users/export?format=csv&stream=true` - Stream large exports
  */
 export abstract class ExportEndpoint<
   E extends Env = Env,
@@ -250,73 +239,27 @@ export abstract class ExportEndpoint<
   ): Response {
     const ctx = this.getContext();
     const filename = this.getExportFilename(format);
-    const csvOptions = {
-      ...this.csvOptions,
-      excludeFields: this.excludedExportFields,
-    };
+    const csvOptions = this.csvOptions;
+    const excludedFields = this.excludedExportFields;
 
-    // Use Hono's stream helper for better integration
     return stream(ctx, async (streamWriter) => {
-      // Set headers before writing
       ctx.header('Content-Type', 'text/csv; charset=utf-8');
       ctx.header('Content-Disposition', `attachment; filename="${filename}"`);
 
-      // Generate CSV header
-      if (records.length > 0) {
-        const firstRecord = records[0];
-        const fields = Object.keys(firstRecord).filter(
-          (key) => !csvOptions.excludeFields?.includes(key)
-        );
+      if (records.length === 0) return;
 
-        // Write header row
-        const headerRow = fields.map((field) => this.escapeCsvField(String(field))).join(',') + '\n';
-        await streamWriter.write(headerRow);
+      const fields = Object.keys(records[0]).filter((key) => !excludedFields.includes(key));
+      const headerRow = fields.map((field) => escapeCsvValue(field, csvOptions)).join(',') + '\n';
+      await streamWriter.write(headerRow);
 
-        // Write data rows in batches for memory efficiency
-        const batchSize = 100;
-        for (let i = 0; i < records.length; i += batchSize) {
-          const batch = records.slice(i, i + batchSize);
-          for (const record of batch) {
-            const row = fields.map((field) => {
-              const value = record[field];
-              return this.escapeCsvField(this.formatCsvValue(value));
-            }).join(',') + '\n';
-            await streamWriter.write(row);
-          }
+      const batchSize = 100;
+      for (let i = 0; i < records.length; i += batchSize) {
+        for (const record of records.slice(i, i + batchSize)) {
+          const row = fields.map((field) => escapeCsvValue(record[field], csvOptions)).join(',') + '\n';
+          await streamWriter.write(row);
         }
       }
     });
-  }
-
-  /**
-   * Escapes a CSV field value for safe output.
-   */
-  private escapeCsvField(value: string): string {
-    // Sanitize CSV formula injection (OWASP recommendation)
-    const firstChar = value.charAt(0);
-    if (firstChar === '=' || firstChar === '+' || firstChar === '-' || firstChar === '@' || firstChar === '\t' || firstChar === '\r') {
-      return `"\t${value.replace(/"/g, '""')}"`;
-    }
-    if (value.includes(',') || value.includes('"') || value.includes('\n') || value.includes('\r')) {
-      return `"${value.replace(/"/g, '""')}"`;
-    }
-    return value;
-  }
-
-  /**
-   * Formats a value for CSV output.
-   */
-  private formatCsvValue(value: unknown): string {
-    if (value === null || value === undefined) {
-      return '';
-    }
-    if (value instanceof Date) {
-      return value.toISOString();
-    }
-    if (typeof value === 'object') {
-      return JSON.stringify(value);
-    }
-    return String(value);
   }
 
   /**
@@ -332,11 +275,11 @@ export abstract class ExportEndpoint<
     const pageSize = this.streamPageSize;
     const maxRecords = Math.min(this.maxExportRecords, 100_000);
     const excludedFields = this.excludedExportFields;
-    const endpoint = this;
+    const csvOptions = this.csvOptions;
     let headerFields: string[] | null = null;
 
     const readable = new ReadableStream({
-      async start(controller) {
+      start: async (controller) => {
         const encoder = new TextEncoder();
         let page = 1;
         let exported = 0;
@@ -348,7 +291,7 @@ export abstract class ExportEndpoint<
               options: { ...filters.options, page, per_page: pageSize },
             };
 
-            const result = await endpoint.list(pageFilters);
+            const result = await this.list(pageFilters);
             let records = result.result;
 
             if (records.length === 0) break;
@@ -356,27 +299,19 @@ export abstract class ExportEndpoint<
               records = records.slice(0, maxRecords - exported);
             }
 
-            // Apply hooks
-            records = await endpoint.after(records);
-            records = await endpoint.beforeExport(records);
-            const prepared = endpoint.prepareRecordsForExport(records);
+            records = await this.after(records);
+            records = await this.beforeExport(records);
+            const prepared = this.prepareRecordsForExport(records);
 
-            // Write header from first batch
             if (!headerFields && prepared.length > 0) {
-              headerFields = Object.keys(prepared[0]).filter(
-                (k) => !excludedFields.includes(k)
-              );
-              const headerRow = headerFields.map((field) => endpoint.escapeCsvField(field)).join(',') + '\n';
+              headerFields = Object.keys(prepared[0]).filter((k) => !excludedFields.includes(k));
+              const headerRow = headerFields.map((field) => escapeCsvValue(field, csvOptions)).join(',') + '\n';
               controller.enqueue(encoder.encode(headerRow));
             }
 
-            // Write rows
             if (headerFields) {
               for (const record of prepared) {
-                const row = headerFields.map((field) => {
-                  const value = record[field];
-                  return endpoint.formatAndEscapeCsvField(value);
-                }).join(',') + '\n';
+                const row = headerFields.map((field) => escapeCsvValue(record[field], csvOptions)).join(',') + '\n';
                 controller.enqueue(encoder.encode(row));
               }
             }
@@ -384,7 +319,6 @@ export abstract class ExportEndpoint<
             exported += records.length;
             page++;
 
-            // Stop if we got fewer records than the page size (last page)
             if (records.length < pageSize) break;
           }
         } catch (err) {
@@ -401,36 +335,6 @@ export abstract class ExportEndpoint<
       headers: {
         'Content-Type': 'text/csv; charset=utf-8',
         'Content-Disposition': `attachment; filename="${filename}"`,
-      },
-    });
-  }
-
-  /**
-   * Formats and escapes a single value for CSV output.
-   */
-  private formatAndEscapeCsvField(value: unknown): string {
-    const formatted = this.formatCsvValue(value);
-    return this.escapeCsvField(formatted);
-  }
-
-  /**
-   * Legacy streaming method using Web ReadableStream.
-   * Kept for backwards compatibility.
-   */
-  protected exportAsCsvStreamLegacy(
-    records: Record<string, unknown>[],
-    format: ExportFormat
-  ): Response {
-    const csvStream = createCsvStream(records, {
-      ...this.csvOptions,
-      excludeFields: this.excludedExportFields,
-    });
-
-    return new Response(csvStream, {
-      status: 200,
-      headers: {
-        'Content-Type': 'text/csv; charset=utf-8',
-        'Content-Disposition': `attachment; filename="${this.getExportFilename(format)}"`,
       },
     });
   }

--- a/src/endpoints/export.ts
+++ b/src/endpoints/export.ts
@@ -89,6 +89,9 @@ export abstract class ExportEndpoint<
   /** Whether to enable streaming for large exports. */
   protected enableStreaming: boolean = true;
 
+  /** Page size for paginated streaming export. @default 500 */
+  protected streamPageSize: number = 500;
+
   /** Fields to exclude from the export. */
   protected excludedExportFields: string[] = [];
 
@@ -317,6 +320,100 @@ export abstract class ExportEndpoint<
   }
 
   /**
+   * Paginated streaming export using ReadableStream.
+   * Fetches records page-by-page and encodes each chunk as CSV rows,
+   * avoiding loading all records into memory at once.
+   */
+  protected exportAsCsvStreamPaginated(
+    filters: ListFilters,
+    format: ExportFormat
+  ): Response {
+    const filename = this.getExportFilename(format);
+    const pageSize = this.streamPageSize;
+    const maxRecords = Math.min(this.maxExportRecords, 100_000);
+    const excludedFields = this.excludedExportFields;
+    const endpoint = this;
+    let headerFields: string[] | null = null;
+
+    const readable = new ReadableStream({
+      async start(controller) {
+        const encoder = new TextEncoder();
+        let page = 1;
+        let exported = 0;
+
+        try {
+          while (exported < maxRecords) {
+            const pageFilters: ListFilters = {
+              ...filters,
+              options: { ...filters.options, page, per_page: pageSize },
+            };
+
+            const result = await endpoint.list(pageFilters);
+            let records = result.result;
+
+            if (records.length === 0) break;
+            if (records.length > maxRecords - exported) {
+              records = records.slice(0, maxRecords - exported);
+            }
+
+            // Apply hooks
+            records = await endpoint.after(records);
+            records = await endpoint.beforeExport(records);
+            const prepared = endpoint.prepareRecordsForExport(records);
+
+            // Write header from first batch
+            if (!headerFields && prepared.length > 0) {
+              headerFields = Object.keys(prepared[0]).filter(
+                (k) => !excludedFields.includes(k)
+              );
+              const headerRow = headerFields.map((field) => endpoint.escapeCsvField(field)).join(',') + '\n';
+              controller.enqueue(encoder.encode(headerRow));
+            }
+
+            // Write rows
+            if (headerFields) {
+              for (const record of prepared) {
+                const row = headerFields.map((field) => {
+                  const value = record[field];
+                  return endpoint.formatAndEscapeCsvField(value);
+                }).join(',') + '\n';
+                controller.enqueue(encoder.encode(row));
+              }
+            }
+
+            exported += records.length;
+            page++;
+
+            // Stop if we got fewer records than the page size (last page)
+            if (records.length < pageSize) break;
+          }
+        } catch (err) {
+          controller.error(err);
+          return;
+        }
+
+        controller.close();
+      },
+    });
+
+    return new Response(readable, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/csv; charset=utf-8',
+        'Content-Disposition': `attachment; filename="${filename}"`,
+      },
+    });
+  }
+
+  /**
+   * Formats and escapes a single value for CSV output.
+   */
+  private formatAndEscapeCsvField(value: unknown): string {
+    const formatted = this.formatCsvValue(value);
+    return this.escapeCsvField(formatted);
+  }
+
+  /**
    * Legacy streaming method using Web ReadableStream.
    * Kept for backwards compatibility.
    */
@@ -334,7 +431,6 @@ export abstract class ExportEndpoint<
       headers: {
         'Content-Type': 'text/csv; charset=utf-8',
         'Content-Disposition': `attachment; filename="${this.getExportFilename(format)}"`,
-        'Transfer-Encoding': 'chunked',
       },
     });
   }
@@ -379,6 +475,11 @@ export abstract class ExportEndpoint<
     const exportOptions = await this.getExportOptions();
     const filters = await this.getFilters();
 
+    // Use paginated streaming for CSV when streaming is requested
+    if (exportOptions.format === 'csv' && exportOptions.stream) {
+      return this.exportAsCsvStreamPaginated(filters, exportOptions.format);
+    }
+
     // Fetch all records for export
     let records = await this.fetchAllForExport(filters);
 
@@ -393,9 +494,6 @@ export abstract class ExportEndpoint<
 
     // Export based on format
     if (exportOptions.format === 'csv') {
-      if (exportOptions.stream && preparedRecords.length > 1000) {
-        return this.exportAsCsvStream(preparedRecords, exportOptions.format);
-      }
       return this.exportAsCsv(preparedRecords, exportOptions.format);
     }
 

--- a/src/endpoints/import.ts
+++ b/src/endpoints/import.ts
@@ -6,7 +6,7 @@ import { getAuditConfig, getSoftDeleteConfig, type NormalizedSoftDeleteConfig } 
 import type { ModelObject } from './types';
 import { createAuditLogger, type AuditLogger } from '../core/audit';
 import { parseCsv, validateCsvHeaders, type CsvParseOptions } from '../utils/csv';
-import { InputValidationException } from '../core/exceptions';
+import { ConfigurationException, InputValidationException } from '../core/exceptions';
 
 // ============================================================================
 // Import Types
@@ -120,6 +120,9 @@ export abstract class ImportEndpoint<
 
   /** Maximum number of records per import request. */
   protected maxBatchSize: number = 1000;
+
+  /** Number of rows to process concurrently in each batch. @default 100 */
+  protected importBatchSize: number = 100;
 
   /** Whether to stop on first error. */
   protected stopOnError: boolean = false;
@@ -257,7 +260,7 @@ export abstract class ImportEndpoint<
                   results: z.array(z.object({
                     rowNumber: z.number(),
                     status: z.enum(['created', 'updated', 'skipped', 'failed']),
-                    data: z.any().optional(),
+                    data: z.unknown().optional(),
                     error: z.string().optional(),
                     validationErrors: z.array(z.object({
                       path: z.string(),
@@ -286,7 +289,7 @@ export abstract class ImportEndpoint<
                   results: z.array(z.object({
                     rowNumber: z.number(),
                     status: z.enum(['created', 'updated', 'skipped', 'failed']),
-                    data: z.any().optional(),
+                    data: z.unknown().optional(),
                     error: z.string().optional(),
                     validationErrors: z.array(z.object({
                       path: z.string(),
@@ -307,7 +310,7 @@ export abstract class ImportEndpoint<
                 error: z.object({
                   code: z.string(),
                   message: z.string(),
-                  details: z.any().optional(),
+                  details: z.unknown().optional(),
                 }),
               }),
             },
@@ -322,10 +325,21 @@ export abstract class ImportEndpoint<
    */
   protected async getImportOptions(): Promise<ImportOptions> {
     const { query } = await this.getValidatedData();
+    const skipInvalidRows = query?.skipInvalid === 'true'
+      ? true
+      : query?.skipInvalid === 'false'
+        ? false
+        : this.skipInvalidRows;
+    const stopOnError = query?.stopOnError === 'true'
+      ? true
+      : query?.stopOnError === 'false'
+        ? false
+        : this.stopOnError;
+
     return {
       mode: (query?.mode as ImportMode) || this.defaultMode,
-      skipInvalidRows: query?.skipInvalid === 'true' ? true : this.skipInvalidRows,
-      stopOnError: query?.stopOnError === 'true' ? true : this.stopOnError,
+      skipInvalidRows,
+      stopOnError,
     };
   }
 
@@ -666,6 +680,9 @@ export abstract class ImportEndpoint<
 
     const options = await this.getImportOptions();
     const items = await this.parseImportData();
+    if (!Number.isInteger(this.importBatchSize) || this.importBatchSize < 1) {
+      throw new ConfigurationException('importBatchSize must be a positive integer');
+    }
 
     const summary: ImportSummary = {
       total: items.length,
@@ -676,38 +693,45 @@ export abstract class ImportEndpoint<
     };
 
     const results: ImportRowResult<ModelObject<M['model']>>[] = [];
+    let stopped = false;
+    const effectiveBatchSize = options.stopOnError ? 1 : this.importBatchSize;
 
-    // Process each row
-    for (let i = 0; i < items.length; i++) {
-      const rowNumber = i + 1;
-      const data = items[i];
+    // Process rows in batches for memory efficiency
+    for (let i = 0; i < items.length && !stopped; i += effectiveBatchSize) {
+      const batch = items.slice(i, i + effectiveBatchSize);
+      const batchResults = await Promise.all(
+        batch.map(async (data, idx) => {
+          const rowNumber = i + idx + 1;
+          let result = await this.processRow(data, rowNumber, options);
+          result = await this.after(result, rowNumber, options.mode);
+          return result;
+        })
+      );
 
-      let result = await this.processRow(data, rowNumber, options);
+      for (const result of batchResults) {
+        results.push(result);
 
-      // Apply after hook
-      result = await this.after(result, rowNumber, options.mode);
+        // Update summary
+        switch (result.status) {
+          case 'created':
+            summary.created++;
+            break;
+          case 'updated':
+            summary.updated++;
+            break;
+          case 'skipped':
+            summary.skipped++;
+            break;
+          case 'failed':
+            summary.failed++;
+            break;
+        }
 
-      results.push(result);
-
-      // Update summary
-      switch (result.status) {
-        case 'created':
-          summary.created++;
+        // Stop on error if configured
+        if (options.stopOnError && result.status === 'failed') {
+          stopped = true;
           break;
-        case 'updated':
-          summary.updated++;
-          break;
-        case 'skipped':
-          summary.skipped++;
-          break;
-        case 'failed':
-          summary.failed++;
-          break;
-      }
-
-      // Stop on error if configured
-      if (options.stopOnError && result.status === 'failed') {
-        break;
+        }
       }
     }
 

--- a/src/endpoints/subscribe.ts
+++ b/src/endpoints/subscribe.ts
@@ -3,7 +3,10 @@ import { streamSSE } from 'hono/streaming';
 import type { CrudEventPayload, CrudEventType, EventSubscription } from '../events/types';
 import { resolveEventEmitter, type CrudEventEmitter } from '../events/emitter';
 
-// Module-level connection tracking per table
+// Per-isolate SSE connection counter. Not a strict global limit:
+// in Cloudflare Workers each isolate keeps its own counter, so the cap
+// applies per isolate, not per deployment. For strict caps use a Durable
+// Object or KV-backed tracker.
 const connectionCounts = new Map<string, number>();
 
 /** Default sensitive fields to strip from SSE event payloads. */

--- a/src/endpoints/subscribe.ts
+++ b/src/endpoints/subscribe.ts
@@ -1,7 +1,7 @@
 import type { Context, Env } from 'hono';
 import { streamSSE } from 'hono/streaming';
 import type { CrudEventPayload, CrudEventType, EventSubscription } from '../events/types';
-import { getEventEmitter, type CrudEventEmitter } from '../events/emitter';
+import { resolveEventEmitter, type CrudEventEmitter } from '../events/emitter';
 
 // Module-level connection tracking per table
 const connectionCounts = new Map<string, number>();
@@ -17,7 +17,7 @@ export interface SubscribeEndpointConfig {
   table: string;
   /** Specific event types to subscribe to. If empty, subscribes to all. */
   events?: CrudEventType[];
-  /** Custom event emitter. Uses global emitter if not provided. */
+  /** Custom event emitter. Falls back to ctx.var.eventEmitter or a configured compatibility global emitter. */
   emitter?: CrudEventEmitter;
   /** Filter function to control which events are sent to a specific client */
   filter?: (event: CrudEventPayload, ctx: Context) => boolean;
@@ -63,16 +63,19 @@ function stripSensitiveFields(
  * @example
  * ```ts
  * import { Hono } from 'hono';
- * import { createSubscribeHandler } from 'hono-crud';
+ * import { createSubscribeHandler, CrudEventEmitter } from 'hono-crud';
  *
  * const app = new Hono();
  *
+ * const events = new CrudEventEmitter();
+ *
  * // Subscribe to all user events
- * app.get('/users/subscribe', createSubscribeHandler({ table: 'users' }));
+ * app.get('/users/subscribe', createSubscribeHandler({ table: 'users', emitter: events }));
  *
  * // Subscribe to specific events with filtering
  * app.get('/users/subscribe', createSubscribeHandler({
  *   table: 'users',
+ *   emitter: events,
  *   events: ['created', 'updated'],
  *   filter: (event, ctx) => {
  *     // Only send events for the authenticated user's records
@@ -95,6 +98,14 @@ export function createSubscribeHandler(config: SubscribeEndpointConfig) {
   } = config;
 
   return (ctx: Context<Env>) => {
+    const emitter = resolveEventEmitter(ctx, customEmitter);
+    if (!emitter) {
+      return ctx.json(
+        { success: false, error: { code: 'EVENT_EMITTER_NOT_CONFIGURED', message: 'Event emitter not configured' } },
+        500
+      );
+    }
+
     // Check connection limit
     const currentCount = connectionCounts.get(table) || 0;
     if (currentCount >= maxConnections) {
@@ -108,7 +119,6 @@ export function createSubscribeHandler(config: SubscribeEndpointConfig) {
     connectionCounts.set(table, currentCount + 1);
 
     return streamSSE(ctx, async (stream) => {
-      const emitter = customEmitter ?? getEventEmitter();
       let subscription: EventSubscription;
 
       // Subscribe to events

--- a/src/events/emitter.ts
+++ b/src/events/emitter.ts
@@ -1,5 +1,7 @@
 import type { CrudEventType, CrudEventPayload, CrudEventListener, EventSubscription } from './types';
 import { getLogger } from '../core/logger';
+import type { Context, Env } from 'hono';
+import { getContextVar } from '../core/context-helpers';
 
 /**
  * Lightweight event emitter for CRUD operations.
@@ -198,6 +200,8 @@ let globalEmitter: CrudEventEmitter | null = null;
 
 /**
  * Get or create the global event emitter.
+ * Compatibility API. Prefer passing an emitter explicitly or injecting one with
+ * createCrudMiddleware() in edge runtimes.
  */
 export function getEventEmitter(): CrudEventEmitter {
   if (!globalEmitter) {
@@ -211,4 +215,23 @@ export function getEventEmitter(): CrudEventEmitter {
  */
 export function setEventEmitter(emitter: CrudEventEmitter): void {
   globalEmitter = emitter;
+}
+
+/**
+ * Resolve an event emitter without creating a global instance.
+ */
+export function resolveEventEmitter<E extends Env>(
+  ctx?: Context<E>,
+  explicit?: CrudEventEmitter
+): CrudEventEmitter | null {
+  if (explicit) {
+    return explicit;
+  }
+  if (ctx) {
+    const contextEmitter = getContextVar<CrudEventEmitter>(ctx, 'eventEmitter');
+    if (contextEmitter) {
+      return contextEmitter;
+    }
+  }
+  return globalEmitter;
 }

--- a/src/events/emitter.ts
+++ b/src/events/emitter.ts
@@ -200,8 +200,11 @@ let globalEmitter: CrudEventEmitter | null = null;
 
 /**
  * Get or create the global event emitter.
- * Compatibility API. Prefer passing an emitter explicitly or injecting one with
- * createCrudMiddleware() in edge runtimes.
+ *
+ * Compatibility API only. In edge runtimes (Cloudflare Workers, Deno, Bun)
+ * the global emitter is per-isolate state — listeners are not shared across
+ * isolates and may surprise multi-tenant code. Prefer passing an emitter
+ * explicitly or injecting one via `createCrudMiddleware`.
  */
 export function getEventEmitter(): CrudEventEmitter {
   if (!globalEmitter) {

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -1,4 +1,4 @@
-export { CrudEventEmitter, getEventEmitter, setEventEmitter } from './emitter';
+export { CrudEventEmitter, getEventEmitter, setEventEmitter, resolveEventEmitter } from './emitter';
 export { registerWebhooks } from './webhook';
 export type { CrudEventType, CrudEventPayload, CrudEventListener, EventSubscription } from './types';
 export type { WebhookEndpoint, WebhookConfig, WebhookDeliveryResult } from './webhook';

--- a/src/events/webhook.ts
+++ b/src/events/webhook.ts
@@ -1,5 +1,5 @@
 import type { CrudEventPayload, CrudEventListener } from './types';
-import { getEventEmitter, type CrudEventEmitter } from './emitter';
+import { resolveEventEmitter, type CrudEventEmitter } from './emitter';
 
 /**
  * Webhook endpoint configuration.
@@ -25,10 +25,23 @@ export interface WebhookEndpoint {
 export interface WebhookConfig {
   /** Webhook endpoints to deliver events to */
   endpoints: WebhookEndpoint[];
-  /** Event emitter to subscribe to. Uses global emitter if not provided. */
+  /** Event emitter to subscribe to. Falls back only to a configured compatibility global emitter. */
   emitter?: CrudEventEmitter;
   /** Callback for delivery failures */
   onError?: (endpoint: WebhookEndpoint, event: CrudEventPayload, error: Error) => void;
+  /**
+   * Wrap delivery promises with waitUntil for edge runtimes.
+   * Without this, delivery may be aborted when the response is sent.
+   *
+   * @example
+   * ```ts
+   * registerWebhooks({
+   *   endpoints: [...],
+   *   waitUntil: c.executionCtx.waitUntil.bind(c.executionCtx),
+   * });
+   * ```
+   */
+  waitUntil?: (promise: Promise<unknown>) => void;
 }
 
 /**
@@ -146,7 +159,9 @@ async function deliverToEndpoint(
  * ```ts
  * import { registerWebhooks, getEventEmitter } from 'hono-crud';
  *
+ * const emitter = getEventEmitter(); // Compatibility global, or pass your own emitter.
  * const unsubscribe = registerWebhooks({
+ *   emitter,
  *   endpoints: [
  *     {
  *       url: 'https://hooks.example.com/crud',
@@ -164,14 +179,17 @@ async function deliverToEndpoint(
  * ```
  */
 export function registerWebhooks(config: WebhookConfig): () => void {
-  const emitter = config.emitter ?? getEventEmitter();
+  const emitter = resolveEventEmitter(undefined, config.emitter);
+  if (!emitter) {
+    throw new Error('Event emitter not configured. Pass emitter explicitly or call setEventEmitter() first.');
+  }
 
   const listener: CrudEventListener = (event) => {
     for (const endpoint of config.endpoints) {
       if (!matchesFilter(event, endpoint.events)) continue;
 
       // Fire and forget delivery
-      deliverToEndpoint(endpoint, event).then((result) => {
+      const deliveryPromise = deliverToEndpoint(endpoint, event).then((result) => {
         if (!result.success && config.onError) {
           config.onError(
             endpoint,
@@ -188,6 +206,11 @@ export function registerWebhooks(config: WebhookConfig): () => void {
           );
         }
       });
+
+      // Keep delivery alive past response in edge runtimes
+      if (config.waitUntil) {
+        config.waitUntil(deliveryPromise);
+      }
     }
   };
 

--- a/src/idempotency/middleware.ts
+++ b/src/idempotency/middleware.ts
@@ -1,7 +1,6 @@
 import type { MiddlewareHandler } from 'hono';
 import type { IdempotencyConfig, IdempotencyEntry, IdempotencyStorage } from './types';
-import { MemoryIdempotencyStorage } from './storage/memory';
-import { createRegistryWithDefault } from '../storage/registry';
+import { createNullableRegistry } from '../storage/registry';
 import { getContextVar } from '../core/context-helpers';
 
 // ============================================================================
@@ -10,11 +9,11 @@ import { getContextVar } from '../core/context-helpers';
 
 /**
  * Global idempotency storage registry.
- * Uses lazy initialization with MemoryIdempotencyStorage as default.
+ * Compatibility global registry. Prefer passing storage explicitly or injecting
+ * it with createCrudMiddleware() in edge runtimes.
  */
-export const idempotencyStorageRegistry = createRegistryWithDefault<IdempotencyStorage>(
-  'idempotencyStorage',
-  () => new MemoryIdempotencyStorage()
+export const idempotencyStorageRegistry = createNullableRegistry<IdempotencyStorage>(
+  'idempotencyStorage'
 );
 
 /**
@@ -54,7 +53,7 @@ export function getIdempotencyStorage(): IdempotencyStorage {
  * import { idempotency } from 'hono-crud';
  *
  * const app = new Hono();
- * app.use('/api/*', idempotency());
+ * app.use('/api/*', idempotency({ storage: new MemoryIdempotencyStorage() }));
  *
  * // Or with configuration:
  * app.use('/api/*', idempotency({

--- a/src/index.ts
+++ b/src/index.ts
@@ -369,6 +369,7 @@ export {
   // Storage implementations
   MemoryCacheStorage,
   RedisCacheStorage,
+  KVCacheStorage,
   // Key generation utilities
   generateCacheKey,
   createInvalidationPattern,
@@ -388,6 +389,7 @@ export type {
   InvalidationPatternOptions,
   RedisClient,
   RedisCacheStorageOptions,
+  KVCacheStorageOptions,
   CacheEndpointMethods,
   CacheInvalidationMethods,
 } from './cache/index';
@@ -411,6 +413,7 @@ export {
   // Storage implementations
   MemoryRateLimitStorage,
   RedisRateLimitStorage,
+  KVRateLimitStorage,
 } from './rate-limit/index';
 export type {
   FixedWindowEntry,
@@ -430,6 +433,7 @@ export type {
   MemoryRateLimitStorageOptions,
   RedisRateLimitClient,
   RedisRateLimitStorageOptions,
+  KVRateLimitStorageOptions,
 } from './rate-limit/index';
 
 // Logging exports
@@ -472,6 +476,10 @@ export type {
   MemoryLoggingStorageOptions,
 } from './logging/index';
 
+// Unified middleware
+export { createCrudMiddleware } from './middleware';
+export type { CrudMiddlewareConfig } from './middleware';
+
 // Storage exports (context-based storage management)
 export {
   // Middleware
@@ -489,6 +497,7 @@ export {
   resolveAuditStorage,
   resolveVersioningStorage,
   resolveAPIKeyStorage,
+  resolveIdempotencyStorage,
   // Registry
   StorageRegistry,
   createNullableRegistry,
@@ -504,6 +513,7 @@ export {
   CrudEventEmitter,
   getEventEmitter,
   setEventEmitter,
+  resolveEventEmitter,
   registerWebhooks,
 } from './events/index';
 export type {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,67 @@
+import type { Env, MiddlewareHandler } from 'hono';
+import type { CacheStorage } from './cache/types';
+import type { RateLimitStorage } from './rate-limit/types';
+import type { LoggingStorage } from './logging/types';
+import type { AuditLogStorage } from './core/audit';
+import type { VersioningStorage } from './core/versioning';
+import type { IdempotencyStorage } from './idempotency/types';
+import type { CrudEventEmitter } from './events/emitter';
+import type { StorageEnv } from './storage/types';
+
+/**
+ * Unified configuration for hono-crud middleware.
+ * Injects storage instances and event emitter into Hono context
+ * so endpoints resolve them automatically (context > global fallback).
+ *
+ * This is the recommended approach for edge runtimes where bindings
+ * (KV, D1, etc.) are only available inside request handlers.
+ *
+ * @example
+ * ```ts
+ * import { createCrudMiddleware, KVCacheStorage, KVRateLimitStorage } from 'hono-crud';
+ *
+ * app.use('*', async (c, next) => {
+ *   const cache = new KVCacheStorage({ kv: c.env.CACHE_KV });
+ *   const rateLimit = new KVRateLimitStorage({ kv: c.env.RATE_LIMIT_KV });
+ *   return createCrudMiddleware({ cache, rateLimit })(c, next);
+ * });
+ * ```
+ */
+export interface CrudMiddlewareConfig {
+  /** Cache storage instance. */
+  cache?: CacheStorage;
+  /** Rate limit storage instance. */
+  rateLimit?: RateLimitStorage;
+  /** Audit log storage instance. */
+  audit?: AuditLogStorage;
+  /** Versioning storage instance. */
+  versioning?: VersioningStorage;
+  /** Logging storage instance. */
+  logging?: LoggingStorage;
+  /** Idempotency storage instance. */
+  idempotency?: IdempotencyStorage;
+  /** Event emitter instance. */
+  events?: CrudEventEmitter;
+}
+
+/**
+ * Creates middleware that injects all hono-crud storage instances into context.
+ * Endpoints resolve storage with priority: explicit param > context > global.
+ *
+ * @param config - Storage and emitter instances to inject
+ * @returns Hono middleware handler
+ */
+export function createCrudMiddleware<E extends Env = Env>(
+  config: CrudMiddlewareConfig
+): MiddlewareHandler<E & StorageEnv> {
+  return async (c, next) => {
+    if (config.cache) c.set('cacheStorage', config.cache);
+    if (config.rateLimit) c.set('rateLimitStorage', config.rateLimit);
+    if (config.audit) c.set('auditStorage', config.audit);
+    if (config.versioning) c.set('versioningStorage', config.versioning);
+    if (config.logging) c.set('loggingStorage', config.logging);
+    if (config.idempotency) c.set('idempotencyStorage', config.idempotency);
+    if (config.events) c.set('eventEmitter', config.events);
+    await next();
+  };
+}

--- a/src/rate-limit/index.ts
+++ b/src/rate-limit/index.ts
@@ -43,3 +43,6 @@ export type { MemoryRateLimitStorageOptions } from './storage/memory';
 
 export { RedisRateLimitStorage } from './storage/redis';
 export type { RedisRateLimitClient, RedisRateLimitStorageOptions } from './storage/redis';
+
+export { KVRateLimitStorage } from './storage/cloudflare-kv';
+export type { KVRateLimitStorageOptions } from './storage/cloudflare-kv';

--- a/src/rate-limit/storage/cloudflare-kv.ts
+++ b/src/rate-limit/storage/cloudflare-kv.ts
@@ -1,0 +1,205 @@
+import type {
+  RateLimitStorage,
+  FixedWindowEntry,
+  SlidingWindowEntry,
+  RateLimitEntry,
+} from '../types';
+import type { KVNamespace } from '../../shared/kv-types';
+
+/**
+ * Options for Cloudflare KV rate limit storage.
+ */
+export interface KVRateLimitStorageOptions {
+  /** KV namespace binding. */
+  kv: KVNamespace;
+  /** Key prefix for all rate limit entries. @default 'rl:' */
+  prefix?: string;
+  /**
+   * Whether KV read/write failures should allow the request to continue.
+   * KV is best-effort for rate limits, so fail-open is the edge-safe default.
+   * @default true
+   */
+  failOpen?: boolean;
+  /** Called when a KV operation or stored payload fails. */
+  onError?: (
+    error: Error,
+    context: { operation: 'increment' | 'addTimestamp' | 'get' | 'reset'; key: string }
+  ) => void;
+}
+
+/**
+ * Cloudflare KV rate limit storage implementation.
+ *
+ * **Important caveats:**
+ * - KV is eventually consistent (~60s stale reads). Rate limiting is best-effort.
+ * - Read-modify-write is not atomic — concurrent requests may race.
+ * - KV allows only one write per second to the same key, so high-frequency
+ *   counters can fail open or undercount.
+ * - KV expirationTtl must be at least 60 seconds; shorter windows are enforced
+ *   by app-level timestamps while the KV entry remains alive for 60 seconds.
+ * - Fixed window algorithm is recommended over sliding window for KV.
+ * - For strict rate limiting, use Durable Objects or Upstash Redis instead.
+ *
+ * Best used with `createCrudMiddleware` since KV bindings are only
+ * available inside request handlers.
+ *
+ * @example
+ * ```ts
+ * import { KVRateLimitStorage, createCrudMiddleware } from 'hono-crud';
+ *
+ * app.use('*', async (c, next) => {
+ *   const rateLimit = new KVRateLimitStorage({ kv: c.env.RATE_LIMIT_KV });
+ *   return createCrudMiddleware({ rateLimit })(c, next);
+ * });
+ * ```
+ */
+export class KVRateLimitStorage implements RateLimitStorage {
+  private kv: KVNamespace;
+  private prefix: string;
+  private failOpen: boolean;
+  private onError?: KVRateLimitStorageOptions['onError'];
+
+  constructor(options: KVRateLimitStorageOptions) {
+    this.kv = options.kv;
+    this.prefix = options.prefix ?? 'rl:';
+    this.failOpen = options.failOpen ?? true;
+    this.onError = options.onError;
+  }
+
+  private getKey(key: string): string {
+    return `${this.prefix}${key}`;
+  }
+
+  private getExpirationTtl(windowMs: number): number {
+    return Math.max(60, Math.ceil(windowMs / 1000));
+  }
+
+  private reportError(
+    operation: 'increment' | 'addTimestamp' | 'get' | 'reset',
+    key: string,
+    error: unknown
+  ): Error {
+    const normalized = error instanceof Error ? error : new Error(String(error));
+    this.onError?.(normalized, { operation, key });
+    return normalized;
+  }
+
+  private parseJson(raw: string, operation: 'increment' | 'addTimestamp' | 'get', key: string): unknown | null {
+    try {
+      return JSON.parse(raw) as unknown;
+    } catch (err) {
+      this.reportError(operation, key, err);
+      return null;
+    }
+  }
+
+  private isFixedWindowEntry(value: unknown): value is FixedWindowEntry {
+    if (value === null || typeof value !== 'object') return false;
+    const record = value as Record<string, unknown>;
+    return typeof record.count === 'number' && typeof record.windowStart === 'number';
+  }
+
+  private isSlidingWindowEntry(value: unknown): value is SlidingWindowEntry {
+    if (value === null || typeof value !== 'object') return false;
+    const record = value as Record<string, unknown>;
+    return Array.isArray(record.timestamps) && record.timestamps.every((item) => typeof item === 'number');
+  }
+
+  async increment(key: string, windowMs: number): Promise<FixedWindowEntry> {
+    const fullKey = this.getKey(key);
+    const now = Date.now();
+    const ttl = this.getExpirationTtl(windowMs);
+    const fallback: FixedWindowEntry = { count: 1, windowStart: now };
+
+    try {
+      const raw = await this.kv.get(fullKey);
+      let entry: FixedWindowEntry;
+
+      if (raw) {
+        const parsed = this.parseJson(raw, 'increment', key);
+        if (this.isFixedWindowEntry(parsed) && now - parsed.windowStart < windowMs) {
+          entry = { count: parsed.count + 1, windowStart: parsed.windowStart };
+        } else {
+          entry = fallback;
+        }
+      } else {
+        entry = fallback;
+      }
+
+      await this.kv.put(fullKey, JSON.stringify(entry), { expirationTtl: ttl });
+
+      return entry;
+    } catch (err) {
+      const error = this.reportError('increment', key, err);
+      if (!this.failOpen) throw error;
+      return fallback;
+    }
+  }
+
+  async addTimestamp(key: string, windowMs: number, now?: number): Promise<SlidingWindowEntry> {
+    const fullKey = this.getKey(key);
+    const currentTime = now ?? Date.now();
+    const windowStart = currentTime - windowMs;
+    const ttl = this.getExpirationTtl(windowMs);
+    const fallback: SlidingWindowEntry = { timestamps: [currentTime] };
+
+    try {
+      const raw = await this.kv.get(fullKey);
+      let timestamps: number[];
+
+      if (raw) {
+        const parsed = this.parseJson(raw, 'addTimestamp', key);
+        timestamps = this.isSlidingWindowEntry(parsed)
+          ? parsed.timestamps.filter((t) => t > windowStart)
+          : [];
+        timestamps.push(currentTime);
+      } else {
+        timestamps = [currentTime];
+      }
+
+      const entry: SlidingWindowEntry = { timestamps };
+      await this.kv.put(fullKey, JSON.stringify(entry), { expirationTtl: ttl });
+
+      return entry;
+    } catch (err) {
+      const error = this.reportError('addTimestamp', key, err);
+      if (!this.failOpen) throw error;
+      return fallback;
+    }
+  }
+
+  async get(key: string): Promise<RateLimitEntry | null> {
+    try {
+      const raw = await this.kv.get(this.getKey(key));
+      if (!raw) return null;
+
+      const parsed = this.parseJson(raw, 'get', key);
+      if (this.isFixedWindowEntry(parsed) || this.isSlidingWindowEntry(parsed)) {
+        return parsed;
+      }
+      return null;
+    } catch (err) {
+      const error = this.reportError('get', key, err);
+      if (!this.failOpen) throw error;
+      return null;
+    }
+  }
+
+  async reset(key: string): Promise<void> {
+    try {
+      await this.kv.delete(this.getKey(key));
+    } catch (err) {
+      const error = this.reportError('reset', key, err);
+      if (!this.failOpen) throw error;
+    }
+  }
+
+  async cleanup(): Promise<number> {
+    // KV handles TTL automatically
+    return 0;
+  }
+
+  destroy(): void {
+    // No cleanup needed — KV lifecycle is managed by the runtime
+  }
+}

--- a/src/rate-limit/storage/redis.ts
+++ b/src/rate-limit/storage/redis.ts
@@ -98,8 +98,8 @@ return cjson.encode({timestamps = timestamps})
  *
  * const storage = new RedisRateLimitStorage({
  *   client: new Redis({
- *     url: process.env.REDIS_URL,
- *     token: process.env.REDIS_TOKEN,
+ *     url: c.env.REDIS_URL,
+ *     token: c.env.REDIS_TOKEN,
  *   }),
  * });
  * setRateLimitStorage(storage);
@@ -111,7 +111,7 @@ return cjson.encode({timestamps = timestamps})
  * import { RedisRateLimitStorage, setRateLimitStorage } from 'hono-crud';
  *
  * const storage = new RedisRateLimitStorage({
- *   client: new Redis(process.env.REDIS_URL),
+ *   client: new Redis(c.env.REDIS_URL),
  * });
  * setRateLimitStorage(storage);
  * ```

--- a/src/shared/kv-types.ts
+++ b/src/shared/kv-types.ts
@@ -1,0 +1,19 @@
+/**
+ * Minimal Cloudflare KV Namespace interface.
+ * Defined locally to avoid depending on @cloudflare/workers-types.
+ */
+export interface KVNamespace {
+  get(key: string, options?: { type?: 'text' }): Promise<string | null>;
+  get(key: string, options: { type: 'json' }): Promise<unknown>;
+  put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>;
+  delete(key: string): Promise<void>;
+  list(options?: {
+    prefix?: string;
+    limit?: number;
+    cursor?: string;
+  }): Promise<{
+    keys: Array<{ name: string; expiration?: number }>;
+    list_complete: boolean;
+    cursor?: string;
+  }>;
+}

--- a/src/storage/helpers.ts
+++ b/src/storage/helpers.ts
@@ -5,6 +5,7 @@ import type { CacheStorage } from '../cache/types';
 import type { AuditLogStorage } from '../core/audit';
 import type { VersioningStorage } from '../core/versioning';
 import type { MemoryAPIKeyStorage } from '../auth/storage/memory';
+import type { IdempotencyStorage } from '../idempotency/types';
 import type { StorageEnv } from './types';
 import { rateLimitStorageRegistry } from '../rate-limit/middleware';
 import { loggingStorageRegistry } from '../logging/middleware';
@@ -12,6 +13,7 @@ import { cacheStorageRegistry } from '../cache/mixin';
 import { auditStorageRegistry } from '../core/audit';
 import { versioningStorageRegistry } from '../core/versioning';
 import { apiKeyStorageRegistry } from '../auth/storage/memory';
+import { idempotencyStorageRegistry } from '../idempotency/middleware';
 
 // Re-export getters for backward compatibility (used by other modules)
 export { getRateLimitStorage } from '../rate-limit/middleware';
@@ -20,6 +22,7 @@ export { getCacheStorage } from '../cache/mixin';
 export { getAuditStorage } from '../core/audit';
 export { getVersioningStorage } from '../core/versioning';
 export { getAPIKeyStorage } from '../auth/storage/memory';
+export { getIdempotencyStorage } from '../idempotency/middleware';
 
 // ============================================================================
 // Type-Safe Context Variable Access
@@ -110,13 +113,13 @@ export function resolveLoggingStorage<E extends Env>(
  *
  * @param ctx - Optional Hono context
  * @param explicitStorage - Optional explicit storage instance
- * @returns The resolved storage (defaults to global MemoryCacheStorage)
+ * @returns The resolved storage, or null when no storage was configured
  */
 export function resolveCacheStorage<E extends Env>(
   ctx?: Context<E>,
   explicitStorage?: CacheStorage
-): CacheStorage {
-  return cacheStorageRegistry.resolve(ctx, explicitStorage) ?? cacheStorageRegistry.getRequired();
+): CacheStorage | null {
+  return cacheStorageRegistry.resolve(ctx, explicitStorage);
 }
 
 /**
@@ -124,13 +127,13 @@ export function resolveCacheStorage<E extends Env>(
  *
  * @param ctx - Optional Hono context
  * @param explicitStorage - Optional explicit storage instance
- * @returns The resolved storage (defaults to global MemoryAuditLogStorage)
+ * @returns The resolved storage, or null when no storage was configured
  */
 export function resolveAuditStorage<E extends Env>(
   ctx?: Context<E>,
   explicitStorage?: AuditLogStorage
-): AuditLogStorage {
-  return auditStorageRegistry.resolve(ctx, explicitStorage) ?? auditStorageRegistry.getRequired();
+): AuditLogStorage | null {
+  return auditStorageRegistry.resolve(ctx, explicitStorage);
 }
 
 /**
@@ -138,13 +141,13 @@ export function resolveAuditStorage<E extends Env>(
  *
  * @param ctx - Optional Hono context
  * @param explicitStorage - Optional explicit storage instance
- * @returns The resolved storage (defaults to global MemoryVersioningStorage)
+ * @returns The resolved storage, or null when no storage was configured
  */
 export function resolveVersioningStorage<E extends Env>(
   ctx?: Context<E>,
   explicitStorage?: VersioningStorage
-): VersioningStorage {
-  return versioningStorageRegistry.resolve(ctx, explicitStorage) ?? versioningStorageRegistry.getRequired();
+): VersioningStorage | null {
+  return versioningStorageRegistry.resolve(ctx, explicitStorage);
 }
 
 /**
@@ -152,11 +155,25 @@ export function resolveVersioningStorage<E extends Env>(
  *
  * @param ctx - Optional Hono context
  * @param explicitStorage - Optional explicit storage instance
- * @returns The resolved storage (defaults to global MemoryAPIKeyStorage)
+ * @returns The resolved storage, or null when no storage was configured
  */
 export function resolveAPIKeyStorage<E extends Env>(
   ctx?: Context<E>,
   explicitStorage?: MemoryAPIKeyStorage
-): MemoryAPIKeyStorage {
-  return apiKeyStorageRegistry.resolve(ctx, explicitStorage) ?? apiKeyStorageRegistry.getRequired();
+): MemoryAPIKeyStorage | null {
+  return apiKeyStorageRegistry.resolve(ctx, explicitStorage);
+}
+
+/**
+ * Resolves idempotency storage with priority: explicit param > context > global.
+ *
+ * @param ctx - Optional Hono context
+ * @param explicitStorage - Optional explicit storage instance
+ * @returns The resolved storage, or null when no storage was configured
+ */
+export function resolveIdempotencyStorage<E extends Env>(
+  ctx?: Context<E>,
+  explicitStorage?: IdempotencyStorage
+): IdempotencyStorage | null {
+  return idempotencyStorageRegistry.resolve(ctx, explicitStorage);
 }

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -20,6 +20,7 @@ export {
   resolveAuditStorage,
   resolveVersioningStorage,
   resolveAPIKeyStorage,
+  resolveIdempotencyStorage,
 } from './helpers';
 
 // Registry

--- a/src/storage/middleware.ts
+++ b/src/storage/middleware.ts
@@ -78,6 +78,14 @@ export function createStorageMiddleware<E extends Env = Env>(
       ctx.set('apiKeyStorage', config.apiKeyStorage);
     }
 
+    if (config.idempotencyStorage) {
+      ctx.set('idempotencyStorage', config.idempotencyStorage);
+    }
+
+    if (config.eventEmitter) {
+      ctx.set('eventEmitter', config.eventEmitter);
+    }
+
     await next();
   };
 }

--- a/src/storage/registry.ts
+++ b/src/storage/registry.ts
@@ -66,6 +66,10 @@ export class StorageRegistry<T> {
   /**
    * Gets the global storage instance.
    * Compatibility API: lazily creates a default if a factory was provided.
+   *
+   * In edge runtimes prefer `resolve(ctx, explicit)` instead — the global
+   * path holds per-isolate state which is not portable across deployments
+   * and may surprise multi-tenant code.
    */
   get(): T | null {
     this.ensureDefault();

--- a/src/storage/registry.ts
+++ b/src/storage/registry.ts
@@ -7,7 +7,9 @@ import { getContextVar } from '../core/context-helpers';
  *
  * Supports two modes:
  * 1. Nullable storage - returns null if not set (e.g., rate limit, logging)
- * 2. Storage with defaults - always returns a storage instance (e.g., cache, audit)
+ * 2. Compatibility defaults - get()/getRequired() lazily create a default
+ *    only for legacy global getter APIs. Request-time resolve() never creates
+ *    hidden mutable state.
  *
  * @example
  * ```ts
@@ -63,10 +65,18 @@ export class StorageRegistry<T> {
 
   /**
    * Gets the global storage instance.
-   * Returns null if not set and no default factory was provided.
+   * Compatibility API: lazily creates a default if a factory was provided.
    */
   get(): T | null {
     this.ensureDefault();
+    return this.globalStorage;
+  }
+
+  /**
+   * Gets only a storage instance that was explicitly configured.
+   * Does not create compatibility defaults.
+   */
+  getConfigured(): T | null {
     return this.globalStorage;
   }
 
@@ -116,8 +126,9 @@ export class StorageRegistry<T> {
       }
     }
 
-    // Priority 3: Global storage
-    this.ensureDefault();
+    // Priority 3: Explicitly configured global storage. Do not create a
+    // default here; edge runtimes should not get hidden in-memory state just
+    // because a request-time helper was called.
     return this.globalStorage;
   }
 
@@ -159,7 +170,6 @@ export class StorageRegistry<T> {
    * Checks if a storage instance is currently set.
    */
   isConfigured(): boolean {
-    this.ensureDefault();
     return this.globalStorage !== null;
   }
 }

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -5,6 +5,8 @@ import type { CacheStorage } from '../cache/types';
 import type { AuditLogStorage } from '../core/audit';
 import type { VersioningStorage } from '../core/versioning';
 import type { MemoryAPIKeyStorage } from '../auth/storage/memory';
+import type { IdempotencyStorage } from '../idempotency/types';
+import type { CrudEventEmitter } from '../events/emitter';
 
 /**
  * Extended Hono environment with storage context variables.
@@ -35,6 +37,8 @@ export interface StorageEnv extends Env {
     auditStorage?: AuditLogStorage;
     versioningStorage?: VersioningStorage;
     apiKeyStorage?: MemoryAPIKeyStorage;
+    idempotencyStorage?: IdempotencyStorage;
+    eventEmitter?: CrudEventEmitter;
   };
 }
 
@@ -86,4 +90,16 @@ export interface StorageMiddlewareConfig {
    * If provided, will be available as `ctx.var.apiKeyStorage`.
    */
   apiKeyStorage?: MemoryAPIKeyStorage;
+
+  /**
+   * Idempotency storage instance.
+   * If provided, will be available as `ctx.var.idempotencyStorage`.
+   */
+  idempotencyStorage?: IdempotencyStorage;
+
+  /**
+   * CRUD event emitter instance.
+   * If provided, will be available as `ctx.var.eventEmitter`.
+   */
+  eventEmitter?: CrudEventEmitter;
 }

--- a/src/types/cloudflare.ts
+++ b/src/types/cloudflare.ts
@@ -1,0 +1,85 @@
+/**
+ * Cloudflare Workers bindings helper types.
+ *
+ * Provides minimal type helpers for using hono-crud with Cloudflare Workers
+ * without requiring `@cloudflare/workers-types` as a dependency.
+ *
+ * @example
+ * ```ts
+ * import type { CloudflareEnv, WaitUntilFn } from 'hono-crud/cloudflare';
+ * import { getWaitUntil } from 'hono-crud/cloudflare';
+ * import { registerWebhooks } from 'hono-crud';
+ *
+ * type Env = CloudflareEnv<{
+ *   DB: D1Database;
+ *   CACHE_KV: KVNamespace;
+ * }>;
+ *
+ * app.use('*', async (c, next) => {
+ *   registerWebhooks({
+ *     endpoints: [...],
+ *     waitUntil: getWaitUntil(c),
+ *   });
+ *   await next();
+ * });
+ * ```
+ */
+
+import type { KVNamespace } from '../shared/kv-types';
+
+// Re-export KVNamespace for convenience
+export type { KVNamespace };
+
+/**
+ * Type for the `waitUntil` function available on Workers execution context.
+ * Extends the lifetime of the event past the response.
+ */
+export type WaitUntilFn = (promise: Promise<unknown>) => void;
+
+/**
+ * Hono environment type for Cloudflare Workers.
+ * Wraps your bindings in the `Bindings` key as Hono expects.
+ *
+ * @example
+ * ```ts
+ * type Env = CloudflareEnv<{
+ *   DB: D1Database;
+ *   CACHE_KV: KVNamespace;
+ *   RATE_LIMIT_KV: KVNamespace;
+ * }>;
+ *
+ * const app = new Hono<Env>();
+ * ```
+ */
+export type CloudflareEnv<
+  B extends Record<string, unknown> = Record<string, unknown>,
+> = {
+  Bindings: B;
+};
+
+/**
+ * Extracts the `waitUntil` function from a Hono context's execution context.
+ * Bind it to `executionCtx` so it can be passed as a standalone function.
+ *
+ * @param ctx - The Hono context (must have `executionCtx.waitUntil`)
+ * @returns Bound `waitUntil` function
+ *
+ * @example
+ * ```ts
+ * import { getWaitUntil } from 'hono-crud/cloudflare';
+ * import { registerWebhooks } from 'hono-crud';
+ *
+ * app.use('*', async (c, next) => {
+ *   registerWebhooks({
+ *     endpoints: [{ url: 'https://hooks.example.com', events: ['create'] }],
+ *     waitUntil: getWaitUntil(c),
+ *   });
+ *   await next();
+ * });
+ * ```
+ */
+export function getWaitUntil(ctx: {
+  executionCtx: { waitUntil: WaitUntilFn };
+}): WaitUntilFn {
+  return ctx.executionCtx.waitUntil.bind(ctx.executionCtx);
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -126,6 +126,14 @@ export type HonoOpenAPIApp<E extends Env = Env> = OpenAPIHono<E> & {
   ): HonoOpenAPIApp<E>;
 };
 
+type RouteRegistrar<E extends Env> = {
+  (path: string, handler: EndpointClass<E>): HonoOpenAPIApp<E>;
+  (
+    path: string,
+    ...handlers: [...MiddlewareHandler<E>[], EndpointClass<E>]
+  ): HonoOpenAPIApp<E>;
+};
+
 /**
  * Registers CRUD endpoints for a resource.
  *
@@ -187,10 +195,11 @@ export function registerCrud<E extends Env = Env>(
     endpoint: EndpointClass<E>
   ): void => {
     const mw = getMiddleware(name);
+    const register = typedApp[method] as RouteRegistrar<E>;
     if (mw.length > 0) {
-      (typedApp[method] as Function)(path, ...mw, endpoint);
+      register(path, ...mw, endpoint);
     } else {
-      (typedApp[method] as Function)(path, endpoint);
+      register(path, endpoint);
     }
   };
 

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono';
 import { z } from 'zod';
 import {
   MemoryCacheStorage,
+  RedisCacheStorage,
   generateCacheKey,
   createInvalidationPattern,
   createRelatedPatterns,
@@ -23,6 +24,7 @@ import {
 } from '../src/adapters/memory/index.js';
 import { fromHono, registerCrud } from '../src/index.js';
 import type { MetaInput, Model } from '../src/index.js';
+import type { RedisClient } from '../src/cache/index.js';
 
 // Define test schema
 const UserSchema = z.object({
@@ -61,6 +63,8 @@ describe('MemoryCacheStorage', () => {
 
       expect(entry).not.toBeNull();
       expect(entry!.data.name).toBe('test');
+      expect(entry!.createdAt).toBeTypeOf('number');
+      expect(entry!.expiresAt).toBeTypeOf('number');
     });
 
     it('should return null for non-existent key', async () => {
@@ -268,6 +272,51 @@ describe('MemoryCacheStorage', () => {
 
       vi.useRealTimers();
     });
+  });
+});
+
+class InMemoryRedisClient implements RedisClient {
+  private values = new Map<string, string>();
+
+  async get(key: string): Promise<string | null> {
+    return this.values.get(key) ?? null;
+  }
+
+  async set(key: string, value: string): Promise<unknown> {
+    this.values.set(key, value);
+    return 'OK';
+  }
+
+  async del(...keys: string[]): Promise<number> {
+    let deleted = 0;
+    for (const key of keys) {
+      if (this.values.delete(key)) deleted++;
+    }
+    return deleted;
+  }
+
+  async exists(...keys: string[]): Promise<number> {
+    return keys.filter((key) => this.values.has(key)).length;
+  }
+}
+
+describe('RedisCacheStorage', () => {
+  it('should migrate legacy Date-string cache entries to epoch milliseconds', async () => {
+    const client = new InMemoryRedisClient();
+    const cache = new RedisCacheStorage({ client, prefix: 'test:' });
+    const now = Date.now();
+
+    await client.set('test:legacy', JSON.stringify({
+      data: { name: 'legacy' },
+      createdAt: new Date(now - 1000).toISOString(),
+      expiresAt: new Date(now + 60_000).toISOString(),
+    }));
+
+    const entry = await cache.get<{ name: string }>('legacy');
+    expect(entry).not.toBeNull();
+    expect(entry!.data.name).toBe('legacy');
+    expect(entry!.createdAt).toBeTypeOf('number');
+    expect(entry!.expiresAt).toBeTypeOf('number');
   });
 });
 

--- a/tests/edge-safety.test.ts
+++ b/tests/edge-safety.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+const srcRoot = join(repoRoot, 'src');
+
+function listSourceFiles(): string[] {
+  const files: string[] = [];
+  const visit = (dir: string) => {
+    for (const entry of readdirSync(dir)) {
+      const fullPath = join(dir, entry);
+      const stat = statSync(fullPath);
+      if (stat.isDirectory()) {
+        visit(fullPath);
+      } else if (entry.endsWith('.ts')) {
+        files.push(fullPath);
+      }
+    }
+  };
+  visit(srcRoot);
+  return files;
+}
+
+function stripCommentsAndStrings(source: string): string {
+  let result = '';
+  let index = 0;
+  let state: 'code' | 'line-comment' | 'block-comment' | 'single' | 'double' | 'template' = 'code';
+
+  while (index < source.length) {
+    const char = source[index];
+    const next = source[index + 1];
+
+    if (state === 'code') {
+      if (char === '/' && next === '/') {
+        state = 'line-comment';
+        result += '  ';
+        index += 2;
+        continue;
+      }
+      if (char === '/' && next === '*') {
+        state = 'block-comment';
+        result += '  ';
+        index += 2;
+        continue;
+      }
+      if (char === "'") state = 'single';
+      if (char === '"') state = 'double';
+      if (char === '`') state = 'template';
+      result += state === 'code' ? char : ' ';
+      index++;
+      continue;
+    }
+
+    if (state === 'line-comment') {
+      result += char === '\n' ? '\n' : ' ';
+      if (char === '\n') state = 'code';
+      index++;
+      continue;
+    }
+
+    if (state === 'block-comment') {
+      result += char === '\n' ? '\n' : ' ';
+      if (char === '*' && next === '/') {
+        result += ' ';
+        index += 2;
+        state = 'code';
+      } else {
+        index++;
+      }
+      continue;
+    }
+
+    const quoteState = state;
+    result += char === '\n' ? '\n' : ' ';
+    if (char === '\\') {
+      result += next === '\n' ? '\n' : ' ';
+      index += 2;
+      continue;
+    }
+    if (
+      (quoteState === 'single' && char === "'") ||
+      (quoteState === 'double' && char === '"') ||
+      (quoteState === 'template' && char === '`')
+    ) {
+      state = 'code';
+    }
+    index++;
+  }
+
+  return result;
+}
+
+describe('edge safety static scan', () => {
+  it('does not import banned Node.js modules from shipped source', () => {
+    const bannedModules = [
+      'fs', 'path', 'os', 'child_process', 'net', 'http', 'https', 'dgram',
+      'cluster', 'worker_threads', 'vm', 'tls', 'dns', 'readline', 'crypto', 'module',
+    ];
+    const importPattern = new RegExp(
+      String.raw`(?:from\s+['"](?:node:)?(?:${bannedModules.join('|')})['"]|import\s*\(\s*['"](?:node:)?(?:${bannedModules.join('|')})['"]\s*\))`
+    );
+
+    const offenders = listSourceFiles().filter((file) => importPattern.test(readFileSync(file, 'utf8')));
+    expect(offenders).toEqual([]);
+  });
+
+  it('does not use banned runtime globals or broad type escapes in shipped source', () => {
+    const patterns: Array<[string, RegExp]> = [
+      ['Buffer', /\bBuffer\b/],
+      ['process', /\bprocess\b/],
+      ['require', /\brequire\s*\(/],
+      ['createRequire', /\bcreateRequire\b/],
+      ['setInterval', /\bsetInterval\s*\(/],
+      ['global mutable state', /\bglobalThis\b|\bglobal\b/],
+      ['eval', /(^|[^\w.])eval\s*\(/],
+      ['new Function', /\bnew\s+Function\b/],
+      ['z.any()', /\bz\.any\s*\(/],
+      ['as Function', /\bas\s+Function\b/],
+    ];
+
+    const offenders: string[] = [];
+    for (const file of listSourceFiles()) {
+      const source = stripCommentsAndStrings(readFileSync(file, 'utf8'));
+      for (const [label, pattern] of patterns) {
+        if (pattern.test(source)) {
+          offenders.push(`${file}: ${label}`);
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/tests/export-import.test.ts
+++ b/tests/export-import.test.ts
@@ -66,6 +66,36 @@ class UserImport extends MemoryImportEndpoint<any, UserMeta> {
   protected optionalImportFields = ['id', 'age', 'active']; // These are optional on import
 }
 
+class LargeUserExport extends UserExport {
+  protected maxExportRecords = 1200;
+
+  override async list() {
+    const records = Array.from({ length: 1001 }, (_, index) => ({
+      id: crypto.randomUUID(),
+      name: `User ${index}`,
+      email: `user-${index}@example.com`,
+      role: 'user' as const,
+      active: true,
+    }));
+
+    return {
+      result: records,
+      result_info: {
+        page: 1,
+        per_page: records.length,
+        total_count: records.length,
+        total_pages: 1,
+        has_next_page: false,
+        has_prev_page: false,
+      },
+    };
+  }
+}
+
+class StopOnErrorImport extends UserImport {
+  protected importBatchSize = 3;
+}
+
 // ============================================================================
 // CSV Utilities Tests
 // ============================================================================
@@ -465,6 +495,31 @@ describe('Export Endpoint', () => {
       const lines = csv.split('\r\n');
       expect(lines[0]).not.toContain('age');
     });
+
+    it('should honor stream=false for large CSV exports', async () => {
+      const largeApp = fromHono(new Hono());
+      registerCrud(largeApp, '/users', {
+        export: LargeUserExport,
+      });
+
+      const res = await largeApp.request('/users/export?format=csv&stream=false');
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Transfer-Encoding')).toBeNull();
+
+      const csv = await res.text();
+      expect(csv).toContain('User 1000');
+    });
+
+    it('should not set Transfer-Encoding for streamed CSV responses', async () => {
+      const largeApp = fromHono(new Hono());
+      registerCrud(largeApp, '/users', {
+        export: LargeUserExport,
+      });
+
+      const res = await largeApp.request('/users/export?format=csv&stream=true');
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Transfer-Encoding')).toBeNull();
+    });
   });
 
   describe('Search and Sort in Export', () => {
@@ -567,6 +622,32 @@ describe('Import Endpoint', () => {
       expect(data.result.summary.skipped).toBe(2);
       expect(data.result.results[1].status).toBe('skipped');
       expect(data.result.results[1].validationErrors).toBeDefined();
+    });
+
+    it('should stop before processing later rows when stopOnError is enabled', async () => {
+      const stopApp = fromHono(new Hono());
+      registerCrud(stopApp, '/users', {
+        import: StopOnErrorImport,
+      });
+
+      const res = await stopApp.request('/users/import?skipInvalid=false&stopOnError=true', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          items: [
+            { name: 'Alice', email: 'alice@example.com', role: 'admin' },
+            { name: 'Bob', email: 'invalid-email', role: 'user' },
+            { name: 'Charlie', email: 'charlie@example.com', role: 'user' },
+          ],
+        }),
+      });
+
+      expect(res.status).toBe(207);
+      const data = await res.json();
+      expect(data.result.summary.created).toBe(1);
+      expect(data.result.summary.failed).toBe(1);
+      expect(data.result.results).toHaveLength(2);
+      expect(data.result.results[1].status).toBe('failed');
     });
 
     it('should require items array in request body', async () => {

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -15,9 +15,11 @@ import {
 import { MemoryRateLimitStorage } from '../src/rate-limit/storage/memory.js';
 import { MemoryLoggingStorage } from '../src/logging/storage/memory.js';
 import { MemoryCacheStorage } from '../src/cache/storage/memory.js';
-import { MemoryAuditLogStorage } from '../src/core/audit.js';
-import { MemoryVersioningStorage } from '../src/core/versioning.js';
+import { MemoryAuditLogStorage, setAuditStorage } from '../src/core/audit.js';
+import { MemoryVersioningStorage, setVersioningStorage } from '../src/core/versioning.js';
 import { MemoryAPIKeyStorage } from '../src/auth/storage/memory.js';
+import { MemoryIdempotencyStorage } from '../src/idempotency/storage/memory.js';
+import { CrudEventEmitter } from '../src/events/emitter.js';
 import {
   setRateLimitStorage,
   getRateLimitStorage,
@@ -30,6 +32,7 @@ import {
   setCacheStorage,
   getCacheStorage,
 } from '../src/cache/mixin.js';
+import { setAPIKeyStorage } from '../src/auth/storage/memory.js';
 
 describe('Storage Module', () => {
   describe('createStorageMiddleware', () => {
@@ -40,6 +43,8 @@ describe('Storage Module', () => {
       const auditStorage = new MemoryAuditLogStorage();
       const versioningStorage = new MemoryVersioningStorage();
       const apiKeyStorage = new MemoryAPIKeyStorage();
+      const idempotencyStorage = new MemoryIdempotencyStorage();
+      const eventEmitter = new CrudEventEmitter();
 
       const app = new Hono<StorageEnv>();
 
@@ -52,6 +57,8 @@ describe('Storage Module', () => {
           auditStorage,
           versioningStorage,
           apiKeyStorage,
+          idempotencyStorage,
+          eventEmitter,
         })
       );
 
@@ -63,6 +70,8 @@ describe('Storage Module', () => {
         expect(ctx.var.auditStorage).toBe(auditStorage);
         expect(ctx.var.versioningStorage).toBe(versioningStorage);
         expect(ctx.var.apiKeyStorage).toBe(apiKeyStorage);
+        expect(ctx.var.idempotencyStorage).toBe(idempotencyStorage);
+        expect(ctx.var.eventEmitter).toBe(eventEmitter);
         return ctx.text('ok');
       });
 
@@ -131,6 +140,10 @@ describe('Storage Module', () => {
       // Clear global storage
       setRateLimitStorage(null as unknown as MemoryRateLimitStorage);
       setLoggingStorage(null as unknown as MemoryLoggingStorage);
+      setCacheStorage(null as unknown as MemoryCacheStorage);
+      setAuditStorage(null as unknown as MemoryAuditLogStorage);
+      setVersioningStorage(null as unknown as MemoryVersioningStorage);
+      setAPIKeyStorage(null as unknown as MemoryAPIKeyStorage);
     });
 
     describe('resolveRateLimitStorage', () => {
@@ -200,10 +213,9 @@ describe('Storage Module', () => {
         expect(result).toBe(explicit);
       });
 
-      it('should return default global storage when nothing configured', () => {
+      it('should return null when nothing configured', () => {
         const result = resolveCacheStorage();
-        // Cache storage always returns a default
-        expect(result).toBeDefined();
+        expect(result).toBeNull();
       });
     });
 
@@ -214,10 +226,9 @@ describe('Storage Module', () => {
         expect(result).toBe(explicit);
       });
 
-      it('should return default global storage when nothing configured', () => {
+      it('should return null when nothing configured', () => {
         const result = resolveAuditStorage();
-        // Audit storage always returns a default
-        expect(result).toBeDefined();
+        expect(result).toBeNull();
       });
     });
 
@@ -228,10 +239,9 @@ describe('Storage Module', () => {
         expect(result).toBe(explicit);
       });
 
-      it('should return default global storage when nothing configured', () => {
+      it('should return null when nothing configured', () => {
         const result = resolveVersioningStorage();
-        // Versioning storage always returns a default
-        expect(result).toBeDefined();
+        expect(result).toBeNull();
       });
     });
 
@@ -242,10 +252,9 @@ describe('Storage Module', () => {
         expect(result).toBe(explicit);
       });
 
-      it('should return default global storage when nothing configured', () => {
+      it('should return null when nothing configured', () => {
         const result = resolveAPIKeyStorage();
-        // API key storage always returns a default
-        expect(result).toBeDefined();
+        expect(result).toBeNull();
       });
     });
   });

--- a/tests/workers/edge-compat.test.ts
+++ b/tests/workers/edge-compat.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Edge compatibility tests running inside miniflare.
+ *
+ * Verifies that core hono-crud modules work within a Workers isolate
+ * without leaking Node.js APIs.
+ *
+ * Run with: vitest --config vitest.config.workers.ts
+ */
+import { describe, it, expect } from 'vitest';
+import { Hono } from 'hono';
+import { z } from 'zod';
+import type { StorageEnv } from '../../src/storage/types';
+
+describe('Edge Runtime Compatibility (Workers)', () => {
+  describe('Web Crypto API', () => {
+    it('should generate UUIDs via crypto.randomUUID()', () => {
+      const uuid = crypto.randomUUID();
+      expect(uuid).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+      );
+    });
+
+    it('should have crypto.subtle available', () => {
+      expect(crypto.subtle).toBeDefined();
+      expect(crypto.subtle.digest).toBeTypeOf('function');
+    });
+
+    it('should compute SHA-256 digest', async () => {
+      const data = new TextEncoder().encode('hello');
+      const hash = await crypto.subtle.digest('SHA-256', data);
+      expect(hash).toBeInstanceOf(ArrayBuffer);
+      expect(hash.byteLength).toBe(32);
+    });
+
+    it('should generate random values', () => {
+      const buf = new Uint8Array(16);
+      crypto.getRandomValues(buf);
+      // Extremely unlikely all zeros
+      expect(buf.some((b) => b !== 0)).toBe(true);
+    });
+  });
+
+  describe('Web Standard APIs', () => {
+    it('should have TextEncoder/TextDecoder', () => {
+      const encoder = new TextEncoder();
+      const decoder = new TextDecoder();
+      const encoded = encoder.encode('test');
+      expect(decoder.decode(encoded)).toBe('test');
+    });
+
+    it('should have ReadableStream', () => {
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('chunk'));
+          controller.close();
+        },
+      });
+      expect(stream).toBeInstanceOf(ReadableStream);
+    });
+
+    it('should have Response and Request', () => {
+      const req = new Request('https://example.com');
+      const res = new Response('ok', { status: 200 });
+      expect(req.url).toBe('https://example.com/');
+      expect(res.status).toBe(200);
+    });
+
+    it('should have URL and URLSearchParams', () => {
+      const url = new URL('https://example.com?a=1&b=2');
+      expect(url.searchParams.get('a')).toBe('1');
+      expect(url.searchParams.get('b')).toBe('2');
+    });
+  });
+
+  describe('Memory storage in Worker isolate', () => {
+    it('should work with MemoryCacheStorage', async () => {
+      // Dynamic import to prove it loads in Workers
+      const { MemoryCacheStorage } = await import('../../src/cache/storage/memory');
+
+      const cache = new MemoryCacheStorage({ maxSize: 100, defaultTtl: 60 });
+      await cache.set('k', { value: 42 });
+
+      const entry = await cache.get<{ value: number }>('k');
+      expect(entry).not.toBeNull();
+      expect(entry!.data.value).toBe(42);
+    });
+
+    it('should work with MemoryRateLimitStorage', async () => {
+      const { MemoryRateLimitStorage } = await import('../../src/rate-limit/storage/memory');
+
+      const rl = new MemoryRateLimitStorage();
+      const result = await rl.increment('test-key', 60_000);
+      expect(result.count).toBe(1);
+    });
+  });
+
+  describe('Hono app in Workers', () => {
+    it('should import the root package entry in a Workers isolate', async () => {
+      const mod = await import('../../src/index');
+      expect(mod.createCrudMiddleware).toBeTypeOf('function');
+      expect(mod.KVCacheStorage).toBeTypeOf('function');
+      expect(mod.KVRateLimitStorage).toBeTypeOf('function');
+    });
+
+    it('should handle requests correctly', async () => {
+      const app = new Hono();
+      app.get('/ping', (c) => c.json({ pong: true }));
+
+      const res = await app.request('/ping');
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body).toEqual({ pong: true });
+    });
+
+    it('should work with Zod validation', () => {
+      const schema = z.object({
+        id: z.string().uuid(),
+        name: z.string().min(1),
+      });
+
+      const result = schema.safeParse({
+        id: crypto.randomUUID(),
+        name: 'test',
+      });
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('createCrudMiddleware in Workers', () => {
+    it('should inject storage into Hono context', async () => {
+      const { createCrudMiddleware } = await import('../../src/middleware');
+      const { MemoryCacheStorage } = await import('../../src/cache/storage/memory');
+
+      const cache = new MemoryCacheStorage();
+      const app = new Hono<StorageEnv>();
+
+      app.use('*', createCrudMiddleware({ cache }));
+      app.get('/test', (c) => {
+        return c.json({ hasCache: c.var.cacheStorage === cache });
+      });
+
+      const res = await app.request('/test');
+      const body = await res.json();
+      expect(body).toEqual({ hasCache: true });
+    });
+  });
+});

--- a/tests/workers/kv-cache.test.ts
+++ b/tests/workers/kv-cache.test.ts
@@ -1,0 +1,141 @@
+/**
+ * KV Cache Storage tests running inside miniflare.
+ *
+ * Verifies that KVCacheStorage works correctly with real KV bindings
+ * in a Cloudflare Workers environment.
+ *
+ * Run with: vitest --config vitest.config.workers.ts
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { env } from 'cloudflare:test';
+import { KVCacheStorage } from '../../src/cache/storage/cloudflare-kv';
+
+describe('KVCacheStorage (Workers)', () => {
+  let cache: KVCacheStorage;
+
+  beforeEach(async () => {
+    cache = new KVCacheStorage({ kv: env.CACHE_KV, prefix: 'test:' });
+    await cache.clear();
+  });
+
+  describe('basic operations', () => {
+    it('should set and get a value', async () => {
+      await cache.set('key1', { name: 'test' });
+      const entry = await cache.get<{ name: string }>('key1');
+
+      expect(entry).not.toBeNull();
+      expect(entry!.data).toEqual({ name: 'test' });
+      expect(entry!.createdAt).toBeTypeOf('number');
+    });
+
+    it('should return null for non-existent key', async () => {
+      const entry = await cache.get('missing');
+      expect(entry).toBeNull();
+    });
+
+    it('should delete a value', async () => {
+      await cache.set('key1', 'value');
+      const deleted = await cache.delete('key1');
+      expect(deleted).toBe(true);
+
+      const entry = await cache.get('key1');
+      expect(entry).toBeNull();
+    });
+
+    it('should return false when deleting non-existent key', async () => {
+      const deleted = await cache.delete('missing');
+      expect(deleted).toBe(false);
+    });
+
+    it('should check if key exists', async () => {
+      await cache.set('key1', 'value');
+      expect(await cache.has('key1')).toBe(true);
+      expect(await cache.has('missing')).toBe(false);
+    });
+  });
+
+  describe('TTL', () => {
+    it('should support TTL values below the KV expirationTtl minimum with app-level expiry', async () => {
+      await cache.set('short-ttl', 'value', { ttl: 1 });
+      const entry = await cache.get('short-ttl');
+
+      expect(entry).not.toBeNull();
+      expect(entry!.expiresAt).toBeTypeOf('number');
+    });
+
+    it('should store entries with TTL', async () => {
+      await cache.set('ttl-key', 'value', { ttl: 60 });
+      const entry = await cache.get('ttl-key');
+
+      expect(entry).not.toBeNull();
+      expect(entry!.expiresAt).toBeTypeOf('number');
+      expect(entry!.expiresAt).toBeGreaterThan(Date.now());
+    });
+
+    it('should use default TTL when none specified', async () => {
+      const cache300 = new KVCacheStorage({
+        kv: env.CACHE_KV,
+        prefix: 'ttl-test:',
+        defaultTtl: 300,
+      });
+
+      await cache300.set('key1', 'value');
+      const entry = await cache300.get('key1');
+
+      expect(entry).not.toBeNull();
+      expect(entry!.expiresAt).not.toBeNull();
+    });
+  });
+
+  describe('tags', () => {
+    it('should store entries with tags', async () => {
+      await cache.set('user:1', { id: 1 }, { tags: ['users'] });
+      await cache.set('user:2', { id: 2 }, { tags: ['users'] });
+
+      const entry = await cache.get<{ id: number }>('user:1');
+      expect(entry).not.toBeNull();
+      expect(entry!.tags).toEqual(['users']);
+    });
+
+    it('should delete entries by tag', async () => {
+      await cache.set('user:1', { id: 1 }, { tags: ['users'] });
+      await cache.set('user:2', { id: 2 }, { tags: ['users'] });
+      await cache.set('post:1', { id: 1 }, { tags: ['posts'] });
+
+      const count = await cache.deleteByTag('users');
+      expect(count).toBe(2);
+
+      expect(await cache.has('user:1')).toBe(false);
+      expect(await cache.has('user:2')).toBe(false);
+      expect(await cache.has('post:1')).toBe(true);
+    });
+  });
+
+  describe('pattern deletion', () => {
+    it('should delete entries matching a prefix pattern', async () => {
+      await cache.set('user:1', 'a');
+      await cache.set('user:2', 'b');
+      await cache.set('post:1', 'c');
+
+      const count = await cache.deletePattern('user:*');
+      expect(count).toBe(2);
+
+      expect(await cache.has('user:1')).toBe(false);
+      expect(await cache.has('user:2')).toBe(false);
+      expect(await cache.has('post:1')).toBe(true);
+    });
+  });
+
+  describe('stats', () => {
+    it('should track hits and misses', async () => {
+      await cache.set('key1', 'value');
+
+      await cache.get('key1'); // hit
+      await cache.get('missing'); // miss
+
+      const stats = cache.getStats();
+      expect(stats.hits).toBe(1);
+      expect(stats.misses).toBe(1);
+    });
+  });
+});

--- a/tests/workers/kv-rate-limit.test.ts
+++ b/tests/workers/kv-rate-limit.test.ts
@@ -1,0 +1,160 @@
+/**
+ * KV Rate Limit Storage tests running inside miniflare.
+ *
+ * Verifies that KVRateLimitStorage works correctly with real KV bindings
+ * in a Cloudflare Workers environment.
+ *
+ * Run with: vitest --config vitest.config.workers.ts
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { env } from 'cloudflare:test';
+import { KVRateLimitStorage } from '../../src/rate-limit/storage/cloudflare-kv';
+import type { KVNamespace } from '../../src/shared/kv-types';
+
+class SameKeyWriteLimitedKV implements KVNamespace {
+  private values = new Map<string, string>();
+  private writeCounts = new Map<string, number>();
+
+  async get(key: string): Promise<string | null> {
+    return this.values.get(key) ?? null;
+  }
+
+  async put(key: string, value: string): Promise<void> {
+    const writes = this.writeCounts.get(key) ?? 0;
+    this.writeCounts.set(key, writes + 1);
+    if (writes > 0) {
+      throw new Error('KV PUT failed: 429 Too Many Requests');
+    }
+    this.values.set(key, value);
+  }
+
+  async delete(key: string): Promise<void> {
+    this.values.delete(key);
+  }
+
+  async list(): Promise<{ keys: Array<{ name: string; expiration?: number }>; list_complete: boolean; cursor?: string }> {
+    return {
+      keys: Array.from(this.values.keys()).map((name) => ({ name })),
+      list_complete: true,
+    };
+  }
+}
+
+describe('KVRateLimitStorage (Workers)', () => {
+  let storage: KVRateLimitStorage;
+
+  beforeEach(() => {
+    storage = new KVRateLimitStorage({ kv: env.RATE_LIMIT_KV, prefix: 'test-rl:' });
+  });
+
+  describe('fixed window (increment)', () => {
+    it('should support windows shorter than the KV expirationTtl minimum', async () => {
+      const entry = await storage.increment('short-window', 1_000);
+
+      expect(entry.count).toBe(1);
+      expect(entry.windowStart).toBeTypeOf('number');
+    });
+
+    it('should start a new window on first request', async () => {
+      const entry = await storage.increment('user:1', 60_000);
+
+      expect(entry.count).toBe(1);
+      expect(entry.windowStart).toBeTypeOf('number');
+      expect(entry.windowStart).toBeLessThanOrEqual(Date.now());
+    });
+
+    it('should increment count within the same window', async () => {
+      await storage.increment('user:2', 60_000);
+      await storage.increment('user:2', 60_000);
+      const entry = await storage.increment('user:2', 60_000);
+
+      expect(entry.count).toBe(3);
+    });
+
+    it('should persist entries and retrieve them', async () => {
+      await storage.increment('user:3', 60_000);
+
+      const entry = await storage.get('user:3');
+      expect(entry).not.toBeNull();
+      expect((entry as { count: number }).count).toBe(1);
+    });
+
+    it('should fail open on repeated same-key KV write errors by default', async () => {
+      const errors: string[] = [];
+      const bestEffortStorage = new KVRateLimitStorage({
+        kv: new SameKeyWriteLimitedKV(),
+        onError: (error) => errors.push(error.message),
+      });
+
+      await bestEffortStorage.increment('same-key', 60_000);
+      const entry = await bestEffortStorage.increment('same-key', 60_000);
+
+      expect(entry.count).toBe(1);
+      expect(errors.some((message) => message.includes('429'))).toBe(true);
+    });
+
+    it('should throw same-key KV write errors when failOpen is false', async () => {
+      const strictStorage = new KVRateLimitStorage({
+        kv: new SameKeyWriteLimitedKV(),
+        failOpen: false,
+      });
+
+      await strictStorage.increment('strict-key', 60_000);
+      await expect(strictStorage.increment('strict-key', 60_000)).rejects.toThrow('429');
+    });
+
+    it('should treat malformed stored JSON as a new best-effort window', async () => {
+      await env.RATE_LIMIT_KV.put('test-rl:bad-json', '{not-json', { expirationTtl: 60 });
+
+      expect(await storage.get('bad-json')).toBeNull();
+      const entry = await storage.increment('bad-json', 60_000);
+      expect(entry.count).toBe(1);
+    });
+  });
+
+  describe('sliding window (addTimestamp)', () => {
+    it('should add timestamps within window', async () => {
+      const now = Date.now();
+      const entry = await storage.addTimestamp('slide:1', 60_000, now);
+
+      expect(entry.timestamps).toHaveLength(1);
+      expect(entry.timestamps[0]).toBe(now);
+    });
+
+    it('should accumulate timestamps', async () => {
+      const now = Date.now();
+      await storage.addTimestamp('slide:2', 60_000, now);
+      await storage.addTimestamp('slide:2', 60_000, now + 100);
+      const entry = await storage.addTimestamp('slide:2', 60_000, now + 200);
+
+      expect(entry.timestamps).toHaveLength(3);
+    });
+
+    it('should expire old timestamps outside window', async () => {
+      const now = Date.now();
+      await storage.addTimestamp('slide:3', 1_000, now - 2_000); // outside window
+      const entry = await storage.addTimestamp('slide:3', 1_000, now);
+
+      // Old timestamp should be filtered out
+      expect(entry.timestamps).toHaveLength(1);
+      expect(entry.timestamps[0]).toBe(now);
+    });
+  });
+
+  describe('reset', () => {
+    it('should remove rate limit entry', async () => {
+      await storage.increment('reset:1', 60_000);
+      await storage.reset('reset:1');
+
+      const entry = await storage.get('reset:1');
+      expect(entry).toBeNull();
+    });
+  });
+
+  describe('cleanup', () => {
+    it('should return 0 (KV handles TTL)', async () => {
+      const count = await storage.cleanup();
+      expect(count).toBe(0);
+    });
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     'src/logging/index.ts',
     'src/storage/index.ts',
     'src/ui.ts',
+    'src/types/cloudflare.ts',
   ],
   format: ['esm'],
   dts: true,
@@ -29,5 +30,7 @@ export default defineConfig({
     '@hono/swagger-ui',
     '@scalar/hono-api-reference',
     'zod',
+    'pluralize',
+    'fastest-levenshtein',
   ],
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      'tests/workers/**',
+    ],
+  },
+});

--- a/vitest.config.workers.ts
+++ b/vitest.config.workers.ts
@@ -1,0 +1,34 @@
+/**
+ * Vitest configuration for Cloudflare Workers edge runtime tests.
+ *
+ * These tests run inside miniflare (Cloudflare's local simulator) to verify
+ * that hono-crud operates correctly in a Workers environment:
+ * - No Node.js APIs leak into library code
+ * - Web Crypto operations work
+ * - KV and D1 storage adapters function correctly
+ * - Memory storage works within Worker isolates
+ *
+ * Prerequisites:
+ *   pnpm add -D @cloudflare/vitest-pool-workers @cloudflare/workers-types
+ *
+ * Run with:
+ *   vitest --config vitest.config.workers.ts
+ */
+import { defineWorkersConfig } from '@cloudflare/vitest-pool-workers/config';
+
+export default defineWorkersConfig({
+  test: {
+    include: ['tests/workers/**/*.test.ts'],
+    poolOptions: {
+      workers: {
+        wrangler: {
+          configPath: './wrangler.toml',
+        },
+        miniflare: {
+          kvNamespaces: ['CACHE_KV', 'RATE_LIMIT_KV'],
+          d1Databases: ['DB'],
+        },
+      },
+    },
+  },
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,18 @@
+# Minimal wrangler configuration for vitest-pool-workers tests.
+# Not intended for deployment — used only for local test bindings.
+
+name = "hono-crud-tests"
+compatibility_date = "2024-11-01"
+
+[[kv_namespaces]]
+binding = "CACHE_KV"
+id = "test-cache-kv"
+
+[[kv_namespaces]]
+binding = "RATE_LIMIT_KV"
+id = "test-rate-limit-kv"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "test-db"
+database_id = "test-db-id"


### PR DESCRIPTION
## Summary
- add Workers verification with Cloudflare Vitest pool config and release gating
- make KV cache/rate-limit storage edge-safe, best-effort where Cloudflare KV cannot guarantee strict counters
- prefer explicit/context storage for edge-sensitive features while preserving compatibility APIs
- fix import/export edge regressions and replace loose schema/type patterns
- add static edge-safety scans and Workers isolate coverage

## Impact
This makes edge-safe usage the default for the shipped library surface and prevents tests from claiming Workers compatibility without actually running in a Workers-like isolate. KV rate limiting remains exported but is documented and implemented as best-effort, with fail-open behavior by default.

## Validation
- pnpm run typecheck
- pnpm test run
- pnpm run build
- pnpm run test:workers