### PR TITLE
feat(config): add middlewares? slot to every per-endpoint config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] — 2026-05-03
+
+### Added
+- `middlewares?: MiddlewareHandler[]` slot on every per-endpoint config in `EndpointsConfig<M>` (`create`, `list`, `read`, `update`, `delete`, `search`, `aggregate`, `restore`, `batchCreate`, `batchUpdate`, `batchDelete`, `batchRestore`, `batchUpsert`, `export`, `import`, `upsert`, `clone`). Middleware listed here runs before the endpoint handler. The existing `RegisterCrudOptions.endpointMiddlewares` continues to work and overrides config-API middlewares for the same verb. Coverage: `tests/per-endpoint-middlewares.test.ts`.
+
+### Fixed
+- `HonoOpenAPIHandler.registerRoute` was passing the OpenAPI-style path (`/widgets/{id}`) to `app.use(...)` for per-route middleware. Hono's `use` expects the route-syntax form (`/widgets/:id`), so middleware on dynamic-segment routes (e.g., `delete`, `read`, `update`, `restore`, `clone`) silently never fired. The fix passes the raw path to `app.use(...)` and keeps the OpenAPI conversion only for `createRoute({ path })`. This unblocks both the new config-API `middlewares` slot and the existing `RegisterCrudOptions.endpointMiddlewares` option on `:id` routes.
+
+### Compatibility
+- Additive. Existing consumers see no behaviour change other than the bugfix above (middleware that previously was silently dropped on `:id` routes will now run as documented).
+
 %b
 %b
 %b
@@ -63,3 +74,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.5.3]: https://github.com/kshdotdev/hono-crud/compare/v0.5.2...v0.5.3
 [0.6.0]: https://github.com/kshdotdev/hono-crud/compare/v0.5.3...v0.6.0
 [0.7.0]: https://github.com/kshdotdev/hono-crud/compare/v0.6.0...v0.7.0
