### PR TITLE
docs: document tree-shakeable subpath imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,24 @@ See [docs/logging.md](./docs/logging.md).
 
 See [docs/advanced-features.md](./docs/advanced-features.md) for examples of every feature.
 
+### Subpath Imports
+
+Every advanced feature is also exposed as a tree-shakeable subpath, so apps that only need one feature can import it directly without pulling in the rest of the library:
+
+```typescript
+import { multiTenant } from 'hono-crud/multi-tenant';
+import { createAuditLogger, MemoryAuditLogStorage } from 'hono-crud/audit';
+import { VersionManager, MemoryVersioningStorage } from 'hono-crud/versioning';
+import { CrudEventEmitter, registerWebhooks } from 'hono-crud/events';
+import { idempotency, MemoryIdempotencyStorage } from 'hono-crud/idempotency';
+import { createHealthEndpoints } from 'hono-crud/health';
+import { encryptFields, decryptFields, StaticKeyProvider } from 'hono-crud/encryption';
+import { applyProfile, type SerializationProfile } from 'hono-crud/serialization';
+import { apiVersion, getApiVersion } from 'hono-crud/api-version';
+```
+
+The same symbols remain available from `'hono-crud'` for convenience.
+
 ## API Documentation
 
 ```typescript


### PR DESCRIPTION
## Summary
- Add a "Subpath Imports" subsection to the README that documents the 9 new tree-shakeable entry points (`hono-crud/audit`, `versioning`, `multi-tenant`, `events`, `idempotency`, `health`, `encryption`, `serialization`, `api-version`) introduced in v0.5.1.
- Notes that the same symbols remain available from the top-level `'hono-crud'` import, so this is purely additive guidance for apps that want smaller bundles.

## Test plan
- [x] All documented symbols verified to exist in their respective `src/<feature>/index.ts` (read each file)
- [ ] Render README on GitHub to confirm formatting