### PR TITLE
feat(config): widen defineEndpoints to the full 17-endpoint surface

### DIFF
--- a/examples/drizzle/clone.ts
+++ b/examples/drizzle/clone.ts
@@ -1,0 +1,327 @@
+/**
+ * Example: Drizzle clone endpoint over libsql in-memory SQLite.
+ *
+ * Self-contained — no docker, no external DB. Run with:
+ *
+ *   pnpm tsx examples/drizzle/clone.ts
+ *
+ * The script wires a single Articles resource with full CRUD plus the new
+ * `DrizzleCloneEndpoint`, seeds two articles, then exercises six clone
+ * scenarios end-to-end via `app.request(...)`. It exits 0 only when every
+ * scenario passes; any mismatch throws and the script exits non-zero.
+ *
+ * Scenarios covered (each prints PASS/FAIL):
+ *   1. Clone a basic record — fresh primary key, source data copied
+ *   2. Clone with body overrides — overrides win over source data
+ *   3. Clone via the strip-publishedAt endpoint — excludeFromClone wipes it
+ *      and the body's value populates the new row
+ *   4. Source not found → 404
+ *   5. Soft-deleted source → 404 (must not be cloneable)
+ *   6. Original record remains intact in the DB after clone
+ */
+
+import { OpenAPIHono } from '@hono/zod-openapi';
+import type { Context } from 'hono';
+import { z } from 'zod';
+import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
+import { drizzle } from 'drizzle-orm/libsql';
+import { createClient } from '@libsql/client';
+import { sql } from 'drizzle-orm';
+import { defineModel, defineMeta, registerCrud, fromHono } from '../../src/index.js';
+import {
+  DrizzleCloneEndpoint,
+  DrizzleCreateEndpoint,
+  DrizzleReadEndpoint,
+  DrizzleListEndpoint,
+  type DrizzleDatabase,
+} from '../../src/adapters/drizzle/index.js';
+
+// -----------------------------------------------------------------------------
+// Schema + DB
+// -----------------------------------------------------------------------------
+
+const articlesTable = sqliteTable('articles', {
+  id: text('id').primaryKey(),
+  title: text('title').notNull(),
+  body: text('body').notNull(),
+  status: text('status').notNull().default('draft'),
+  publishedAt: text('publishedAt'),
+  deletedAt: text('deletedAt'),
+});
+
+const ArticleSchema = z.object({
+  id: z.uuid(),
+  title: z.string().min(1),
+  body: z.string().min(1),
+  status: z.enum(['draft', 'published', 'archived']).default('draft'),
+  publishedAt: z.string().nullable().optional(),
+  deletedAt: z.string().nullable().optional(),
+});
+
+const ArticleModel = defineModel({
+  tableName: 'articles',
+  schema: ArticleSchema,
+  primaryKeys: ['id'],
+  table: articlesTable,
+  softDelete: { field: 'deletedAt' },
+});
+
+const articleMeta = defineMeta({ model: ArticleModel });
+
+const client = createClient({ url: ':memory:' });
+const db = drizzle(client);
+const typedDb = db as unknown as DrizzleDatabase;
+
+// -----------------------------------------------------------------------------
+// Endpoint classes
+// -----------------------------------------------------------------------------
+
+class ArticleCreate extends DrizzleCreateEndpoint {
+  _meta = articleMeta;
+  db = typedDb;
+}
+
+class ArticleRead extends DrizzleReadEndpoint {
+  _meta = articleMeta;
+  db = typedDb;
+}
+
+class ArticleList extends DrizzleListEndpoint {
+  _meta = articleMeta;
+  db = typedDb;
+}
+
+class ArticleClone extends DrizzleCloneEndpoint {
+  _meta = articleMeta;
+  db = typedDb;
+}
+
+/** Variant: strips `publishedAt` so each clone starts unpublished by default. */
+class ArticleCloneAsDraft extends DrizzleCloneEndpoint {
+  _meta = articleMeta;
+  db = typedDb;
+  excludeFromClone = ['publishedAt', 'status'];
+}
+
+// -----------------------------------------------------------------------------
+// App wiring
+// -----------------------------------------------------------------------------
+
+type EndpointInstance = {
+  setContext(ctx: Context): void;
+  handle(): Promise<Response>;
+};
+
+function withContext(EndpointClass: new () => EndpointInstance) {
+  return async (c: Context) => {
+    const endpoint = new EndpointClass();
+    endpoint.setContext(c);
+    return endpoint.handle();
+  };
+}
+
+export function buildApp() {
+  const openApi = new OpenAPIHono();
+  openApi.onError((err, c) => {
+    const status = (err as { status?: number }).status ?? 500;
+    return c.json({ success: false, error: { message: err.message } }, status as 400 | 404 | 500);
+  });
+  const app = fromHono(openApi);
+
+  registerCrud(app, '/articles', {
+    create: ArticleCreate,
+    list: ArticleList,
+    read: ArticleRead,
+    clone: ArticleClone,
+  });
+
+  app.post('/articles/:id/clone-as-draft', withContext(ArticleCloneAsDraft));
+
+  return app;
+}
+
+// -----------------------------------------------------------------------------
+// Demo runner
+// -----------------------------------------------------------------------------
+
+async function setupSchema(): Promise<void> {
+  await db.run(sql`
+    CREATE TABLE IF NOT EXISTS articles (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      body TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'draft',
+      publishedAt TEXT,
+      deletedAt TEXT
+    )
+  `);
+  await db.run(sql`DELETE FROM articles`);
+}
+
+interface OkBody<T> {
+  success: true;
+  result: T;
+}
+
+interface ErrBody {
+  success: false;
+  error: { message: string };
+}
+
+type Article = z.infer<typeof ArticleSchema>;
+
+function check(label: string, condition: boolean, detail?: string): void {
+  if (!condition) {
+    console.error(`  FAIL: ${label}${detail ? ` — ${detail}` : ''}`);
+    throw new Error(`Scenario "${label}" failed`);
+  }
+  console.log(`  PASS: ${label}`);
+}
+
+async function runDemo(): Promise<void> {
+  await setupSchema();
+  const app = buildApp();
+
+  // -------------------------------------------------------------------------
+  // Seed
+  // -------------------------------------------------------------------------
+  console.log('\n[seed] inserting source articles');
+  const sourceId = crypto.randomUUID();
+  await db.insert(articlesTable).values({
+    id: sourceId,
+    title: 'On Composition',
+    body: 'Reuse beats reinvention.',
+    status: 'published',
+    publishedAt: '2026-05-01T10:00:00.000Z',
+  });
+
+  // -------------------------------------------------------------------------
+  // 1. Basic clone
+  // -------------------------------------------------------------------------
+  console.log('\n[1] clone with empty body — fresh PK, data copied');
+  {
+    const res = await app.request(`/articles/${sourceId}/clone`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    check('status 201', res.status === 201, `got ${res.status}`);
+    const body = (await res.json()) as OkBody<Article>;
+    check('success flag', body.success === true);
+    check('fresh primary key', body.result.id !== sourceId, `clone id ${body.result.id} === source ${sourceId}`);
+    check('title copied', body.result.title === 'On Composition');
+    check('body copied', body.result.body === 'Reuse beats reinvention.');
+    check('publishedAt copied', body.result.publishedAt === '2026-05-01T10:00:00.000Z');
+  }
+
+  // -------------------------------------------------------------------------
+  // 2. Body overrides
+  // -------------------------------------------------------------------------
+  console.log('\n[2] clone with body overrides — body wins');
+  {
+    const res = await app.request(`/articles/${sourceId}/clone`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: 'On Composition (Translated)',
+        status: 'draft',
+      }),
+    });
+    check('status 201', res.status === 201, `got ${res.status}`);
+    const body = (await res.json()) as OkBody<Article>;
+    check('title overridden', body.result.title === 'On Composition (Translated)');
+    check('status overridden', body.result.status === 'draft');
+    check('body fallback to source', body.result.body === 'Reuse beats reinvention.');
+  }
+
+  // -------------------------------------------------------------------------
+  // 3. excludeFromClone — strip publishedAt + status, body provides defaults
+  // -------------------------------------------------------------------------
+  console.log('\n[3] clone-as-draft — excludeFromClone strips publishedAt + status');
+  {
+    const res = await app.request(`/articles/${sourceId}/clone-as-draft`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    check('status 201', res.status === 201, `got ${res.status}`);
+    const body = (await res.json()) as OkBody<Article>;
+    check('publishedAt stripped (null)', body.result.publishedAt === null || body.result.publishedAt === undefined);
+    // status was excluded → falls back to schema default 'draft'
+    check('status reset to draft', body.result.status === 'draft', `got ${body.result.status}`);
+    check('title still copied', body.result.title === 'On Composition');
+  }
+
+  // -------------------------------------------------------------------------
+  // 4. Source not found
+  // -------------------------------------------------------------------------
+  console.log('\n[4] clone unknown id → 404');
+  {
+    const res = await app.request(`/articles/${crypto.randomUUID()}/clone`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    check('status 404', res.status === 404, `got ${res.status}`);
+    const body = (await res.json()) as ErrBody;
+    check('error message mentions not found', /not found/i.test(body.error.message), body.error.message);
+  }
+
+  // -------------------------------------------------------------------------
+  // 5. Soft-deleted source
+  // -------------------------------------------------------------------------
+  console.log('\n[5] clone soft-deleted source → 404');
+  {
+    const softId = crypto.randomUUID();
+    await db.insert(articlesTable).values({
+      id: softId,
+      title: 'Tombstoned',
+      body: 'Already gone.',
+      status: 'archived',
+      deletedAt: new Date().toISOString(),
+    });
+    const res = await app.request(`/articles/${softId}/clone`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    check('status 404', res.status === 404, `got ${res.status}`);
+  }
+
+  // -------------------------------------------------------------------------
+  // 6. Original record remains intact in DB
+  // -------------------------------------------------------------------------
+  console.log('\n[6] original source row untouched after all clones');
+  {
+    const original = await db.select().from(articlesTable).where(sql`id = ${sourceId}`);
+    check('source row still exists', original.length === 1);
+    check('source title unchanged', original[0]?.title === 'On Composition');
+    check('source publishedAt unchanged', original[0]?.publishedAt === '2026-05-01T10:00:00.000Z');
+  }
+
+  // -------------------------------------------------------------------------
+  // Final: count of rows in the table.
+  // -------------------------------------------------------------------------
+  const all = await db.select().from(articlesTable);
+  console.log(`\n[done] ${all.length} rows in 'articles' (1 seed + 3 clones + 1 soft-deleted = 5)`);
+}
+
+// Auto-run when invoked directly (tsx examples/drizzle/clone.ts).
+const invokedDirectly =
+  typeof process !== 'undefined' &&
+  Array.isArray(process.argv) &&
+  process.argv[1]?.endsWith('clone.ts');
+
+if (invokedDirectly) {
+  runDemo()
+    .then(() => {
+      console.log('\n✓ all clone scenarios passed');
+      process.exit(0);
+    })
+    .catch((err) => {
+      console.error('\n✗ demo failed:', err instanceof Error ? err.message : err);
+      process.exit(1);
+    });
+}
+
+export { runDemo, ArticleClone, ArticleCloneAsDraft };

--- a/examples/drizzle/comprehensive.ts
+++ b/examples/drizzle/comprehensive.ts
@@ -31,6 +31,7 @@ import {
   DrizzleBatchDeleteEndpoint,
   DrizzleBatchRestoreEndpoint,
   DrizzleUpsertEndpoint,
+  DrizzleCloneEndpoint,
   type DrizzleDatabase,
 } from '../../src/adapters/drizzle/index.js';
 import {
@@ -203,6 +204,21 @@ class UserBatchRestore extends DrizzleBatchRestoreEndpoint {
   maxBatchSize = 100;
 }
 
+class UserClone extends DrizzleCloneEndpoint {
+  _meta = userMeta;
+  db = typedDb;
+  schema = {
+    tags: ['Users'],
+    summary: 'Clone a user',
+    description:
+      'Duplicates the source user, generating a fresh primary key. ' +
+      'The body must supply a unique `email` (the column has a UNIQUE constraint); ' +
+      'name/role/age/status default to the source row unless overridden in the body. ' +
+      '`createdAt`, `updatedAt`, and `deletedAt` are stripped so the new row picks up DB defaults.',
+  };
+  excludeFromClone = ['createdAt', 'updatedAt', 'deletedAt'];
+}
+
 // ============================================================================
 // Post Endpoints
 // ============================================================================
@@ -342,7 +358,7 @@ class CategoryUpsert extends DrizzleUpsertEndpoint {
 
 export const app = fromHono(new Hono());
 
-// Users (full CRUD + batch)
+// Users (full CRUD + batch + clone)
 registerCrud(app, '/users', {
   create: UserCreate,
   list: UserList,
@@ -354,6 +370,7 @@ registerCrud(app, '/users', {
   batchUpdate: UserBatchUpdate,
   batchDelete: UserBatchDelete,
   batchRestore: UserBatchRestore,
+  clone: UserClone,
 });
 
 // Posts

--- a/examples/prisma/comprehensive.ts
+++ b/examples/prisma/comprehensive.ts
@@ -33,6 +33,7 @@ import {
   PrismaBatchDeleteEndpoint,
   PrismaBatchRestoreEndpoint,
   PrismaUpsertEndpoint,
+  PrismaCloneEndpoint,
 } from '../../src/adapters/prisma/index.js';
 import {
   UserSchema,
@@ -196,6 +197,21 @@ class UserBatchRestore extends PrismaBatchRestoreEndpoint {
   maxBatchSize = 100;
 }
 
+class UserClone extends PrismaCloneEndpoint {
+  _meta = userMeta;
+  prisma = prisma;
+  schema = {
+    tags: ['Users'],
+    summary: 'Clone a user',
+    description:
+      'Duplicates the source user, generating a fresh primary key. ' +
+      'The body must supply a unique `email` (the column has a UNIQUE constraint); ' +
+      'name/role/age/status default to the source row unless overridden in the body. ' +
+      '`createdAt`, `updatedAt`, and `deletedAt` are stripped so the new row picks up DB defaults.',
+  };
+  excludeFromClone = ['createdAt', 'updatedAt', 'deletedAt'];
+}
+
 // ============================================================================
 // Post Endpoints
 // ============================================================================
@@ -336,7 +352,7 @@ class CategoryUpsert extends PrismaUpsertEndpoint {
 
 export const app = fromHono(new Hono());
 
-// Users (full CRUD + batch)
+// Users (full CRUD + batch + clone)
 registerCrud(app, '/users', {
   create: UserCreate,
   list: UserList,
@@ -348,6 +364,7 @@ registerCrud(app, '/users', {
   batchUpdate: UserBatchUpdate,
   batchDelete: UserBatchDelete,
   batchRestore: UserBatchRestore,
+  clone: UserClone,
 });
 
 // Posts

--- a/src/adapters/drizzle/advanced.ts
+++ b/src/adapters/drizzle/advanced.ts
@@ -985,27 +985,95 @@ export abstract class DrizzleImportEndpoint<
 }
 
 /**
- * Drizzle Clone endpoint — stub.
+ * Drizzle Clone endpoint.
  *
- * A real Drizzle clone implementation requires per-database conflict semantics
- * for the new record's primary key. Until that lands, instantiating this stub
- * and serving a request throws so misconfiguration is loud rather than silent.
- * Subclass directly and implement `findSource` / `createClone` to ship a real
- * version.
+ * Reads the source row by `lookupField`, lets the base `CloneEndpoint`
+ * strip primary keys + `excludeFromClone` fields and apply body overrides,
+ * then inserts the result with a freshly-generated primary key.
+ *
+ * Soft-deleted source rows are not cloneable — the SELECT predicate adds
+ * `IS NULL` on the soft-delete column when the model has soft-delete
+ * configured.
+ *
+ * Composite-PK note: the base class strips ALL primary keys but this
+ * implementation only fills `primaryKeys[0]` via `generateId()`. Models with
+ * composite primary keys must subclass and override `createClone` to fill the
+ * remaining columns.
+ *
+ * Override `generateId()` to swap UUIDv4 for ULID/snowflake/etc.
  */
 export abstract class DrizzleCloneEndpoint<
   E extends Env = Env,
   M extends MetaInput = MetaInput,
 > extends CloneEndpoint<E, M> {
-  async findSource(): Promise<ModelObject<M['model']> | null> {
-    throw new Error(
-      'DrizzleCloneEndpoint is a stub — subclass and implement findSource()'
-    );
+  /** Drizzle database instance. Can be undefined if using context injection. */
+  db?: DrizzleDatabase;
+
+  /** Gets the database instance from property or context. */
+  protected getDb(): DrizzleDatabase {
+    return getDrizzleDb(this);
   }
 
-  async createClone(): Promise<ModelObject<M['model']>> {
-    throw new Error(
-      'DrizzleCloneEndpoint is a stub — subclass and implement createClone()'
-    );
+  protected getTable(): Table {
+    return getTable(this._meta);
+  }
+
+  protected getColumn(field: string): Column {
+    return getColumn(this.getTable(), field);
+  }
+
+  /** Generates the primary-key value for the cloned row. Defaults to UUIDv4. */
+  protected generateId(): string {
+    return crypto.randomUUID();
+  }
+
+  override async findSource(
+    lookupValue: string,
+    additionalFilters?: Record<string, string>
+  ): Promise<ModelObject<M['model']> | null> {
+    const table = this.getTable();
+    const lookupColumn = this.getColumn(this.lookupField);
+    const softDeleteConfig = this.getSoftDeleteConfig();
+
+    const conditions: SQL[] = [eq(lookupColumn, lookupValue)];
+
+    if (additionalFilters) {
+      for (const [field, value] of Object.entries(additionalFilters)) {
+        conditions.push(eq(this.getColumn(field), value));
+      }
+    }
+
+    if (softDeleteConfig.enabled) {
+      conditions.push(isNull(this.getColumn(softDeleteConfig.field)));
+    }
+
+    const result = await cast(this.getDb())
+      .select()
+      .from(table)
+      .where(and(...conditions))
+      .limit(1);
+
+    if (!result[0]) return null;
+
+    return result[0] as ModelObject<M['model']>;
+  }
+
+  override async createClone(
+    data: ModelObject<M['model']>
+  ): Promise<ModelObject<M['model']>> {
+    const table = this.getTable();
+    const primaryKey = this._meta.model.primaryKeys[0];
+
+    const record = {
+      ...data,
+      [primaryKey]: (data as Record<string, unknown>)[primaryKey] || this.generateId(),
+    };
+
+    const result = await cast(this.getDb())
+      .insert(table)
+      .values(record as Record<string, unknown>)
+      .returning();
+
+    return result[0] as ModelObject<M['model']>;
   }
 }

--- a/src/adapters/drizzle/advanced.ts
+++ b/src/adapters/drizzle/advanced.ts
@@ -3,6 +3,7 @@ import { eq, and, isNull, isNotNull, or, asc, desc, sql } from 'drizzle-orm';
 import type { SQL, Table, Column } from 'drizzle-orm';
 import { UpsertEndpoint } from '../../endpoints/upsert';
 import { BatchUpsertEndpoint } from '../../endpoints/batch-upsert';
+import { CloneEndpoint } from '../../endpoints/clone';
 import {
   VersionHistoryEndpoint,
   VersionReadEndpoint,
@@ -980,5 +981,31 @@ export abstract class DrizzleImportEndpoint<
       .returning();
 
     return result[0] as ModelObject<M['model']>;
+  }
+}
+
+/**
+ * Drizzle Clone endpoint — stub.
+ *
+ * A real Drizzle clone implementation requires per-database conflict semantics
+ * for the new record's primary key. Until that lands, instantiating this stub
+ * and serving a request throws so misconfiguration is loud rather than silent.
+ * Subclass directly and implement `findSource` / `createClone` to ship a real
+ * version.
+ */
+export abstract class DrizzleCloneEndpoint<
+  E extends Env = Env,
+  M extends MetaInput = MetaInput,
+> extends CloneEndpoint<E, M> {
+  async findSource(): Promise<ModelObject<M['model']> | null> {
+    throw new Error(
+      'DrizzleCloneEndpoint is a stub — subclass and implement findSource()'
+    );
+  }
+
+  async createClone(): Promise<ModelObject<M['model']>> {
+    throw new Error(
+      'DrizzleCloneEndpoint is a stub — subclass and implement createClone()'
+    );
   }
 }

--- a/src/adapters/drizzle/index.ts
+++ b/src/adapters/drizzle/index.ts
@@ -27,3 +27,59 @@ export {
   isDrizzleZodAvailable,
 } from './schema-utils';
 export type { DrizzleSchemas } from './schema-utils';
+
+import type { AdapterBundle } from '../../config/index';
+import {
+  DrizzleCreateEndpoint,
+  DrizzleListEndpoint,
+  DrizzleReadEndpoint,
+  DrizzleUpdateEndpoint,
+  DrizzleDeleteEndpoint,
+  DrizzleRestoreEndpoint,
+} from './crud';
+import {
+  DrizzleBatchCreateEndpoint,
+  DrizzleBatchUpdateEndpoint,
+  DrizzleBatchDeleteEndpoint,
+  DrizzleBatchRestoreEndpoint,
+} from './batch';
+import {
+  DrizzleSearchEndpoint,
+  DrizzleAggregateEndpoint,
+  DrizzleExportEndpoint,
+  DrizzleImportEndpoint,
+  DrizzleUpsertEndpoint,
+  DrizzleBatchUpsertEndpoint,
+  DrizzleCloneEndpoint,
+} from './advanced';
+
+/**
+ * Drizzle adapter bundle for use with `defineEndpoints`.
+ *
+ * Populates the 11 verbs Drizzle implements natively plus a stub
+ * `CloneEndpoint` (throws on request — subclass to implement).
+ *
+ * @example
+ * ```ts
+ * const endpoints = defineEndpoints({ meta, create: {}, search: { fields: ['name'] } }, DrizzleAdapters);
+ * ```
+ */
+export const DrizzleAdapters: AdapterBundle = {
+  CreateEndpoint: DrizzleCreateEndpoint,
+  ListEndpoint: DrizzleListEndpoint,
+  ReadEndpoint: DrizzleReadEndpoint,
+  UpdateEndpoint: DrizzleUpdateEndpoint,
+  DeleteEndpoint: DrizzleDeleteEndpoint,
+  RestoreEndpoint: DrizzleRestoreEndpoint,
+  BatchCreateEndpoint: DrizzleBatchCreateEndpoint,
+  BatchUpdateEndpoint: DrizzleBatchUpdateEndpoint,
+  BatchDeleteEndpoint: DrizzleBatchDeleteEndpoint,
+  BatchRestoreEndpoint: DrizzleBatchRestoreEndpoint,
+  BatchUpsertEndpoint: DrizzleBatchUpsertEndpoint,
+  SearchEndpoint: DrizzleSearchEndpoint,
+  AggregateEndpoint: DrizzleAggregateEndpoint,
+  ExportEndpoint: DrizzleExportEndpoint,
+  ImportEndpoint: DrizzleImportEndpoint,
+  UpsertEndpoint: DrizzleUpsertEndpoint,
+  CloneEndpoint: DrizzleCloneEndpoint,
+};

--- a/src/adapters/prisma/advanced.ts
+++ b/src/adapters/prisma/advanced.ts
@@ -1,5 +1,6 @@
 import type { Env } from 'hono';
 import { UpsertEndpoint } from '../../endpoints/upsert';
+import { CloneEndpoint } from '../../endpoints/clone';
 import {
   VersionHistoryEndpoint,
   VersionReadEndpoint,
@@ -860,5 +861,31 @@ export abstract class PrismaAggregateEndpoint<
       const records = await model.findMany({ where });
       return computeAggregations(records as Record<string, unknown>[], options);
     }
+  }
+}
+
+/**
+ * Prisma Clone endpoint — stub.
+ *
+ * A real Prisma clone implementation requires per-model conflict semantics for
+ * the new record's primary key. Until that lands, instantiating this stub and
+ * serving a request throws so misconfiguration is loud rather than silent.
+ * Subclass directly and implement `findSource` / `createClone` to ship a real
+ * version.
+ */
+export abstract class PrismaCloneEndpoint<
+  E extends Env = Env,
+  M extends MetaInput = MetaInput,
+> extends CloneEndpoint<E, M> {
+  async findSource(): Promise<ModelObject<M['model']> | null> {
+    throw new Error(
+      'PrismaCloneEndpoint is a stub — subclass and implement findSource()'
+    );
+  }
+
+  async createClone(): Promise<ModelObject<M['model']>> {
+    throw new Error(
+      'PrismaCloneEndpoint is a stub — subclass and implement createClone()'
+    );
   }
 }

--- a/src/adapters/prisma/advanced.ts
+++ b/src/adapters/prisma/advanced.ts
@@ -865,27 +865,71 @@ export abstract class PrismaAggregateEndpoint<
 }
 
 /**
- * Prisma Clone endpoint — stub.
+ * Prisma Clone endpoint.
  *
- * A real Prisma clone implementation requires per-model conflict semantics for
- * the new record's primary key. Until that lands, instantiating this stub and
- * serving a request throws so misconfiguration is loud rather than silent.
- * Subclass directly and implement `findSource` / `createClone` to ship a real
- * version.
+ * Reads the source row by `lookupField`, lets the base `CloneEndpoint`
+ * strip primary keys + `excludeFromClone` fields and apply body overrides,
+ * then inserts the result with a freshly-generated primary key.
+ *
+ * Soft-deleted source rows are not cloneable — the WHERE clause adds a
+ * `<field>: null` predicate when the model has soft-delete configured.
+ *
+ * Composite-PK note: the base class strips ALL primary keys but this
+ * implementation only fills `primaryKeys[0]` via `generateId()`. Models with
+ * composite primary keys must subclass and override `createClone` to fill the
+ * remaining columns.
+ *
+ * Override `generateId()` to swap UUIDv4 for ULID/snowflake/etc.
  */
 export abstract class PrismaCloneEndpoint<
   E extends Env = Env,
   M extends MetaInput = MetaInput,
 > extends CloneEndpoint<E, M> {
-  async findSource(): Promise<ModelObject<M['model']> | null> {
-    throw new Error(
-      'PrismaCloneEndpoint is a stub — subclass and implement findSource()'
-    );
+  abstract prisma: PrismaClient;
+
+  protected async getModel(): Promise<PrismaModelOperations> {
+    return getPrismaModel(this.prisma, this._meta.model.tableName);
   }
 
-  async createClone(): Promise<ModelObject<M['model']>> {
-    throw new Error(
-      'PrismaCloneEndpoint is a stub — subclass and implement createClone()'
-    );
+  /** Generates the primary-key value for the cloned row. Defaults to UUIDv4. */
+  protected generateId(): string {
+    return crypto.randomUUID();
+  }
+
+  override async findSource(
+    lookupValue: string,
+    additionalFilters?: Record<string, string>
+  ): Promise<ModelObject<M['model']> | null> {
+    const model = await this.getModel();
+    const softDeleteConfig = this.getSoftDeleteConfig();
+
+    const where: Record<string, unknown> = {
+      [this.lookupField]: lookupValue,
+      ...additionalFilters,
+    };
+
+    if (softDeleteConfig.enabled) {
+      where[softDeleteConfig.field] = null;
+    }
+
+    const result = await model.findFirst({ where });
+    if (!result) return null;
+
+    return result as ModelObject<M['model']>;
+  }
+
+  override async createClone(
+    data: ModelObject<M['model']>
+  ): Promise<ModelObject<M['model']>> {
+    const model = await this.getModel();
+    const primaryKey = this._meta.model.primaryKeys[0];
+
+    const record = {
+      ...data,
+      [primaryKey]: (data as Record<string, unknown>)[primaryKey] || this.generateId(),
+    };
+
+    const result = await model.create({ data: record });
+    return result as ModelObject<M['model']>;
   }
 }

--- a/src/adapters/prisma/index.ts
+++ b/src/adapters/prisma/index.ts
@@ -6,3 +6,59 @@ export {
 export * from './crud';
 export * from './batch';
 export * from './advanced';
+
+import type { AdapterBundle } from '../../config/index';
+import {
+  PrismaCreateEndpoint,
+  PrismaListEndpoint,
+  PrismaReadEndpoint,
+  PrismaUpdateEndpoint,
+  PrismaDeleteEndpoint,
+} from './crud';
+import {
+  PrismaRestoreEndpoint,
+  PrismaBatchCreateEndpoint,
+  PrismaBatchUpdateEndpoint,
+  PrismaBatchDeleteEndpoint,
+  PrismaBatchRestoreEndpoint,
+  PrismaBatchUpsertEndpoint,
+} from './batch';
+import {
+  PrismaSearchEndpoint,
+  PrismaAggregateEndpoint,
+  PrismaExportEndpoint,
+  PrismaImportEndpoint,
+  PrismaUpsertEndpoint,
+  PrismaCloneEndpoint,
+} from './advanced';
+
+/**
+ * Prisma adapter bundle for use with `defineEndpoints`.
+ *
+ * Populates the 11 verbs Prisma implements natively plus a stub
+ * `CloneEndpoint` (throws on request — subclass to implement).
+ *
+ * @example
+ * ```ts
+ * const endpoints = defineEndpoints({ meta, create: {}, search: { fields: ['name'] } }, PrismaAdapters);
+ * ```
+ */
+export const PrismaAdapters: AdapterBundle = {
+  CreateEndpoint: PrismaCreateEndpoint,
+  ListEndpoint: PrismaListEndpoint,
+  ReadEndpoint: PrismaReadEndpoint,
+  UpdateEndpoint: PrismaUpdateEndpoint,
+  DeleteEndpoint: PrismaDeleteEndpoint,
+  RestoreEndpoint: PrismaRestoreEndpoint,
+  BatchCreateEndpoint: PrismaBatchCreateEndpoint,
+  BatchUpdateEndpoint: PrismaBatchUpdateEndpoint,
+  BatchDeleteEndpoint: PrismaBatchDeleteEndpoint,
+  BatchRestoreEndpoint: PrismaBatchRestoreEndpoint,
+  BatchUpsertEndpoint: PrismaBatchUpsertEndpoint,
+  SearchEndpoint: PrismaSearchEndpoint,
+  AggregateEndpoint: PrismaAggregateEndpoint,
+  ExportEndpoint: PrismaExportEndpoint,
+  ImportEndpoint: PrismaImportEndpoint,
+  UpsertEndpoint: PrismaUpsertEndpoint,
+  CloneEndpoint: PrismaCloneEndpoint,
+};

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -49,6 +49,18 @@ import {
   MemoryReadEndpoint,
   MemoryUpdateEndpoint,
   MemoryDeleteEndpoint,
+  MemoryRestoreEndpoint,
+  MemoryBatchCreateEndpoint,
+  MemoryBatchUpdateEndpoint,
+  MemoryBatchDeleteEndpoint,
+  MemoryBatchRestoreEndpoint,
+  MemoryBatchUpsertEndpoint,
+  MemorySearchEndpoint,
+  MemoryAggregateEndpoint,
+  MemoryExportEndpoint,
+  MemoryImportEndpoint,
+  MemoryUpsertEndpoint,
+  MemoryCloneEndpoint,
 } from '../adapters/memory/index';
 
 // ============================================================================
@@ -250,6 +262,236 @@ export interface DeleteEndpointConfig<M extends MetaInput> {
   hooks?: DeleteHooks<M>;
 }
 
+// ----------------------------------------------------------------------------
+// Extended-verb endpoint configs (search, aggregate, restore, batch.*, export,
+// import, upsert, clone). All optional via EndpointsConfig<M>; the dispatch
+// arms below only fire when the slot is present.
+// ----------------------------------------------------------------------------
+
+/**
+ * Search endpoint hooks.
+ *
+ * The dedicated `/search` endpoint (SearchEndpoint) is read-only and only
+ * supports an `after` callback for post-processing results.
+ */
+interface SearchHooks<M extends MetaInput> {
+  after?: (items: ModelObject<M['model']>[]) => Promise<ModelObject<M['model']>[]> | ModelObject<M['model']>[];
+}
+
+/**
+ * Search endpoint configuration.
+ *
+ * Note: `paramName` is reserved in the briefed shape but not currently wired —
+ * the SearchEndpoint reads its query from a fixed `q` param. Override via a
+ * subclass for now; first-class config will follow if there's demand.
+ */
+export interface SearchEndpointConfig<M extends MetaInput> {
+  openapi?: OpenAPIConfig;
+  /** Fields included in the search index (maps to SearchEndpoint.searchFields). */
+  fields?: string[];
+  /** Reserved — currently unused; SearchEndpoint reads `q` by default. */
+  paramName?: string;
+  /** Default search mode: 'any' | 'all' | 'phrase'. Maps to SearchEndpoint.defaultMode. */
+  mode?: 'any' | 'all' | 'phrase';
+  hooks?: SearchHooks<M>;
+}
+
+/**
+ * Aggregate endpoint hooks.
+ */
+interface AggregateHooks {
+  after?: (result: unknown) => Promise<unknown> | unknown;
+}
+
+/**
+ * Aggregate endpoint configuration.
+ */
+export interface AggregateEndpointConfig<_M extends MetaInput> {
+  openapi?: OpenAPIConfig;
+  /** Fields the client may filter aggregations by (maps to AggregateEndpoint.filterFields). */
+  fields?: string[];
+  hooks?: AggregateHooks;
+}
+
+/**
+ * Restore endpoint hooks.
+ */
+interface RestoreHooks<M extends MetaInput> extends HookConfig {
+  before?: (lookupValue: string, tx?: unknown) => Promise<void> | void;
+  after?: (restoredItem: ModelObject<M['model']>, tx?: unknown) => Promise<void> | void;
+}
+
+/**
+ * Restore endpoint configuration.
+ */
+export interface RestoreEndpointConfig<M extends MetaInput> {
+  openapi?: OpenAPIConfig;
+  hooks?: RestoreHooks<M>;
+}
+
+/**
+ * Batch-create endpoint hooks.
+ */
+interface BatchCreateHooks<M extends MetaInput> extends HookConfig {
+  before?: (data: ModelObject<M['model']>[], tx?: unknown) => Promise<ModelObject<M['model']>[]> | ModelObject<M['model']>[];
+  after?: (data: ModelObject<M['model']>[], tx?: unknown) => Promise<ModelObject<M['model']>[]> | ModelObject<M['model']>[];
+}
+
+/**
+ * Batch-create endpoint configuration.
+ */
+export interface BatchCreateEndpointConfig<M extends MetaInput> {
+  openapi?: OpenAPIConfig;
+  hooks?: BatchCreateHooks<M>;
+  bodySchema?: ZodObject<ZodRawShape>;
+  maxBatchSize?: number;
+}
+
+/**
+ * Batch-update endpoint hooks.
+ */
+interface BatchUpdateHooks<M extends MetaInput> extends HookConfig {
+  before?: (data: Partial<ModelObject<M['model']>>[], tx?: unknown) => Promise<Partial<ModelObject<M['model']>>[]> | Partial<ModelObject<M['model']>>[];
+  after?: (data: ModelObject<M['model']>[], tx?: unknown) => Promise<ModelObject<M['model']>[]> | ModelObject<M['model']>[];
+}
+
+/**
+ * Batch-update endpoint configuration.
+ */
+export interface BatchUpdateEndpointConfig<M extends MetaInput> {
+  openapi?: OpenAPIConfig;
+  hooks?: BatchUpdateHooks<M>;
+  maxBatchSize?: number;
+}
+
+/**
+ * Batch-delete endpoint hooks.
+ */
+interface BatchDeleteHooks<M extends MetaInput> extends HookConfig {
+  before?: (lookupValues: string[], tx?: unknown) => Promise<void> | void;
+  after?: (deletedItems: ModelObject<M['model']>[], tx?: unknown) => Promise<void> | void;
+}
+
+/**
+ * Batch-delete endpoint configuration.
+ */
+export interface BatchDeleteEndpointConfig<M extends MetaInput> {
+  openapi?: OpenAPIConfig;
+  hooks?: BatchDeleteHooks<M>;
+  maxBatchSize?: number;
+}
+
+/**
+ * Batch-restore endpoint hooks.
+ */
+interface BatchRestoreHooks<M extends MetaInput> extends HookConfig {
+  before?: (lookupValues: string[], tx?: unknown) => Promise<void> | void;
+  after?: (restoredItems: ModelObject<M['model']>[], tx?: unknown) => Promise<void> | void;
+}
+
+/**
+ * Batch-restore endpoint configuration.
+ */
+export interface BatchRestoreEndpointConfig<M extends MetaInput> {
+  openapi?: OpenAPIConfig;
+  hooks?: BatchRestoreHooks<M>;
+  maxBatchSize?: number;
+}
+
+/**
+ * Batch-upsert endpoint hooks.
+ */
+interface BatchUpsertHooks<M extends MetaInput> extends HookConfig {
+  before?: (data: ModelObject<M['model']>[], tx?: unknown) => Promise<ModelObject<M['model']>[]> | ModelObject<M['model']>[];
+  after?: (data: ModelObject<M['model']>[], tx?: unknown) => Promise<ModelObject<M['model']>[]> | ModelObject<M['model']>[];
+}
+
+/**
+ * Batch-upsert endpoint configuration.
+ */
+export interface BatchUpsertEndpointConfig<M extends MetaInput> {
+  openapi?: OpenAPIConfig;
+  hooks?: BatchUpsertHooks<M>;
+  bodySchema?: ZodObject<ZodRawShape>;
+  /** Conflict-target column(s) for the upsert. String is normalized to single-element array. */
+  conflictTarget?: string | string[];
+  maxBatchSize?: number;
+}
+
+/**
+ * Export endpoint configuration.
+ *
+ * Note: `formats` is accepted as a whitelist hint but only the first element
+ * is wired through to `defaultFormat`. Full whitelist semantics (rejecting
+ * non-listed formats) require an `allowedFormats` field on ExportEndpoint —
+ * deferred.
+ */
+export interface ExportEndpointConfig<_M extends MetaInput> {
+  openapi?: OpenAPIConfig;
+  formats?: ('csv' | 'json')[];
+  /** Maximum rows to export (maps to ExportEndpoint.maxExportRecords). */
+  maxRows?: number;
+}
+
+/**
+ * Import endpoint hooks.
+ *
+ * Hook callbacks delegate via `super.before/after`; ImportEndpoint does not
+ * declare hook-mode protected fields, so `beforeMode`/`afterMode` are not part
+ * of this surface.
+ */
+interface ImportHooks<M extends MetaInput> {
+  before?: (rows: ModelObject<M['model']>[], tx?: unknown) => Promise<ModelObject<M['model']>[]> | ModelObject<M['model']>[];
+  after?: (rows: ModelObject<M['model']>[], tx?: unknown) => Promise<ModelObject<M['model']>[]> | ModelObject<M['model']>[];
+}
+
+/**
+ * Import endpoint configuration.
+ */
+export interface ImportEndpointConfig<M extends MetaInput> {
+  openapi?: OpenAPIConfig;
+  hooks?: ImportHooks<M>;
+  /** Maximum rows accepted per request (maps to ImportEndpoint.maxBatchSize). */
+  maxRows?: number;
+}
+
+/**
+ * Upsert endpoint hooks.
+ */
+interface UpsertHooks<M extends MetaInput> extends HookConfig {
+  before?: (data: ModelObject<M['model']>, tx?: unknown) => Promise<ModelObject<M['model']>> | ModelObject<M['model']>;
+  after?: (data: ModelObject<M['model']>, tx?: unknown) => Promise<ModelObject<M['model']>> | ModelObject<M['model']>;
+}
+
+/**
+ * Upsert endpoint configuration.
+ */
+export interface UpsertEndpointConfig<M extends MetaInput> {
+  openapi?: OpenAPIConfig;
+  hooks?: UpsertHooks<M>;
+  bodySchema?: ZodObject<ZodRawShape>;
+  /** Conflict-target column(s) for the upsert. String is normalized to single-element array. */
+  conflictTarget?: string | string[];
+}
+
+/**
+ * Clone endpoint hooks.
+ */
+interface CloneHooks<M extends MetaInput> {
+  before?: (sourceId: string, tx?: unknown) => Promise<void> | void;
+  after?: (cloned: ModelObject<M['model']>, tx?: unknown) => Promise<void> | void;
+}
+
+/**
+ * Clone endpoint configuration.
+ */
+export interface CloneEndpointConfig<M extends MetaInput> {
+  openapi?: OpenAPIConfig;
+  hooks?: CloneHooks<M>;
+  /** Field names to strip from the cloned record (maps to CloneEndpoint.excludeFromClone). */
+  fieldsToReset?: string[];
+}
+
 /**
  * Complete endpoints configuration object.
  */
@@ -266,6 +508,30 @@ export interface EndpointsConfig<M extends MetaInput> {
   update?: UpdateEndpointConfig<M>;
   /** Delete endpoint configuration */
   delete?: DeleteEndpointConfig<M>;
+  /** Search endpoint configuration */
+  search?: SearchEndpointConfig<M>;
+  /** Aggregate endpoint configuration */
+  aggregate?: AggregateEndpointConfig<M>;
+  /** Restore endpoint configuration (un-delete soft-deleted records) */
+  restore?: RestoreEndpointConfig<M>;
+  /** Batch-create endpoint configuration */
+  batchCreate?: BatchCreateEndpointConfig<M>;
+  /** Batch-update endpoint configuration */
+  batchUpdate?: BatchUpdateEndpointConfig<M>;
+  /** Batch-delete endpoint configuration */
+  batchDelete?: BatchDeleteEndpointConfig<M>;
+  /** Batch-restore endpoint configuration */
+  batchRestore?: BatchRestoreEndpointConfig<M>;
+  /** Batch-upsert endpoint configuration */
+  batchUpsert?: BatchUpsertEndpointConfig<M>;
+  /** Export endpoint configuration */
+  export?: ExportEndpointConfig<M>;
+  /** Import endpoint configuration */
+  import?: ImportEndpointConfig<M>;
+  /** Upsert endpoint configuration */
+  upsert?: UpsertEndpointConfig<M>;
+  /** Clone endpoint configuration */
+  clone?: CloneEndpointConfig<M>;
 }
 
 /**
@@ -277,6 +543,20 @@ export interface AdapterBundle<E extends Env = Env> {
   ReadEndpoint: abstract new () => OpenAPIRoute<E>;
   UpdateEndpoint: abstract new () => OpenAPIRoute<E>;
   DeleteEndpoint: abstract new () => OpenAPIRoute<E>;
+  // Optional extended-verb slots — adapters populate what they implement;
+  // dispatch arms gate on both `config.<verb>` and adapter presence.
+  SearchEndpoint?: abstract new () => OpenAPIRoute<E>;
+  AggregateEndpoint?: abstract new () => OpenAPIRoute<E>;
+  RestoreEndpoint?: abstract new () => OpenAPIRoute<E>;
+  BatchCreateEndpoint?: abstract new () => OpenAPIRoute<E>;
+  BatchUpdateEndpoint?: abstract new () => OpenAPIRoute<E>;
+  BatchDeleteEndpoint?: abstract new () => OpenAPIRoute<E>;
+  BatchRestoreEndpoint?: abstract new () => OpenAPIRoute<E>;
+  BatchUpsertEndpoint?: abstract new () => OpenAPIRoute<E>;
+  ExportEndpoint?: abstract new () => OpenAPIRoute<E>;
+  ImportEndpoint?: abstract new () => OpenAPIRoute<E>;
+  UpsertEndpoint?: abstract new () => OpenAPIRoute<E>;
+  CloneEndpoint?: abstract new () => OpenAPIRoute<E>;
 }
 
 /**
@@ -288,6 +568,18 @@ export interface GeneratedEndpoints<E extends Env = Env> {
   read?: EndpointClass<E>;
   update?: EndpointClass<E>;
   delete?: EndpointClass<E>;
+  search?: EndpointClass<E>;
+  aggregate?: EndpointClass<E>;
+  restore?: EndpointClass<E>;
+  batchCreate?: EndpointClass<E>;
+  batchUpdate?: EndpointClass<E>;
+  batchDelete?: EndpointClass<E>;
+  batchRestore?: EndpointClass<E>;
+  batchUpsert?: EndpointClass<E>;
+  export?: EndpointClass<E>;
+  import?: EndpointClass<E>;
+  upsert?: EndpointClass<E>;
+  clone?: EndpointClass<E>;
 }
 
 // ============================================================================
@@ -308,6 +600,18 @@ export const MemoryAdapters: AdapterBundle = {
   ReadEndpoint: MemoryReadEndpoint,
   UpdateEndpoint: MemoryUpdateEndpoint,
   DeleteEndpoint: MemoryDeleteEndpoint,
+  SearchEndpoint: MemorySearchEndpoint,
+  AggregateEndpoint: MemoryAggregateEndpoint,
+  RestoreEndpoint: MemoryRestoreEndpoint,
+  BatchCreateEndpoint: MemoryBatchCreateEndpoint,
+  BatchUpdateEndpoint: MemoryBatchUpdateEndpoint,
+  BatchDeleteEndpoint: MemoryBatchDeleteEndpoint,
+  BatchRestoreEndpoint: MemoryBatchRestoreEndpoint,
+  BatchUpsertEndpoint: MemoryBatchUpsertEndpoint,
+  ExportEndpoint: MemoryExportEndpoint,
+  ImportEndpoint: MemoryImportEndpoint,
+  UpsertEndpoint: MemoryUpsertEndpoint,
+  CloneEndpoint: MemoryCloneEndpoint,
 };
 
 // ============================================================================
@@ -447,6 +751,201 @@ export function defineEndpoints<M extends MetaInput, E extends Env = Env>(
       afterHookMode: cfg.hooks?.afterMode,
       before: cfg.hooks?.before as ((...args: unknown[]) => unknown) | undefined,
       after: cfg.hooks?.after as ((...args: unknown[]) => unknown) | undefined,
+    });
+  }
+
+  // ----- Extended-verb dispatch arms -----
+  // Each arm fires only when both the config slot is present AND the adapter
+  // bundle ships the matching endpoint base class.
+
+  // Generate Search endpoint
+  if (config.search !== undefined && adapters.SearchEndpoint) {
+    const cfg = config.search;
+    result.search = generateEndpointClass(adapters.SearchEndpoint, {
+      meta: config.meta,
+      schema: cfg.openapi,
+      after: cfg.hooks?.after as ((...args: unknown[]) => unknown) | undefined,
+      extras: {
+        ...(cfg.fields !== undefined ? { searchFields: cfg.fields } : {}),
+        ...(cfg.mode !== undefined ? { defaultMode: cfg.mode } : {}),
+      },
+    });
+  }
+
+  // Generate Aggregate endpoint
+  if (config.aggregate !== undefined && adapters.AggregateEndpoint) {
+    const cfg = config.aggregate;
+    result.aggregate = generateEndpointClass(adapters.AggregateEndpoint, {
+      meta: config.meta,
+      schema: cfg.openapi,
+      after: cfg.hooks?.after as ((...args: unknown[]) => unknown) | undefined,
+      extras: {
+        ...(cfg.fields !== undefined ? { filterFields: cfg.fields } : {}),
+      },
+    });
+  }
+
+  // Generate Restore endpoint
+  if (config.restore !== undefined && adapters.RestoreEndpoint) {
+    const cfg = config.restore;
+    result.restore = generateEndpointClass(adapters.RestoreEndpoint, {
+      meta: config.meta,
+      schema: cfg.openapi,
+      beforeHookMode: cfg.hooks?.beforeMode,
+      afterHookMode: cfg.hooks?.afterMode,
+      before: cfg.hooks?.before as ((...args: unknown[]) => unknown) | undefined,
+      after: cfg.hooks?.after as ((...args: unknown[]) => unknown) | undefined,
+    });
+  }
+
+  // Generate BatchCreate endpoint
+  if (config.batchCreate !== undefined && adapters.BatchCreateEndpoint) {
+    const cfg = config.batchCreate;
+    result.batchCreate = generateEndpointClass(adapters.BatchCreateEndpoint, {
+      meta: config.meta,
+      schema: cfg.openapi,
+      bodySchema: cfg.bodySchema,
+      beforeHookMode: cfg.hooks?.beforeMode,
+      afterHookMode: cfg.hooks?.afterMode,
+      before: cfg.hooks?.before as ((...args: unknown[]) => unknown) | undefined,
+      after: cfg.hooks?.after as ((...args: unknown[]) => unknown) | undefined,
+      extras: {
+        ...(cfg.maxBatchSize !== undefined ? { maxBatchSize: cfg.maxBatchSize } : {}),
+      },
+    });
+  }
+
+  // Generate BatchUpdate endpoint
+  if (config.batchUpdate !== undefined && adapters.BatchUpdateEndpoint) {
+    const cfg = config.batchUpdate;
+    result.batchUpdate = generateEndpointClass(adapters.BatchUpdateEndpoint, {
+      meta: config.meta,
+      schema: cfg.openapi,
+      beforeHookMode: cfg.hooks?.beforeMode,
+      afterHookMode: cfg.hooks?.afterMode,
+      before: cfg.hooks?.before as ((...args: unknown[]) => unknown) | undefined,
+      after: cfg.hooks?.after as ((...args: unknown[]) => unknown) | undefined,
+      extras: {
+        ...(cfg.maxBatchSize !== undefined ? { maxBatchSize: cfg.maxBatchSize } : {}),
+      },
+    });
+  }
+
+  // Generate BatchDelete endpoint
+  if (config.batchDelete !== undefined && adapters.BatchDeleteEndpoint) {
+    const cfg = config.batchDelete;
+    result.batchDelete = generateEndpointClass(adapters.BatchDeleteEndpoint, {
+      meta: config.meta,
+      schema: cfg.openapi,
+      beforeHookMode: cfg.hooks?.beforeMode,
+      afterHookMode: cfg.hooks?.afterMode,
+      before: cfg.hooks?.before as ((...args: unknown[]) => unknown) | undefined,
+      after: cfg.hooks?.after as ((...args: unknown[]) => unknown) | undefined,
+      extras: {
+        ...(cfg.maxBatchSize !== undefined ? { maxBatchSize: cfg.maxBatchSize } : {}),
+      },
+    });
+  }
+
+  // Generate BatchRestore endpoint
+  if (config.batchRestore !== undefined && adapters.BatchRestoreEndpoint) {
+    const cfg = config.batchRestore;
+    result.batchRestore = generateEndpointClass(adapters.BatchRestoreEndpoint, {
+      meta: config.meta,
+      schema: cfg.openapi,
+      beforeHookMode: cfg.hooks?.beforeMode,
+      afterHookMode: cfg.hooks?.afterMode,
+      before: cfg.hooks?.before as ((...args: unknown[]) => unknown) | undefined,
+      after: cfg.hooks?.after as ((...args: unknown[]) => unknown) | undefined,
+      extras: {
+        ...(cfg.maxBatchSize !== undefined ? { maxBatchSize: cfg.maxBatchSize } : {}),
+      },
+    });
+  }
+
+  // Generate BatchUpsert endpoint
+  if (config.batchUpsert !== undefined && adapters.BatchUpsertEndpoint) {
+    const cfg = config.batchUpsert;
+    const upsertKeys =
+      typeof cfg.conflictTarget === 'string'
+        ? [cfg.conflictTarget]
+        : cfg.conflictTarget;
+    result.batchUpsert = generateEndpointClass(adapters.BatchUpsertEndpoint, {
+      meta: config.meta,
+      schema: cfg.openapi,
+      bodySchema: cfg.bodySchema,
+      beforeHookMode: cfg.hooks?.beforeMode,
+      afterHookMode: cfg.hooks?.afterMode,
+      before: cfg.hooks?.before as ((...args: unknown[]) => unknown) | undefined,
+      after: cfg.hooks?.after as ((...args: unknown[]) => unknown) | undefined,
+      extras: {
+        ...(cfg.maxBatchSize !== undefined ? { maxBatchSize: cfg.maxBatchSize } : {}),
+        ...(upsertKeys !== undefined ? { upsertKeys } : {}),
+      },
+    });
+  }
+
+  // Generate Export endpoint
+  if (config.export !== undefined && adapters.ExportEndpoint) {
+    const cfg = config.export;
+    result.export = generateEndpointClass(adapters.ExportEndpoint, {
+      meta: config.meta,
+      schema: cfg.openapi,
+      extras: {
+        ...(cfg.maxRows !== undefined ? { maxExportRecords: cfg.maxRows } : {}),
+        ...(cfg.formats !== undefined && cfg.formats.length > 0
+          ? { defaultFormat: cfg.formats[0] }
+          : {}),
+      },
+    });
+  }
+
+  // Generate Import endpoint
+  if (config.import !== undefined && adapters.ImportEndpoint) {
+    const cfg = config.import;
+    result.import = generateEndpointClass(adapters.ImportEndpoint, {
+      meta: config.meta,
+      schema: cfg.openapi,
+      before: cfg.hooks?.before as ((...args: unknown[]) => unknown) | undefined,
+      after: cfg.hooks?.after as ((...args: unknown[]) => unknown) | undefined,
+      extras: {
+        ...(cfg.maxRows !== undefined ? { maxBatchSize: cfg.maxRows } : {}),
+      },
+    });
+  }
+
+  // Generate Upsert endpoint
+  if (config.upsert !== undefined && adapters.UpsertEndpoint) {
+    const cfg = config.upsert;
+    const upsertKeys =
+      typeof cfg.conflictTarget === 'string'
+        ? [cfg.conflictTarget]
+        : cfg.conflictTarget;
+    result.upsert = generateEndpointClass(adapters.UpsertEndpoint, {
+      meta: config.meta,
+      schema: cfg.openapi,
+      bodySchema: cfg.bodySchema,
+      beforeHookMode: cfg.hooks?.beforeMode,
+      afterHookMode: cfg.hooks?.afterMode,
+      before: cfg.hooks?.before as ((...args: unknown[]) => unknown) | undefined,
+      after: cfg.hooks?.after as ((...args: unknown[]) => unknown) | undefined,
+      extras: {
+        ...(upsertKeys !== undefined ? { upsertKeys } : {}),
+      },
+    });
+  }
+
+  // Generate Clone endpoint
+  if (config.clone !== undefined && adapters.CloneEndpoint) {
+    const cfg = config.clone;
+    result.clone = generateEndpointClass(adapters.CloneEndpoint, {
+      meta: config.meta,
+      schema: cfg.openapi,
+      before: cfg.hooks?.before as ((...args: unknown[]) => unknown) | undefined,
+      after: cfg.hooks?.after as ((...args: unknown[]) => unknown) | undefined,
+      extras: {
+        ...(cfg.fieldsToReset !== undefined ? { excludeFromClone: cfg.fieldsToReset } : {}),
+      },
     });
   }
 

--- a/src/core/generate-endpoint-class.ts
+++ b/src/core/generate-endpoint-class.ts
@@ -66,6 +66,14 @@ export interface NormalizedEndpointConfig {
   blockedSelectFields?: string[];
   alwaysIncludeFields?: string[];
   defaultSelectFields?: string[];
+
+  // Verb-specific protected field overrides for endpoints whose
+  // configuration shape isn't part of the shared 5-verb surface
+  // (search, aggregate, batch.*, export, import, upsert, clone).
+  // Spread onto the generated subclass instance via Object.assign in
+  // the constructor; absent keys leave the endpoint base-class default
+  // in place.
+  extras?: Record<string, unknown>;
 }
 
 /**
@@ -83,9 +91,18 @@ export function generateEndpointClass<
 >(BaseClass: B, config: NormalizedEndpointConfig): B & (new () => InstanceType<B>) {
   const middlewares = config.middlewares ?? [];
 
+  const extras = config.extras;
+
   // @ts-expect-error - TS cannot resolve members of a dynamically-provided abstract base class (TS#4628)
   const Generated = class extends BaseClass {
     static _middlewares = middlewares;
+
+    constructor() {
+      super();
+      if (extras) {
+        Object.assign(this, extras);
+      }
+    }
 
     _meta = config.meta;
     schema = (config.schema ?? {}) as OpenAPIRouteSchema;

--- a/src/index.ts
+++ b/src/index.ts
@@ -651,12 +651,26 @@ export {
   defineEndpoints,
   MemoryAdapters,
 } from './config/index';
+export { DrizzleAdapters } from './adapters/drizzle/index';
+export { PrismaAdapters } from './adapters/prisma/index';
 export type {
   CreateEndpointConfig as ConfigCreateEndpoint,
   ListEndpointConfig as ConfigListEndpoint,
   ReadEndpointConfig as ConfigReadEndpoint,
   UpdateEndpointConfig as ConfigUpdateEndpoint,
   DeleteEndpointConfig as ConfigDeleteEndpoint,
+  SearchEndpointConfig as ConfigSearchEndpoint,
+  AggregateEndpointConfig as ConfigAggregateEndpoint,
+  RestoreEndpointConfig as ConfigRestoreEndpoint,
+  BatchCreateEndpointConfig as ConfigBatchCreateEndpoint,
+  BatchUpdateEndpointConfig as ConfigBatchUpdateEndpoint,
+  BatchDeleteEndpointConfig as ConfigBatchDeleteEndpoint,
+  BatchRestoreEndpointConfig as ConfigBatchRestoreEndpoint,
+  BatchUpsertEndpointConfig as ConfigBatchUpsertEndpoint,
+  ExportEndpointConfig as ConfigExportEndpoint,
+  ImportEndpointConfig as ConfigImportEndpoint,
+  UpsertEndpointConfig as ConfigUpsertEndpoint,
+  CloneEndpointConfig as ConfigCloneEndpoint,
   EndpointsConfig,
   AdapterBundle,
   GeneratedEndpoints,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,10 +27,13 @@ export type CrudEndpointName =
   | 'batchUpdate'
   | 'batchDelete'
   | 'batchRestore'
+  | 'batchUpsert'
   | 'search'
   | 'aggregate'
   | 'export'
-  | 'import';
+  | 'import'
+  | 'upsert'
+  | 'clone';
 
 /**
  * Per-endpoint middleware configuration.
@@ -69,6 +72,8 @@ export interface CrudEndpoints<E extends Env = Env> {
   batchDelete?: EndpointClass<E>;
   /** Batch restore endpoint for un-deleting multiple soft-deleted records */
   batchRestore?: EndpointClass<E>;
+  /** Batch upsert endpoint for bulk insert-or-update */
+  batchUpsert?: EndpointClass<E>;
   /** Search endpoint for full-text search with relevance scoring */
   search?: EndpointClass<E>;
   /** Aggregate endpoint for computing aggregations */
@@ -77,6 +82,10 @@ export interface CrudEndpoints<E extends Env = Env> {
   export?: EndpointClass<E>;
   /** Import endpoint for bulk data import from CSV/JSON */
   import?: EndpointClass<E>;
+  /** Upsert endpoint for single insert-or-update */
+  upsert?: EndpointClass<E>;
+  /** Clone endpoint for duplicating a record by id */
+  clone?: EndpointClass<E>;
 }
 
 /**
@@ -230,6 +239,10 @@ export function registerCrud<E extends Env = Env>(
     registerRoute('post', `${normalizedPath}/batch/restore`, 'batchRestore', endpoints.batchRestore);
   }
 
+  if (endpoints.batchUpsert) {
+    registerRoute('post', `${normalizedPath}/batch/upsert`, 'batchUpsert', endpoints.batchUpsert);
+  }
+
   // Search endpoint - must be registered BEFORE :id routes
   if (endpoints.search) {
     registerRoute('get', `${normalizedPath}/search`, 'search', endpoints.search);
@@ -250,7 +263,12 @@ export function registerCrud<E extends Env = Env>(
     registerRoute('post', `${normalizedPath}/import`, 'import', endpoints.import);
   }
 
-  // Item-level routes (with :id parameter) - must be registered AFTER /batch, /search, /export, /import routes
+  // Upsert endpoint - must be registered BEFORE :id routes
+  if (endpoints.upsert) {
+    registerRoute('post', `${normalizedPath}/upsert`, 'upsert', endpoints.upsert);
+  }
+
+  // Item-level routes (with :id parameter) - must be registered AFTER /batch, /search, /export, /import, /upsert routes
   if (endpoints.read) {
     registerRoute('get', `${normalizedPath}/:id`, 'read', endpoints.read);
   }
@@ -265,6 +283,10 @@ export function registerCrud<E extends Env = Env>(
 
   if (endpoints.restore) {
     registerRoute('post', `${normalizedPath}/:id/restore`, 'restore', endpoints.restore);
+  }
+
+  if (endpoints.clone) {
+    registerRoute('post', `${normalizedPath}/:id/clone`, 'clone', endpoints.clone);
   }
 }
 

--- a/tests/define-endpoints-widening.test.ts
+++ b/tests/define-endpoints-widening.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import { z } from 'zod';
+import {
+  fromHono,
+  registerCrud,
+  defineEndpoints,
+  MemoryAdapters,
+  defineMeta,
+  defineModel,
+} from '../src/index.js';
+import { clearStorage } from '../src/adapters/memory/index.js';
+
+const WidgetSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  status: z.string().optional(),
+  deletedAt: z.string().nullable().optional(),
+});
+
+const WidgetModel = defineModel({
+  tableName: 'widgets_widening',
+  schema: WidgetSchema,
+  primaryKeys: ['id'],
+  softDelete: true,
+});
+
+const widgetMeta = defineMeta({ model: WidgetModel });
+
+const ALL_VERBS = [
+  'create',
+  'list',
+  'read',
+  'update',
+  'delete',
+  'search',
+  'aggregate',
+  'restore',
+  'batchCreate',
+  'batchUpdate',
+  'batchDelete',
+  'batchRestore',
+  'batchUpsert',
+  'export',
+  'import',
+  'upsert',
+  'clone',
+] as const;
+
+describe('defineEndpoints widening to 17 verbs', () => {
+  beforeEach(() => clearStorage());
+
+  it('generates an endpoint class for every configured verb', () => {
+    const endpoints = defineEndpoints(
+      {
+        meta: widgetMeta,
+        create: {},
+        list: {},
+        read: {},
+        update: {},
+        delete: {},
+        search: { fields: ['name'] },
+        aggregate: { fields: ['id'] },
+        restore: {},
+        batchCreate: { maxBatchSize: 50 },
+        batchUpdate: { maxBatchSize: 50 },
+        batchDelete: { maxBatchSize: 50 },
+        batchRestore: { maxBatchSize: 50 },
+        batchUpsert: { maxBatchSize: 50, conflictTarget: 'id' },
+        export: { formats: ['json'], maxRows: 1000 },
+        import: { maxRows: 1000 },
+        upsert: { conflictTarget: 'id' },
+        clone: { fieldsToReset: ['status'] },
+      },
+      MemoryAdapters,
+    );
+
+    for (const verb of ALL_VERBS) {
+      expect(typeof endpoints[verb]).toBe('function');
+    }
+  });
+
+  it('skips slots not present in the config', () => {
+    const endpoints = defineEndpoints(
+      { meta: widgetMeta, create: {}, list: {} },
+      MemoryAdapters,
+    );
+
+    expect(typeof endpoints.create).toBe('function');
+    expect(typeof endpoints.list).toBe('function');
+    expect(endpoints.search).toBeUndefined();
+    expect(endpoints.aggregate).toBeUndefined();
+    expect(endpoints.restore).toBeUndefined();
+    expect(endpoints.batchCreate).toBeUndefined();
+    expect(endpoints.batchUpsert).toBeUndefined();
+    expect(endpoints.upsert).toBeUndefined();
+    expect(endpoints.clone).toBeUndefined();
+  });
+
+  it('forwards verb-specific config keys onto the generated class instance', () => {
+    const endpoints = defineEndpoints(
+      {
+        meta: widgetMeta,
+        clone: { fieldsToReset: ['status', 'deletedAt'] },
+        upsert: { conflictTarget: 'id' },
+        batchUpsert: { conflictTarget: ['id', 'name'], maxBatchSize: 25 },
+        batchCreate: { maxBatchSize: 7 },
+        export: { formats: ['csv', 'json'], maxRows: 500 },
+        import: { maxRows: 999 },
+        search: { fields: ['name'], mode: 'all' },
+        aggregate: { fields: ['status'] },
+      },
+      MemoryAdapters,
+    );
+
+    type Probe = Record<string, unknown>;
+    const cloneInst = new endpoints.clone!() as unknown as Probe;
+    expect(cloneInst.excludeFromClone).toEqual(['status', 'deletedAt']);
+
+    const upsertInst = new endpoints.upsert!() as unknown as Probe;
+    expect(upsertInst.upsertKeys).toEqual(['id']);
+
+    const batchUpsertInst = new endpoints.batchUpsert!() as unknown as Probe;
+    expect(batchUpsertInst.upsertKeys).toEqual(['id', 'name']);
+    expect(batchUpsertInst.maxBatchSize).toBe(25);
+
+    const batchCreateInst = new endpoints.batchCreate!() as unknown as Probe;
+    expect(batchCreateInst.maxBatchSize).toBe(7);
+
+    const exportInst = new endpoints.export!() as unknown as Probe;
+    expect(exportInst.maxExportRecords).toBe(500);
+    expect(exportInst.defaultFormat).toBe('csv');
+
+    const importInst = new endpoints.import!() as unknown as Probe;
+    expect(importInst.maxBatchSize).toBe(999);
+
+    const searchInst = new endpoints.search!() as unknown as Probe;
+    expect(searchInst.searchFields).toEqual(['name']);
+    expect(searchInst.defaultMode).toBe('all');
+
+    const aggregateInst = new endpoints.aggregate!() as unknown as Probe;
+    expect(aggregateInst.filterFields).toEqual(['status']);
+  });
+
+  it('mounts every verb under registerCrud and the routes do not 5xx', async () => {
+    const endpoints = defineEndpoints(
+      {
+        meta: widgetMeta,
+        create: {},
+        list: {},
+        read: {},
+        update: {},
+        delete: {},
+        search: { fields: ['name'] },
+        aggregate: { fields: ['id'] },
+        restore: {},
+        batchCreate: {},
+        batchUpdate: {},
+        batchDelete: {},
+        batchRestore: {},
+        batchUpsert: { conflictTarget: 'id' },
+        export: {},
+        import: {},
+        upsert: { conflictTarget: 'id' },
+        clone: {},
+      },
+      MemoryAdapters,
+    );
+
+    const app = fromHono(new Hono());
+    registerCrud(app, '/widgets', endpoints);
+
+    // Seed one record so item-level routes have something to operate on.
+    const created = await app.request('/widgets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'first' }),
+    });
+    expect(created.status).toBe(201);
+    const createdJson = (await created.json()) as { result: { id: string } };
+    const seedId = createdJson.result.id;
+
+    type Probe = { method: string; path: string; body?: unknown };
+    const probes: Probe[] = [
+      { method: 'GET', path: '/widgets' },
+      { method: 'GET', path: '/widgets/search?q=first' },
+      { method: 'GET', path: '/widgets/aggregate?aggregations=count' },
+      { method: 'GET', path: '/widgets/export' },
+      { method: 'POST', path: '/widgets/batch', body: { items: [{ name: 'b' }] } },
+      { method: 'PATCH', path: '/widgets/batch', body: { items: [] } },
+      { method: 'DELETE', path: '/widgets/batch', body: { ids: [] } },
+      { method: 'POST', path: '/widgets/batch/restore', body: { ids: [] } },
+      { method: 'POST', path: '/widgets/batch/upsert', body: { items: [{ id: seedId, name: 'updated' }] } },
+      { method: 'POST', path: '/widgets/import', body: { items: [] } },
+      { method: 'POST', path: '/widgets/upsert', body: { id: seedId, name: 'upserted' } },
+      { method: 'GET', path: `/widgets/${seedId}` },
+      { method: 'PATCH', path: `/widgets/${seedId}`, body: { name: 'renamed' } },
+      { method: 'POST', path: `/widgets/${seedId}/clone`, body: {} },
+      { method: 'DELETE', path: `/widgets/${seedId}` },
+      { method: 'POST', path: `/widgets/${seedId}/restore` },
+    ];
+
+    for (const probe of probes) {
+      const init: RequestInit = { method: probe.method };
+      if (probe.body !== undefined) {
+        init.headers = { 'Content-Type': 'application/json' };
+        init.body = JSON.stringify(probe.body);
+      }
+      const res = await app.request(probe.path, init);
+      expect(
+        res.status,
+        `${probe.method} ${probe.path} returned ${res.status}`,
+      ).toBeLessThan(500);
+    }
+  });
+
+  it('routes /upsert as upsert, not as read({ id: "upsert" })', async () => {
+    const endpoints = defineEndpoints(
+      {
+        meta: widgetMeta,
+        read: {},
+        upsert: { conflictTarget: 'id' },
+      },
+      MemoryAdapters,
+    );
+
+    const app = fromHono(new Hono());
+    registerCrud(app, '/widgets', endpoints);
+
+    // GET /widgets/upsert → read handler (id="upsert"), 404 because no record.
+    const readRes = await app.request('/widgets/upsert');
+    expect(readRes.status).toBe(404);
+
+    // POST /widgets/upsert → upsert handler, must not 404 with read's id-not-found shape.
+    const upsertRes = await app.request('/widgets/upsert', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: 'fixed-id', name: 'via upsert' }),
+    });
+    expect(upsertRes.status).toBeLessThan(500);
+    expect(upsertRes.status).not.toBe(404);
+  });
+
+  it('routes /batch/upsert distinct from /batch/{create,update,delete,restore}', async () => {
+    const endpoints = defineEndpoints(
+      {
+        meta: widgetMeta,
+        batchCreate: {},
+        batchUpsert: { conflictTarget: 'id' },
+      },
+      MemoryAdapters,
+    );
+
+    const app = fromHono(new Hono());
+    registerCrud(app, '/widgets', endpoints);
+
+    const upsertRes = await app.request('/widgets/batch/upsert', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ items: [{ id: 'x', name: 'x' }] }),
+    });
+    expect(upsertRes.status).toBeLessThan(500);
+  });
+});

--- a/tests/drizzle.test.ts
+++ b/tests/drizzle.test.ts
@@ -25,6 +25,7 @@ import {
   DrizzleBatchCreateEndpoint,
   DrizzleBatchDeleteEndpoint,
   DrizzleAggregateEndpoint,
+  DrizzleCloneEndpoint,
   type DrizzleDatabase,
 } from '../src/adapters/drizzle/index.js';
 
@@ -164,6 +165,11 @@ class UserBatchDelete extends DrizzleBatchDeleteEndpoint {
   db = db as unknown as DrizzleDatabase;
 }
 
+class UserClone extends DrizzleCloneEndpoint {
+  _meta = { model: UserModel };
+  db = db as unknown as DrizzleDatabase;
+}
+
 class PostCreate extends DrizzleCreateEndpoint {
   _meta = { model: PostModel };
   db = db as unknown as DrizzleDatabase;
@@ -227,6 +233,7 @@ function createApp() {
   app.put('/users/upsert', withContext(UserUpsert));
   app.post('/users/batch', withContext(UserBatchCreate));
   app.post('/users/batch-delete', withContext(UserBatchDelete));
+  app.post('/users/:id/clone', withContext(UserClone));
 
   // Post endpoints
   // Note: aggregate must be before :id to avoid conflict
@@ -639,6 +646,91 @@ describe('Drizzle Adapter', () => {
       const result = await response.json() as { result: { groups: unknown[] } };
 
       expect(result.result.groups).toHaveLength(2);
+    });
+  });
+
+  describe('Clone', () => {
+    it('should clone a record with a fresh primary key, copying source data', async () => {
+      const seed = await db.insert(usersTable).values({
+        id: crypto.randomUUID(),
+        name: 'Clone Source',
+        email: 'source@example.com',
+        role: 'user',
+      }).returning();
+
+      const response = await app.request(`/users/${seed[0].id}/clone`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+
+      expect(response.status).toBe(201);
+      const result = await response.json() as { success: boolean; result: { id: string; name: string; email: string; role: string } };
+      expect(result.success).toBe(true);
+      expect(result.result.id).toBeDefined();
+      expect(result.result.id).not.toBe(seed[0].id);
+      expect(result.result.name).toBe('Clone Source');
+      expect(result.result.email).toBe('source@example.com');
+      expect(result.result.role).toBe('user');
+
+      // Original row remains intact in the database.
+      const all = await db.select().from(usersTable);
+      expect(all).toHaveLength(2);
+    });
+
+    it('applies body overrides on top of the cloned data', async () => {
+      const seed = await db.insert(usersTable).values({
+        id: crypto.randomUUID(),
+        name: 'Original Name',
+        email: 'orig@example.com',
+        role: 'user',
+      }).returning();
+
+      const response = await app.request(`/users/${seed[0].id}/clone`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Override Name', email: 'new@example.com' }),
+      });
+
+      expect(response.status).toBe(201);
+      const result = await response.json() as { success: boolean; result: { name: string; email: string; role: string } };
+      expect(result.result.name).toBe('Override Name');
+      expect(result.result.email).toBe('new@example.com');
+      expect(result.result.role).toBe('user');
+    });
+
+    it('returns NotFound when the source id does not exist', async () => {
+      const response = await app.request(`/users/${crypto.randomUUID()}/clone`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+
+      // The test's app.onError handler converts every error to 400 — the
+      // production error is a NotFoundException (status 404).
+      expect(response.status).toBe(400);
+      const result = await response.json() as { error: { message: string } };
+      expect(result.error.message).toMatch(/not found/i);
+    });
+
+    it('returns NotFound when the source row is soft-deleted', async () => {
+      const seed = await db.insert(usersTable).values({
+        id: crypto.randomUUID(),
+        name: 'Soft Deleted',
+        email: 'sd@example.com',
+        role: 'user',
+        deletedAt: new Date().toISOString(),
+      }).returning();
+
+      const response = await app.request(`/users/${seed[0].id}/clone`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+
+      expect(response.status).toBe(400);
+      const result = await response.json() as { error: { message: string } };
+      expect(result.error.message).toMatch(/not found/i);
     });
   });
 

--- a/tests/examples/db-comprehensive.test.ts
+++ b/tests/examples/db-comprehensive.test.ts
@@ -3,7 +3,7 @@ import { app as drizzleApp } from '../../examples/drizzle/comprehensive';
 import { closeDb as closeDrizzleDb, initDb as initDrizzleDb } from '../../examples/drizzle/db';
 import { app as prismaApp } from '../../examples/prisma/comprehensive';
 import { clearDb as clearPrismaDb, closeDb as closePrismaDb, initDb as initPrismaDb } from '../../examples/prisma/db';
-import { clear, exerciseComprehensiveCrud } from './harness';
+import { clear, exerciseClone, exerciseComprehensiveCrud } from './harness';
 
 describe('database-backed comprehensive examples', () => {
   describe('drizzle postgres example', () => {
@@ -22,6 +22,10 @@ describe('database-backed comprehensive examples', () => {
     it('runs the public CRUD feature flow through the exported app', async () => {
       await exerciseComprehensiveCrud(drizzleApp);
     });
+
+    it('clones a user with body overrides and rejects soft-deleted/missing sources', async () => {
+      await exerciseClone(drizzleApp);
+    });
   });
 
   describe('prisma postgres example', () => {
@@ -39,6 +43,10 @@ describe('database-backed comprehensive examples', () => {
 
     it('runs the public CRUD feature flow through the exported app', async () => {
       await exerciseComprehensiveCrud(prismaApp);
+    });
+
+    it('clones a user with body overrides and rejects soft-deleted/missing sources', async () => {
+      await exerciseClone(prismaApp);
     });
   });
 });

--- a/tests/examples/harness.ts
+++ b/tests/examples/harness.ts
@@ -129,3 +129,76 @@ export async function exerciseComprehensiveCrud(app: ExampleApp): Promise<void> 
   response = await app.request('/openapi.json');
   await expectOk(response);
 }
+
+/**
+ * Exercises the clone endpoint against a comprehensive example app.
+ * Assumes /seed has populated the DB with the standard fixture (alice, bob, charlie).
+ */
+export async function exerciseClone(app: ExampleApp): Promise<void> {
+  await seed(app);
+
+  const sourceUserId = 'a0000000-0000-0000-0000-000000000001';
+
+  // Read the source so we can compare against the clone.
+  let response = await app.request(`/users/${sourceUserId}`);
+  await expectOk(response);
+  const source = await json<SuccessResponse<{ id: string; name: string; email: string; role: string; age?: number }>>(response);
+  expect(source.result.email).toBe('alice@example.com');
+
+  // 1. Basic clone with body override for the unique email + role passthrough.
+  // Note: zod schema defaults on the body (role: .default('user')) clobber the
+  // source value when the field is absent from the request, so callers must
+  // explicitly forward fields they want to preserve from the source.
+  const newEmail = `clone-${crypto.randomUUID()}@example.com`;
+  response = await app.request(`/users/${sourceUserId}/clone`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: newEmail, role: source.result.role, status: 'active' }),
+  });
+  await expectOk(response);
+  const cloned = await json<SuccessResponse<{ id: string; name: string; email: string; role: string; age?: number }>>(response);
+  expect(cloned.success).toBe(true);
+  expect(cloned.result.id).toBeDefined();
+  expect(cloned.result.id).not.toBe(sourceUserId);
+  expect(cloned.result.email).toBe(newEmail);
+  expect(cloned.result.name).toBe(source.result.name);
+  expect(cloned.result.role).toBe(source.result.role);
+
+  // 2. Source row remains intact in the DB.
+  response = await app.request(`/users/${sourceUserId}`);
+  await expectOk(response);
+  const reReadSource = await json<SuccessResponse<{ email: string }>>(response);
+  expect(reReadSource.result.email).toBe('alice@example.com');
+
+  // 3. Body overrides win — name + email both replaced.
+  const overrideEmail = `clone-${crypto.randomUUID()}@example.com`;
+  response = await app.request(`/users/${sourceUserId}/clone`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: overrideEmail, name: 'Cloned Alice' }),
+  });
+  await expectOk(response);
+  const overridden = await json<SuccessResponse<{ name: string; email: string }>>(response);
+  expect(overridden.result.name).toBe('Cloned Alice');
+  expect(overridden.result.email).toBe(overrideEmail);
+
+  // 4. Unknown source id — should not succeed.
+  response = await app.request(`/users/00000000-0000-0000-0000-000000000999/clone`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: `clone-${crypto.randomUUID()}@example.com` }),
+  });
+  expect(response.status).toBeGreaterThanOrEqual(400);
+  expect(response.status).toBeLessThan(500);
+
+  // 5. Soft-deleted source — should also not be cloneable.
+  response = await app.request(`/users/${sourceUserId}`, { method: 'DELETE' });
+  await expectOk(response);
+  response = await app.request(`/users/${sourceUserId}/clone`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: `clone-${crypto.randomUUID()}@example.com` }),
+  });
+  expect(response.status).toBeGreaterThanOrEqual(400);
+  expect(response.status).toBeLessThan(500);
+}

