### PR TITLE
feat(config): per-endpoint bodySchema override on create/update

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -32,6 +32,7 @@
  * ```
  */
 
+import type { ZodObject, ZodRawShape } from 'zod';
 import type { MetaInput, HookMode } from '../core/types';
 import type { ModelObject } from '../endpoints/types';
 
@@ -81,6 +82,18 @@ export interface CreateEndpointConfig<M extends MetaInput> {
   openapi?: OpenAPIConfig;
   hooks?: CreateHooks<M>;
   nestedCreate?: string[];
+  /**
+   * Override the request body validation schema for this endpoint.
+   *
+   * When set, the default schema (model schema minus primary keys, with
+   * multi-tenant exclusions and nested-relation merging applied) is bypassed
+   * — the user's schema is used as-is. Same precedence as `meta.fields`, but
+   * scoped to this single endpoint.
+   *
+   * The caller is responsible for excluding any auto-injected fields
+   * (primary keys, tenant id, etc.) from the override schema.
+   */
+  bodySchema?: ZodObject<ZodRawShape>;
 }
 
 /**
@@ -199,6 +212,16 @@ export interface UpdateEndpointConfig<M extends MetaInput> {
   fields?: UpdateFieldConfig;
   nestedWrites?: string[];
   hooks?: UpdateHooks<M>;
+  /**
+   * Override the request body validation schema for this endpoint.
+   *
+   * When set, the default schema (model schema minus primary keys, with
+   * `fields.allowed` / `fields.blocked` filtering and `.partial()` applied,
+   * plus nested-relation merging) is bypassed — the user's schema is used
+   * as-is. Note: the override is **not** automatically wrapped in
+   * `.partial()`; the caller decides which fields are required.
+   */
+  bodySchema?: ZodObject<ZodRawShape>;
 }
 
 /**
@@ -336,6 +359,13 @@ export function defineEndpoints<M extends MetaInput>(
       protected afterHookMode: HookMode = createConfig.hooks?.afterMode || 'sequential';
       protected allowNestedCreate = createConfig.nestedCreate || [];
 
+      protected getBodySchema(): ZodObject<ZodRawShape> {
+        if (createConfig.bodySchema) {
+          return createConfig.bodySchema;
+        }
+        return super.getBodySchema();
+      }
+
       async before(data: ModelObject<M['model']>, tx?: unknown): Promise<ModelObject<M['model']>> {
         if (createConfig.hooks?.before) {
           return createConfig.hooks.before(data, tx);
@@ -444,6 +474,13 @@ export function defineEndpoints<M extends MetaInput>(
       protected allowNestedWrites = updateConfig.nestedWrites || [];
       protected beforeHookMode: HookMode = updateConfig.hooks?.beforeMode || 'sequential';
       protected afterHookMode: HookMode = updateConfig.hooks?.afterMode || 'sequential';
+
+      protected getBodySchema(): ZodObject<ZodRawShape> {
+        if (updateConfig.bodySchema) {
+          return updateConfig.bodySchema;
+        }
+        return super.getBodySchema();
+      }
 
       async before(data: Partial<ModelObject<M['model']>>, tx?: unknown): Promise<Partial<ModelObject<M['model']>>> {
         if (updateConfig.hooks?.before) {

--- a/tests/body-schema-override.test.ts
+++ b/tests/body-schema-override.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { fromHono, registerCrud, defineEndpoints, MemoryAdapters, defineMeta, defineModel } from '../src/index.js';
+import { clearStorage } from '../src/adapters/memory/index.js';
+
+const PostSchema = z.object({
+  id: z.uuid(),
+  title: z.string().min(1),
+  body: z.string().min(1),
+  authorId: z.string(),
+  internalNotes: z.string().optional(),
+});
+
+const PostModel = defineModel({
+  tableName: 'posts_body_schema',
+  schema: PostSchema,
+  primaryKeys: ['id'],
+});
+
+const postMeta = defineMeta({ model: PostModel });
+
+describe('per-endpoint bodySchema override', () => {
+  beforeEach(() => clearStorage());
+
+  describe('CreateEndpointConfig.bodySchema', () => {
+    it('uses the override schema instead of the model-derived one', async () => {
+      // The override schema demands a `slug` field that the model does not have,
+      // and forbids the `internalNotes` field that the model permits. This
+      // proves the override schema replaces (not extends) the default.
+      const CreatePostInput = z.object({
+        title: z.string().min(5),
+        body: z.string(),
+        authorId: z.string(),
+        slug: z.string().regex(/^[a-z0-9-]+$/),
+      });
+
+      const endpoints = defineEndpoints(
+        {
+          meta: postMeta,
+          create: { bodySchema: CreatePostInput as never },
+          list: {},
+        },
+        MemoryAdapters,
+      );
+
+      const app = fromHono(new Hono());
+      registerCrud(app, '/posts', endpoints);
+
+      // Missing `slug` — model schema would have allowed this; override rejects it.
+      const r1 = await app.request('/posts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'Hello world', body: 'b', authorId: 'u1' }),
+      });
+      expect(r1.status).toBe(400);
+
+      // Title too short — override demands min(5).
+      const r2 = await app.request('/posts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'Hi', body: 'b', authorId: 'u1', slug: 'hi' }),
+      });
+      expect(r2.status).toBe(400);
+
+      // All required override fields present.
+      const r3 = await app.request('/posts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: 'Hello world',
+          body: 'b',
+          authorId: 'u1',
+          slug: 'hello-world',
+        }),
+      });
+      expect(r3.status).toBe(201);
+    });
+
+    it('falls back to the model-derived schema when no override is set', async () => {
+      const endpoints = defineEndpoints(
+        { meta: postMeta, create: {} },
+        MemoryAdapters,
+      );
+
+      const app = fromHono(new Hono());
+      registerCrud(app, '/posts2', endpoints);
+
+      // Missing `body` — required by the model schema.
+      const r = await app.request('/posts2', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'Hi', authorId: 'u1' }),
+      });
+      expect(r.status).toBe(400);
+    });
+  });
+
+  describe('UpdateEndpointConfig.bodySchema', () => {
+    it('uses the override schema and is not auto-partialed', async () => {
+      // Pre-seed an item via create to update later.
+      const seedEndpoints = defineEndpoints(
+        { meta: postMeta, create: {} },
+        MemoryAdapters,
+      );
+      const seedApp = fromHono(new Hono());
+      registerCrud(seedApp, '/posts3', seedEndpoints);
+      const created = await seedApp.request('/posts3', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'Original', body: 'b', authorId: 'u1' }),
+      });
+      const id = ((await created.json()) as { result: { id: string } }).result.id;
+
+      // The override demands BOTH title and body — no `.partial()` applied.
+      const UpdatePostInput = z.object({
+        title: z.string().min(1),
+        body: z.string().min(1),
+      });
+
+      const updEndpoints = defineEndpoints(
+        {
+          meta: postMeta,
+          update: { bodySchema: UpdatePostInput as never },
+        },
+        MemoryAdapters,
+      );
+      const updApp = fromHono(new Hono());
+      registerCrud(updApp, '/posts3', updEndpoints);
+
+      // Only `title` provided — fails because override requires `body` too.
+      const r1 = await updApp.request(`/posts3/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'New title' }),
+      });
+      expect(r1.status).toBe(400);
+
+      // Both fields → succeeds.
+      const r2 = await updApp.request(`/posts3/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'New title', body: 'New body' }),
+      });
+      expect(r2.status).toBe(200);
+    });
+
+    it('falls back to the model-derived partial schema when no override is set', async () => {
+      const endpoints = defineEndpoints(
+        { meta: postMeta, create: {}, update: {} },
+        MemoryAdapters,
+      );
+      const app = fromHono(new Hono());
+      registerCrud(app, '/posts4', endpoints);
+
+      const created = await app.request('/posts4', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'X', body: 'y', authorId: 'u1' }),
+      });
+      const id = ((await created.json()) as { result: { id: string } }).result.id;
+
+      // Default update schema is partial — single-field PATCH succeeds.
+      const r = await app.request(`/posts4/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'updated' }),
+      });
+      expect(r.status).toBe(200);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds an optional `bodySchema?: ZodObject<ZodRawShape>` field to `CreateEndpointConfig<M>` and `UpdateEndpointConfig<M>`. When set, the generated endpoint class overrides `getBodySchema()` to return the caller's Zod schema instead of the default model-derived one.

