### PR TITLE
fix(ci): add postgres service to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,25 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: hono_crud
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/hono_crud?schema=public
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -44,7 +63,7 @@ jobs:
         run: pnpm run typecheck
 
       - name: Run tests
-        run: pnpm test run
+        run: pnpm test
 
       - name: Build
         run: pnpm run build


### PR DESCRIPTION
## Summary
The Release workflow runs `pnpm test`, which now includes `test:examples` (`prisma:push` + integration tests against Postgres). PR #15 added a Postgres service to `ci.yml`, but `release.yml` was untouched and is failing on `main` with `P1001: Can't reach database server at localhost:5432`.

This PR mirrors the CI workflow change in `release.yml`: postgres-16 service + `DATABASE_URL` env, and drops the vestigial `run` arg from `pnpm test`.

## Test plan
- [ ] Release workflow passes on this PR's `main`-merge run