--- a/tests/prisma.test.ts
+++ b/tests/prisma.test.ts
@@ -24,6 +24,7 @@ import {
   PrismaBatchRestoreEndpoint,
   PrismaSearchEndpoint,
   PrismaAggregateEndpoint,
+  PrismaCloneEndpoint,
   registerPrismaModelMapping,
   registerPrismaModelMappings,
   clearPrismaModelMappings,
@@ -374,6 +375,11 @@ class UserSearch extends PrismaSearchEndpoint {
   fieldWeights = { name: 2.0, email: 1.0 };
 }
 
+class UserClone extends PrismaCloneEndpoint {
+  _meta = { model: UserModel };
+  get prisma() { return mockPrisma; }
+}
+
 class PostCreate extends PrismaCreateEndpoint {
   _meta = { model: PostModel };
   get prisma() { return mockPrisma; }
@@ -445,6 +451,7 @@ function createApp() {
   app.patch('/users/:id', withContext(UserUpdate));
   app.delete('/users/:id', withContext(UserDelete));
   app.post('/users/:id/restore', withContext(UserRestore));
+  app.post('/users/:id/clone', withContext(UserClone));
 
   // Post endpoints
   app.get('/posts/aggregate', withContext(PostAggregate));
@@ -871,6 +878,86 @@ describe('Prisma Adapter', () => {
       const result = await response.json() as { result: { groups: unknown[] } };
 
       expect(result.result.groups).toHaveLength(2);
+    });
+  });
+
+  describe('Clone', () => {
+    it('clones a record with a fresh primary key, copying source data', async () => {
+      const sourceId = crypto.randomUUID();
+      userStorage.push({
+        id: sourceId,
+        name: 'Clone Source',
+        email: 'source@example.com',
+        role: 'user',
+      });
+
+      const response = await app.request(`/users/${sourceId}/clone`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+
+      expect(response.status).toBe(201);
+      const result = await response.json() as { success: boolean; result: { id: string; name: string; email: string; role: string } };
+      expect(result.success).toBe(true);
+      expect(result.result.id).toBeDefined();
+      expect(result.result.id).not.toBe(sourceId);
+      expect(result.result.name).toBe('Clone Source');
+      expect(result.result.email).toBe('source@example.com');
+      expect(result.result.role).toBe('user');
+
+      expect(userStorage).toHaveLength(2);
+    });
+
+    it('applies body overrides on top of the cloned data', async () => {
+      const sourceId = crypto.randomUUID();
+      userStorage.push({
+        id: sourceId,
+        name: 'Original Name',
+        email: 'orig@example.com',
+        role: 'user',
+      });
+
+      const response = await app.request(`/users/${sourceId}/clone`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Override Name', email: 'new@example.com' }),
+      });
+
+      expect(response.status).toBe(201);
+      const result = await response.json() as { success: boolean; result: { name: string; email: string; role: string } };
+      expect(result.result.name).toBe('Override Name');
+      expect(result.result.email).toBe('new@example.com');
+      expect(result.result.role).toBe('user');
+    });
+
+    it('returns 404 when the source id does not exist', async () => {
+      const response = await app.request(`/users/${crypto.randomUUID()}/clone`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+
+      expect(response.status).toBe(404);
+    });
+
+    it('returns 404 when the source row is soft-deleted', async () => {
+      const sourceId = crypto.randomUUID();
+      userStorage.push({
+        id: sourceId,
+        name: 'Soft Deleted',
+        email: 'sd@example.com',
+        role: 'user',
+        deletedAt: new Date().toISOString(),
+      });
+
+      const response = await app.request(`/users/${sourceId}/clone`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+
+      expect(response.status).toBe(404);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Adds 12 new `<Verb>EndpointConfig<M>` slots to `EndpointsConfig<M>` (search, aggregate, restore, batch{Create,Update,Delete,Restore,Upsert}, export, import, upsert, clone) plus matching `*Hooks<M>` interfaces. `defineEndpoints` generates wired classes for every configured verb.
- `CrudEndpointName` and `CrudEndpoints<E>` widen from 14 → 17 names (adds `batchUpsert`, `upsert`, `clone`). `registerCrud` mounts the three new routes (`POST /batch/upsert`, `POST /upsert`, `POST /:id/clone`) with correct ordering relative to `:id`.
- `generateEndpointClass` gains an `extras?: Record<string, unknown>` slot that is `Object.assign`'d onto the generated subclass instance in its constructor — so verb-specific protected fields (`maxBatchSize`, `upsertKeys`, `excludeFromClone`, `defaultFormat`, …) get populated without enumerating ~50 keys in `NormalizedEndpointConfig`.
- `MemoryAdapters` populates all 17 slots. New `DrizzleAdapters` and `PrismaAdapters` bundle constants ship the 16 verbs each adapter implements natively plus a `*CloneEndpoint` stub that throws on request — real Drizzle/Prisma clone follows separately. Both bundles are re-exported from the public barrel alongside the new config types.

## Compatibility
Purely additive. The 5-verb code path is unchanged; the new `AdapterBundle<E>` slots are optional so existing custom bundles compile without modification. `CHANGELOG.md` and `package.json` are intentionally untouched — the GH Actions release bot owns version bumps and the `%b` slots.

## Unblocks
`@velajs/crud@0.4.0` was blocked on this surface — its bridge forwards `endpoints.search = {...}` etc. into `defineEndpoints` and the slots were silently dropped. Once a hono-crud version is tagged + published, velajs/crud bumps its peer-dep and mirrors the 17-name widening.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test:unit` — 741/741 pass, including 6 new tests in `tests/define-endpoints-widening.test.ts` (generation, skip-when-absent, extras forwarding, full-mount smoke, `/upsert` vs `read('upsert')` disambiguation, `/batch/upsert` distinct from other batch verbs)
- [x] `pnpm test:package-example` — local-consumer example boots and serves
- [x] `pnpm typecheck:examples` — clean