### Why

Today there are two ways to influence the request-body schema:

1. \`meta.fields\` — a **model-wide** override that applies to **both** create and update. All-or-nothing.
2. \`update.fields.{allowed,blocked}\` — per-endpoint **field filtering**, but only on update, and only by name.

There's no way to supply a different Zod schema *per route*. Common cases this unlocks:
- A stricter create schema (extra validation rules, computed-field requirements) that doesn't apply on update.
- An update schema that omits fields the create demands (e.g. immutable identifiers).
- Endpoint-specific input shapes that diverge from the storage model entirely (mapping/translation layer at the edge).

### API

\`\`\`ts
import { z } from 'zod';
import { defineEndpoints, defineMeta, defineModel, MemoryAdapters } from 'hono-crud';

const PostModel = defineModel({ tableName: 'posts', schema: PostSchema, primaryKeys: ['id'] });

const CreatePostInput = z.object({
  title: z.string().min(5),
  body: z.string(),
  authorId: z.string(),
  slug: z.string().regex(/^[a-z0-9-]+\$/),
});

const endpoints = defineEndpoints({
  meta: defineMeta({ model: PostModel }),
  create: { bodySchema: CreatePostInput },     // ← stricter than the model
  update: { bodySchema: CreatePostInput.partial().omit({ authorId: true }) },
}, MemoryAdapters);
\`\`\`

### Precedence (per endpoint)

\`bodySchema\` > \`meta.fields\` > model-derived (default).

### When \`bodySchema\` is set

- **Create**: the default exclusions (primary keys, multi-tenant field) and nested-relation merging are bypassed. The caller is responsible for excluding any auto-injected fields from the override schema.
- **Update**: the caller's schema is **not** automatically wrapped in \`.partial()\`. Required vs. optional is the caller's call. (Same precedent as \`meta.fields\` on update — it's also not auto-partialed.)

These two notes are the only behavior-shape decisions worth flagging; both are documented in the JSDoc on the new fields.

## What's NOT in this PR

- No change to the model-level \`meta.fields\` escape hatch — still works exactly as before.
- No change to \`update.fields.{allowed,blocked}\` field filtering — still applies when \`bodySchema\` is unset.
- No new public adapter export. The override slots into the existing \`getBodySchema()\` extension point already used by adapters.
- No filter / pagination / sort DSL changes.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` — 697 / 697 pass (4 new tests in \`tests/body-schema-override.test.ts\`):
  - Create override is used when set (rejects bodies that don't match it; accepts ones that do)
  - Create falls back to model-derived schema when \`bodySchema\` absent
  - Update override is used as-is and is NOT auto-partialed (requires all fields the override demands)
  - Update falls back to model-derived partial schema when absent
- [x] \`pnpm build\` clean