+[0.8.0]: https://github.com/kshdotdev/hono-crud/compare/v0.7.0...v0.8.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hono-crud",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "CRUD generator for Hono with Zod validation and OpenAPI generation",
   "author": "Kauan Guesser <contato@kauan.net>",
   "license": "MIT",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -32,7 +32,7 @@
  * ```
  */
 
-import type { Env } from 'hono';
+import type { Env, MiddlewareHandler } from 'hono';
 import type { ZodObject, ZodRawShape } from 'zod';
 import type { MetaInput, HookMode } from '../core/types';
 import type { FilterConfig } from '../core/types';
@@ -97,6 +97,8 @@ interface CreateHooks<M extends MetaInput> extends HookConfig {
  */
 export interface CreateEndpointConfig<M extends MetaInput> {
   openapi?: OpenAPIConfig;
+  /** Middleware applied to this endpoint route. Runs before the handler. */
+  middlewares?: MiddlewareHandler[];
   hooks?: CreateHooks<M>;
   nestedCreate?: string[];
   /**
@@ -175,6 +177,8 @@ interface ListHooks<M extends MetaInput> {
  */
 export interface ListEndpointConfig<M extends MetaInput> {
   openapi?: OpenAPIConfig;
+  /** Middleware applied to this endpoint route. Runs before the handler. */
+  middlewares?: MiddlewareHandler[];
   filtering?: FilteringConfig;
   search?: SearchConfig;
   sorting?: SortingConfig;
@@ -197,6 +201,8 @@ interface ReadHooks<M extends MetaInput> {
  */
 export interface ReadEndpointConfig<M extends MetaInput> {
   openapi?: OpenAPIConfig;
+  /** Middleware applied to this endpoint route. Runs before the handler. */
+  middlewares?: MiddlewareHandler[];
   lookupField?: string;
   additionalFilters?: string[];
   includes?: string[];
@@ -226,6 +232,8 @@ interface UpdateHooks<M extends MetaInput> extends HookConfig {
  */
 export interface UpdateEndpointConfig<M extends MetaInput> {
   openapi?: OpenAPIConfig;
+  /** Middleware applied to this endpoint route. Runs before the handler. */
+  middlewares?: MiddlewareHandler[];
   lookupField?: string;
   additionalFilters?: string[];
   fields?: UpdateFieldConfig;
@@ -256,6 +264,8 @@ interface DeleteHooks<M extends MetaInput> extends HookConfig {
  */
 export interface DeleteEndpointConfig<M extends MetaInput> {
   openapi?: OpenAPIConfig;
+  /** Middleware applied to this endpoint route. Runs before the handler. */
+  middlewares?: MiddlewareHandler[];
   lookupField?: string;
   additionalFilters?: string[];
   includeCascadeResults?: boolean;
@@ -287,6 +297,8 @@ interface SearchHooks<M extends MetaInput> {
  */
 export interface SearchEndpointConfig<M extends MetaInput> {
   openapi?: OpenAPIConfig;
+  /** Middleware applied to this endpoint route. Runs before the handler. */
+  middlewares?: MiddlewareHandler[];
   /** Fields included in the search index (maps to SearchEndpoint.searchFields). */
   fields?: string[];
   /** Reserved — currently unused; SearchEndpoint reads `q` by default. */
@@ -308,6 +320,8 @@ interface AggregateHooks {
  */
 export interface AggregateEndpointConfig<_M extends MetaInput> {
   openapi?: OpenAPIConfig;
+  /** Middleware applied to this endpoint route. Runs before the handler. */
+  middlewares?: MiddlewareHandler[];
   /** Fields the client may filter aggregations by (maps to AggregateEndpoint.filterFields). */
   fields?: string[];
   hooks?: AggregateHooks;
@@ -326,6 +340,8 @@ interface RestoreHooks<M extends MetaInput> extends HookConfig {
  */
 export interface RestoreEndpointConfig<M extends MetaInput> {
   openapi?: OpenAPIConfig;
+  /** Middleware applied to this endpoint route. Runs before the handler. */
+  middlewares?: MiddlewareHandler[];
   hooks?: RestoreHooks<M>;
 }
 
@@ -342,6 +358,8 @@ interface BatchCreateHooks<M extends MetaInput> extends HookConfig {
  */
 export interface BatchCreateEndpointConfig<M extends MetaInput> {
   openapi?: OpenAPIConfig;
+  /** Middleware applied to this endpoint route. Runs before the handler. */
+  middlewares?: MiddlewareHandler[];
   hooks?: BatchCreateHooks<M>;
   bodySchema?: ZodObject<ZodRawShape>;
   maxBatchSize?: number;
@@ -360,6 +378,8 @@ interface BatchUpdateHooks<M extends MetaInput> extends HookConfig {
  */
 export interface BatchUpdateEndpointConfig<M extends MetaInput> {
   openapi?: OpenAPIConfig;
+  /** Middleware applied to this endpoint route. Runs before the handler. */
+  middlewares?: MiddlewareHandler[];
   hooks?: BatchUpdateHooks<M>;
   maxBatchSize?: number;
 }
@@ -377,6 +397,8 @@ interface BatchDeleteHooks<M extends MetaInput> extends HookConfig {
  */
 export interface BatchDeleteEndpointConfig<M extends MetaInput> {
   openapi?: OpenAPIConfig;
+  /** Middleware applied to this endpoint route. Runs before the handler. */
+  middlewares?: MiddlewareHandler[];
   hooks?: BatchDeleteHooks<M>;
   maxBatchSize?: number;
 }
@@ -394,6 +416,8 @@ interface BatchRestoreHooks<M extends MetaInput> extends HookConfig {
  */
 export interface BatchRestoreEndpointConfig<M extends MetaInput> {
   openapi?: OpenAPIConfig;
+  /** Middleware applied to this endpoint route. Runs before the handler. */
+  middlewares?: MiddlewareHandler[];
   hooks?: BatchRestoreHooks<M>;
   maxBatchSize?: number;
 }
@@ -411,6 +435,8 @@ interface BatchUpsertHooks<M extends MetaInput> extends HookConfig {
  */
 export interface BatchUpsertEndpointConfig<M extends MetaInput> {
   openapi?: OpenAPIConfig;
+  /** Middleware applied to this endpoint route. Runs before the handler. */
+  middlewares?: MiddlewareHandler[];
   hooks?: BatchUpsertHooks<M>;
   bodySchema?: ZodObject<ZodRawShape>;
   /** Conflict-target column(s) for the upsert. String is normalized to single-element array. */
@@ -428,6 +454,8 @@ export interface BatchUpsertEndpointConfig<M extends MetaInput> {
  */
 export interface ExportEndpointConfig<_M extends MetaInput> {
   openapi?: OpenAPIConfig;
+  /** Middleware applied to this endpoint route. Runs before the handler. */
+  middlewares?: MiddlewareHandler[];
   formats?: ('csv' | 'json')[];
   /** Maximum rows to export (maps to ExportEndpoint.maxExportRecords). */
   maxRows?: number;
@@ -450,6 +478,8 @@ interface ImportHooks<M extends MetaInput> {
  */
 export interface ImportEndpointConfig<M extends MetaInput> {
   openapi?: OpenAPIConfig;
+  /** Middleware applied to this endpoint route. Runs before the handler. */
+  middlewares?: MiddlewareHandler[];
   hooks?: ImportHooks<M>;
   /** Maximum rows accepted per request (maps to ImportEndpoint.maxBatchSize). */
   maxRows?: number;
@@ -468,6 +498,8 @@ interface UpsertHooks<M extends MetaInput> extends HookConfig {
  */
 export interface UpsertEndpointConfig<M extends MetaInput> {
   openapi?: OpenAPIConfig;
+  /** Middleware applied to this endpoint route. Runs before the handler. */
+  middlewares?: MiddlewareHandler[];
   hooks?: UpsertHooks<M>;
   bodySchema?: ZodObject<ZodRawShape>;
   /** Conflict-target column(s) for the upsert. String is normalized to single-element array. */
@@ -487,6 +519,8 @@ interface CloneHooks<M extends MetaInput> {
  */
 export interface CloneEndpointConfig<M extends MetaInput> {
   openapi?: OpenAPIConfig;
+  /** Middleware applied to this endpoint route. Runs before the handler. */
+  middlewares?: MiddlewareHandler[];
   hooks?: CloneHooks<M>;
   /** Field names to strip from the cloned record (maps to CloneEndpoint.excludeFromClone). */
   fieldsToReset?: string[];
@@ -663,6 +697,7 @@ export function defineEndpoints<M extends MetaInput, E extends Env = Env>(
     result.create = generateEndpointClass(adapters.CreateEndpoint, {
       meta: config.meta,
       schema: cfg.openapi,
+      middlewares: cfg.middlewares,
       bodySchema: cfg.bodySchema,
       beforeHookMode: cfg.hooks?.beforeMode,
       afterHookMode: cfg.hooks?.afterMode,
@@ -678,6 +713,7 @@ export function defineEndpoints<M extends MetaInput, E extends Env = Env>(
     result.list = generateEndpointClass(adapters.ListEndpoint, {
       meta: config.meta,
       schema: cfg.openapi,
+      middlewares: cfg.middlewares,
       filterFields: cfg.filtering?.fields,
       filterConfig: cfg.filtering?.config,
       searchFields: cfg.search?.fields,
@@ -705,6 +741,7 @@ export function defineEndpoints<M extends MetaInput, E extends Env = Env>(
     result.read = generateEndpointClass(adapters.ReadEndpoint, {
       meta: config.meta,
       schema: cfg.openapi,
+      middlewares: cfg.middlewares,
       lookupField: cfg.lookupField,
       additionalFilters: cfg.additionalFilters,
       allowedIncludes: cfg.includes,
@@ -724,6 +761,7 @@ export function defineEndpoints<M extends MetaInput, E extends Env = Env>(
     result.update = generateEndpointClass(adapters.UpdateEndpoint, {
       meta: config.meta,
       schema: cfg.openapi,
+      middlewares: cfg.middlewares,
       bodySchema: cfg.bodySchema,
       lookupField: cfg.lookupField,
       additionalFilters: cfg.additionalFilters,
@@ -744,6 +782,7 @@ export function defineEndpoints<M extends MetaInput, E extends Env = Env>(
     result.delete = generateEndpointClass(adapters.DeleteEndpoint, {
       meta: config.meta,
       schema: cfg.openapi,
+      middlewares: cfg.middlewares,
       lookupField: cfg.lookupField,
       additionalFilters: cfg.additionalFilters,
       includeCascadeResults: cfg.includeCascadeResults,
@@ -764,6 +803,7 @@ export function defineEndpoints<M extends MetaInput, E extends Env = Env>(
     result.search = generateEndpointClass(adapters.SearchEndpoint, {
       meta: config.meta,
       schema: cfg.openapi,
+      middlewares: cfg.middlewares,
       after: cfg.hooks?.after as ((...args: unknown[]) => unknown) | undefined,
       extras: {
         ...(cfg.fields !== undefined ? { searchFields: cfg.fields } : {}),
@@ -778,6 +818,7 @@ export function defineEndpoints<M extends MetaInput, E extends Env = Env>(
     result.aggregate = generateEndpointClass(adapters.AggregateEndpoint, {
       meta: config.meta,
       schema: cfg.openapi,
+      middlewares: cfg.middlewares,
       after: cfg.hooks?.after as ((...args: unknown[]) => unknown) | undefined,
       extras: {
         ...(cfg.fields !== undefined ? { filterFields: cfg.fields } : {}),
@@ -791,6 +832,7 @@ export function defineEndpoints<M extends MetaInput, E extends Env = Env>(
     result.restore = generateEndpointClass(adapters.RestoreEndpoint, {
       meta: config.meta,
       schema: cfg.openapi,
+      middlewares: cfg.middlewares,
       beforeHookMode: cfg.hooks?.beforeMode,
       afterHookMode: cfg.hooks?.afterMode,
       before: cfg.hooks?.before as ((...args: unknown[]) => unknown) | undefined,
@@ -804,6 +846,7 @@ export function defineEndpoints<M extends MetaInput, E extends Env = Env>(
     result.batchCreate = generateEndpointClass(adapters.BatchCreateEndpoint, {
       meta: config.meta,
       schema: cfg.openapi,
+      middlewares: cfg.middlewares,
       bodySchema: cfg.bodySchema,
       beforeHookMode: cfg.hooks?.beforeMode,
       afterHookMode: cfg.hooks?.afterMode,
@@ -821,6 +864,7 @@ export function defineEndpoints<M extends MetaInput, E extends Env = Env>(
     result.batchUpdate = generateEndpointClass(adapters.BatchUpdateEndpoint, {
       meta: config.meta,
       schema: cfg.openapi,
+      middlewares: cfg.middlewares,
       beforeHookMode: cfg.hooks?.beforeMode,
       afterHookMode: cfg.hooks?.afterMode,
       before: cfg.hooks?.before as ((...args: unknown[]) => unknown) | undefined,
@@ -837,6 +881,7 @@ export function defineEndpoints<M extends MetaInput, E extends Env = Env>(
     result.batchDelete = generateEndpointClass(adapters.BatchDeleteEndpoint, {
       meta: config.meta,
       schema: cfg.openapi,
+      middlewares: cfg.middlewares,
       beforeHookMode: cfg.hooks?.beforeMode,
       afterHookMode: cfg.hooks?.afterMode,
       before: cfg.hooks?.before as ((...args: unknown[]) => unknown) | undefined,
@@ -853,6 +898,7 @@ export function defineEndpoints<M extends MetaInput, E extends Env = Env>(
     result.batchRestore = generateEndpointClass(adapters.BatchRestoreEndpoint, {
       meta: config.meta,
       schema: cfg.openapi,
+      middlewares: cfg.middlewares,
       beforeHookMode: cfg.hooks?.beforeMode,
       afterHookMode: cfg.hooks?.afterMode,
       before: cfg.hooks?.before as ((...args: unknown[]) => unknown) | undefined,
@@ -873,6 +919,7 @@ export function defineEndpoints<M extends MetaInput, E extends Env = Env>(
     result.batchUpsert = generateEndpointClass(adapters.BatchUpsertEndpoint, {
       meta: config.meta,
       schema: cfg.openapi,
+      middlewares: cfg.middlewares,
       bodySchema: cfg.bodySchema,
       beforeHookMode: cfg.hooks?.beforeMode,
       afterHookMode: cfg.hooks?.afterMode,
@@ -891,6 +938,7 @@ export function defineEndpoints<M extends MetaInput, E extends Env = Env>(
     result.export = generateEndpointClass(adapters.ExportEndpoint, {
       meta: config.meta,
       schema: cfg.openapi,
+      middlewares: cfg.middlewares,
       extras: {
         ...(cfg.maxRows !== undefined ? { maxExportRecords: cfg.maxRows } : {}),
         ...(cfg.formats !== undefined && cfg.formats.length > 0
@@ -906,6 +954,7 @@ export function defineEndpoints<M extends MetaInput, E extends Env = Env>(
     result.import = generateEndpointClass(adapters.ImportEndpoint, {
       meta: config.meta,
       schema: cfg.openapi,
+      middlewares: cfg.middlewares,
       before: cfg.hooks?.before as ((...args: unknown[]) => unknown) | undefined,
       after: cfg.hooks?.after as ((...args: unknown[]) => unknown) | undefined,
       extras: {
@@ -924,6 +973,7 @@ export function defineEndpoints<M extends MetaInput, E extends Env = Env>(
     result.upsert = generateEndpointClass(adapters.UpsertEndpoint, {
       meta: config.meta,
       schema: cfg.openapi,
+      middlewares: cfg.middlewares,
       bodySchema: cfg.bodySchema,
       beforeHookMode: cfg.hooks?.beforeMode,
       afterHookMode: cfg.hooks?.afterMode,
@@ -941,6 +991,7 @@ export function defineEndpoints<M extends MetaInput, E extends Env = Env>(
     result.clone = generateEndpointClass(adapters.CloneEndpoint, {
       meta: config.meta,
       schema: cfg.openapi,
+      middlewares: cfg.middlewares,
       before: cfg.hooks?.before as ((...args: unknown[]) => unknown) | undefined,
       after: cfg.hooks?.after as ((...args: unknown[]) => unknown) | undefined,
       extras: {

--- a/src/core/openapi.ts
+++ b/src/core/openapi.ts
@@ -194,11 +194,15 @@ export class HonoOpenAPIHandler<E extends Env = Env> {
       },
     });
 
-    // Apply middleware for this specific path+method before route handler
+    // Apply middleware for this specific path+method before route handler.
+    // NOTE: `app.use(...)` uses Hono's `:id` route-syntax, NOT the OpenAPI
+    // `{id}` form produced by `convertPath`. Passing the converted form
+    // here results in middleware that never matches dynamic-segment routes
+    // (e.g. `/widgets/:id`) — the literal `{id}` segment never appears in
+    // an actual request. Use the raw path so `:id` matches at runtime.
     if (middlewares.length > 0) {
-      const pathPattern = this.convertPath(path);
       for (const mw of middlewares) {
-        this.app.use(pathPattern, async (c, next) => {
+        this.app.use(path, async (c, next) => {
           // Only apply middleware if the HTTP method matches
           if (c.req.method.toLowerCase() === method) {
             return mw(c as Context<E>, next);

--- a/tests/per-endpoint-middlewares.test.ts
+++ b/tests/per-endpoint-middlewares.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for the per-endpoint `middlewares?: MiddlewareHandler[]` slot on
+ * every `EndpointsConfig<M>` config block. The slot lets consumers attach
+ * route-level middleware (e.g., `requireApproval`, `requirePolicy`) directly
+ * via `defineEndpoints(...)` without falling back to `app.use(path, ...)`
+ * with HTTP-method gating.
+ *
+ * Internally, `defineEndpoints` forwards `cfg.middlewares` into
+ * `generateEndpointClass(...)`, which assigns them to `static _middlewares`
+ * on the generated class. `registerCrud` already merges class-level
+ * `_middlewares` with the explicit `RegisterCrudOptions.endpointMiddlewares`,
+ * so this is purely additive — no other surface changes.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import { z } from 'zod';
+import {
+  fromHono,
+  registerCrud,
+  defineEndpoints,
+  MemoryAdapters,
+  defineMeta,
+  defineModel,
+  requireApproval,
+  MemoryApprovalStorage,
+} from '../src/index.js';
+import { clearStorage } from '../src/adapters/memory/index.js';
+
+const WidgetSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+});
+
+const WidgetModel = defineModel({
+  tableName: 'widgets_per_endpoint_mw',
+  schema: WidgetSchema,
+  primaryKeys: ['id'],
+});
+
+const widgetMeta = defineMeta({ model: WidgetModel });
+
+describe('EndpointsConfig per-endpoint middlewares slot', () => {
+  let approvalStorage: MemoryApprovalStorage;
+
+  beforeEach(() => {
+    clearStorage();
+    approvalStorage = new MemoryApprovalStorage();
+  });
+
+  it('applies endpoints.delete.middlewares to the DELETE route only', async () => {
+    const endpoints = defineEndpoints(
+      {
+        meta: widgetMeta,
+        create: {},
+        delete: {
+          middlewares: [
+            requireApproval({
+              reason: 'destructive widget delete',
+              approvalStorage,
+            }),
+          ],
+        },
+      },
+      MemoryAdapters,
+    );
+
+    const app = fromHono(new Hono());
+    registerCrud(app, '/widgets', endpoints);
+
+    // CREATE has no gate — succeeds outright.
+    const createRes = await app.request('/widgets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'first' }),
+    });
+    expect(createRes.status).toBe(201);
+    const created = (await createRes.json()) as { result: { id: string } };
+    const widgetId = created.result.id;
+
+    // First DELETE → 202, gated by requireApproval, returns actionId.
+    const firstDelete = await app.request(`/widgets/${widgetId}`, {
+      method: 'DELETE',
+    });
+    expect(firstDelete.status).toBe(202);
+    const pending = (await firstDelete.json()) as {
+      status: string;
+      actionId: string;
+    };
+    expect(pending.status).toBe('pending');
+    expect(pending.actionId).toMatch(/^[0-9a-f-]{36}$/);
+
+    // Approver signs off, then resume the DELETE.
+    await approvalStorage.approve(pending.actionId, 'approver-1');
+    const resumed = await app.request(`/widgets/${widgetId}`, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ _resume_: pending.actionId }),
+    });
+    // The DeleteEndpoint runs to completion (200/204 either is acceptable;
+    // `requireApproval` doesn't constrain the downstream status).
+    expect([200, 204]).toContain(resumed.status);
+  });
+
+  it('does NOT apply endpoints.create.middlewares to the DELETE route', async () => {
+    const endpoints = defineEndpoints(
+      {
+        meta: widgetMeta,
+        create: {
+          middlewares: [
+            requireApproval({
+              reason: 'gated create',
+              approvalStorage,
+            }),
+          ],
+        },
+        delete: {},
+      },
+      MemoryAdapters,
+    );
+
+    const app = fromHono(new Hono());
+    registerCrud(app, '/widgets', endpoints);
+
+    // CREATE is gated → 202.
+    const createRes = await app.request('/widgets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'gated' }),
+    });
+    expect(createRes.status).toBe(202);
+    const pending = (await createRes.json()) as { actionId: string };
+    await approvalStorage.approve(pending.actionId, 'approver-1');
+
+    // Resume CREATE so we have a row to delete.
+    const resumed = await app.request('/widgets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'gated',
+        _resume_: pending.actionId,
+      }),
+    });
+    expect(resumed.status).toBe(201);
+    const created = (await resumed.json()) as { result: { id: string } };
+
+    // DELETE has NO middleware attached — must execute outright (no 202).
+    const deleteRes = await app.request(`/widgets/${created.result.id}`, {
+      method: 'DELETE',
+    });
+    expect(deleteRes.status).not.toBe(202);
+    expect([200, 204]).toContain(deleteRes.status);
+  });
+
+  it('explicit endpointMiddlewares on registerCrud overrides the config-API slot', async () => {
+    // Sanity check: ensure the existing RegisterCrudOptions.endpointMiddlewares
+    // path still works alongside config-API middlewares. registerCrud merges
+    // [global, endpointMiddlewares, classMiddlewares] in order — so an
+    // explicit override is composed with (not silently dropped by) the
+    // config-API slot.
+    let configMwHits = 0;
+    let optionMwHits = 0;
+
+    const endpoints = defineEndpoints(
+      {
+        meta: widgetMeta,
+        create: {
+          middlewares: [
+            async (_c, next) => {
+              configMwHits += 1;
+              await next();
+            },
+          ],
+        },
+      },
+      MemoryAdapters,
+    );
+
+    const app = fromHono(new Hono());
+    registerCrud(app, '/widgets', endpoints, {
+      endpointMiddlewares: {
+        create: [
+          async (_c, next) => {
+            optionMwHits += 1;
+            await next();
+          },
+        ],
+      },
+    });
+
+    const res = await app.request('/widgets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'both' }),
+    });
+    expect(res.status).toBe(201);
+    expect(configMwHits).toBe(1);
+    expect(optionMwHits).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `middlewares?: MiddlewareHandler[]` to every per-endpoint config in `EndpointsConfig<M>` (17 configs: `create`, `list`, `read`, `update`, `delete`, `search`, `aggregate`, `restore`, `batchCreate`, `batchUpdate`, `batchDelete`, `batchRestore`, `batchUpsert`, `export`, `import`, `upsert`, `clone`).
- `defineEndpoints` forwards `cfg.middlewares` into `generateEndpointClass(...)` (which already supports a `middlewares` field and attaches them as `static _middlewares` on the generated class). `registerCrud` already merges class-level `_middlewares` at mount time, so this is fully non-breaking — no shape changes to `defineEndpoints`'s return type or to `registerCrud`.
- Existing `RegisterCrudOptions.endpointMiddlewares` continues to work as an explicit override (compose-not-replace).
- Bumps `package.json` to `0.8.0` (next minor over the published `0.7.0`).

## Why

Downstream consumers (notably `@velajs/crud`) currently fall back to `app.use('/path/:id', wrapped)` with HTTP-method gating to attach `requireApproval` / `requirePolicy` to a single verb. The config-API path had no slot for per-endpoint middleware; `endpointMiddlewares` on `registerCrud` is one level too coarse and lives outside the config object. This bridges that gap so consumers can write:

```ts
defineEndpoints({
  meta,
  delete: {
    middlewares: [requireApproval({ reason: 'destructive' })],
  },
  list: {
    middlewares: [requirePolicy(meta.model.policies)],
  },
}, MemoryAdapters);
```

## Bugfix included

While exercising the new slot end-to-end, surfaced a pre-existing bug in `HonoOpenAPIHandler.registerRoute` (`src/core/openapi.ts`): the path passed to `app.use(...)` was OpenAPI-style (`/widgets/{id}`), but Hono's `.use` expects route-syntax (`/widgets/:id`). As a result, middleware on every dynamic-segment route (`delete`, `read`, `update`, `restore`, `clone`) silently never fired — also affecting the existing `RegisterCrudOptions.endpointMiddlewares` option. One-line fix: pass the raw path to `app.use`, keep the OpenAPI conversion only for `createRoute({ path })`.

This was a latent-but-publicly-broken contract; fixing it in the same PR avoided shipping the new feature in a state where consumers would silently observe it not working on `:id` routes. CHANGELOG entry calls this out under `### Fixed`.

## Implementation pattern

**Option 2 (mutate adapter / class-level static)** — non-breaking, no signature changes. The infrastructure (`NormalizedEndpointConfig.middlewares` → `static _middlewares` → `registerCrud` merge) already existed for the builder API; `defineEndpoints` just had to forward the value into each of 17 dispatch arms.

## Test plan

- [x] `pnpm typecheck` clean (0 errors)
- [x] `pnpm test:unit` green: 37 files / 752 tests
- [x] `tests/per-endpoint-middlewares.test.ts` (3 tests):
  - `endpoints.delete.middlewares = [requireApproval(...)]` end-to-end (202 + actionId, then approval + resume → 200)
  - Same middleware on `endpoints.create.middlewares` does NOT intercept DELETE on the same path
  - Explicit `endpointMiddlewares` on `registerCrud` composes with (does not replace) the config-API slot
- [ ] Optional: smoke-test via the harbor-crud-api example