### PR TITLE
fix(ci): generate prisma client and provision postgres for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,24 @@ jobs:
       matrix:
         node-version: [20, 22]
 
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: hono_crud
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/hono_crud?schema=public
+
     steps:
       - uses: actions/checkout@v4
 
@@ -31,7 +49,7 @@ jobs:
         run: pnpm run typecheck
 
       - name: Run tests
-        run: pnpm test run
+        run: pnpm test
 
       - name: Build
         run: pnpm run build

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "test:examples": "pnpm run prisma:generate && pnpm run prisma:push && vitest run tests/examples",
     "test:workers": "vitest run --config vitest.config.workers.ts",
     "typecheck": "tsc --noEmit",
-    "typecheck:examples": "tsc -p tsconfig.examples.json",
+    "typecheck:examples": "pnpm run prisma:generate && tsc -p tsconfig.examples.json",
     "prepare": "tsup",
     "prepublishOnly": "pnpm test"
   },


### PR DESCRIPTION
## Summary
CI was failing on `typecheck:examples` because `examples/prisma/db.ts` imports `PrismaClient` from `@prisma/client`, which only re-exports the generated client after `prisma generate` has run. With the type missing, `prisma.user.create()` collapsed to `any`, which in turn made `(u) =>` in `examples/prisma/soft-delete.ts` an implicit-any.

- `typecheck:examples` now runs `prisma:generate` first.
- CI workflow gains a `postgres:16-alpine` service + `DATABASE_URL` env so the rest of `pnpm test` (which calls `prisma:push` and the integration tests) can run.
- Dropped the vestigial `run` arg from `pnpm test run` (it wasn't doing anything since `test` is no longer just `vitest`).

## Test plan
- [ ] CI passes on Node 20 and 22
- [ ] `pnpm run typecheck:examples` passes locally (verified)