### PR TITLE
feat: export sync toOpenApiPaths + model tag for OpenAPI grouping

### DIFF
--- a/src/core/generate-endpoint-class.ts
+++ b/src/core/generate-endpoint-class.ts
@@ -93,6 +93,23 @@ export function generateEndpointClass<
 
   const extras = config.extras;
 
+  // Resolve the effective OpenAPI schema for this endpoint, defaulting
+  // `tags` from the model's `tag` (or `tableName` when unset). A
+  // per-endpoint `openapi.tags` override always wins — when the caller
+  // already supplied a non-empty `tags` array we leave the schema
+  // untouched, so existing behaviour for explicitly-tagged endpoints is
+  // byte-identical. Only endpoints that previously had *no* tag now
+  // inherit the resource-level group, which is the whole point of
+  // `Model.tag`.
+  const baseSchema = (config.schema ?? {}) as OpenAPIRouteSchema;
+  const hasExplicitTags =
+    Array.isArray(baseSchema.tags) && baseSchema.tags.length > 0;
+  const resolvedTag =
+    config.meta.model.tag ?? config.meta.model.tableName;
+  const resolvedSchema: OpenAPIRouteSchema = hasExplicitTags
+    ? baseSchema
+    : { ...baseSchema, tags: [resolvedTag] };
+
   // @ts-expect-error - TS cannot resolve members of a dynamically-provided abstract base class (TS#4628)
   const Generated = class extends BaseClass {
     static _middlewares = middlewares;
@@ -105,7 +122,7 @@ export function generateEndpointClass<
     }
 
     _meta = config.meta;
-    schema = (config.schema ?? {}) as OpenAPIRouteSchema;
+    schema = resolvedSchema;
 
     // Hook modes (Create / Update / Delete)
     protected beforeHookMode: HookMode = config.beforeHookMode ?? 'sequential';

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1017,6 +1017,23 @@ export interface Model<
 > {
   /** Database table name */
   tableName: string;
+  /**
+   * Optional OpenAPI tag / API group for this resource.
+   *
+   * This is the canonical "what API group does this resource belong to"
+   * home. It flows into every generated endpoint's
+   * `OpenAPIRouteSchema.tags` (and therefore the emitted OpenAPI
+   * operations) unless a per-endpoint `openapi.tags` override is set,
+   * which always wins. When unset, the effective tag falls back to
+   * `tableName`, so consumers that never set explicit tags get stable,
+   * resource-grouped documentation by default.
+   *
+   * @example
+   * ```ts
+   * defineModel({ tableName: 'users', tag: 'Accounts', schema, primaryKeys: ['id'] });
+   * ```
+   */
+  tag?: string;
   /** Zod schema for validation and type inference */
   schema: T;
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,8 @@ export type {
   PerTenantOpenApiConfig,
   PerTenantOpenApiOptions,
 } from './openapi/lazy';
+export { toOpenApiPaths } from './openapi/paths';
+export type { OpenApiPathItem, ToOpenApiPathsOptions } from './openapi/paths';
 export {
   ApiException,
   InputValidationException,

--- a/src/openapi/paths.ts
+++ b/src/openapi/paths.ts
@@ -1,0 +1,212 @@
+/**
+ * Pure, synchronous OpenAPI paths emission.
+ *
+ * `toOpenApiPaths(endpoints, options?)` turns a `defineEndpoints(...)` result
+ * (`GeneratedEndpoints`) into an OpenAPI 3.1 *paths fragment* —
+ * `{ [path]: { [verb]: operation } }` — without a running server, without
+ * `await`, and without calling `Model.resolveSchema()`.
+ *
+ * It exists so consumers (NestJS-style wrappers, doc aggregators, gateway
+ * config generators) stop hand-deriving a lossy OpenAPI fragment from static
+ * config. hono-crud already owns the authoritative per-endpoint
+ * `OpenAPIRouteSchema` (every generated endpoint exposes `getSchema()`); this
+ * function is the single source of truth for turning that into emitted
+ * OpenAPI.
+ *
+ * For a statically-defined model (`defineModel({ schema: <zod object>, ... })`
+ * with no `resolveSchema`), `endpoint.getSchema()` returns fully-populated
+ * request/response Zod schemas synchronously — no context, no resolution
+ * needed. This function feeds those through the exact same
+ * `createRoute` + `OpenAPIHono` + `getOpenAPI31Document` pipeline that
+ * `registerCrud`/`buildPerTenantOpenApi` use internally, then returns only
+ * the `paths` object. Models that rely on the async `resolveSchema` hook for
+ * per-tenant shapes still emit their *static* `schema` here (the documented
+ * fallback) — use `buildPerTenantOpenApi(...)` when a resolved per-tenant
+ * document is required.
+ */
+
+import { OpenAPIHono, createRoute } from '@hono/zod-openapi';
+import { z } from 'zod';
+
+import type { GeneratedEndpoints } from '../config/index';
+import type { OpenAPIRouteSchema } from '../core/types';
+
+/**
+ * A single OpenAPI 3.1 Path Item: a map of lowercase HTTP verbs to
+ * Operation objects (plus the occasional `parameters`/`$ref`). Kept as a
+ * loose JSON-serializable record so this module doesn't leak the deep
+ * `openapi3-ts` generic surface onto consumers — the values are plain
+ * objects produced by `@hono/zod-openapi`'s document generator.
+ */
+export type OpenApiPathItem = Record<string, unknown>;
+
+/**
+ * Options for {@link toOpenApiPaths}.
+ */
+export interface ToOpenApiPathsOptions {
+  /**
+   * Prefix prepended to every emitted path key (e.g. `'/api/v1/users'`).
+   * Slash-normalized: leading slash is ensured, duplicate slashes are
+   * collapsed, a trailing slash is dropped. Defaults to `''` (paths are
+   * emitted relative to the resource root, e.g. `/`, `/{id}`).
+   */
+  basePath?: string;
+  /**
+   * Override the OpenAPI tag for every emitted operation. When set, this
+   * replaces whatever tag the endpoint's `getSchema()` resolved (model
+   * `tag` / `tableName` / explicit `openapi.tags`). When unset, the
+   * per-endpoint tags are preserved as-is.
+   */
+  tag?: string;
+}
+
+type RouteMethod = 'get' | 'post' | 'patch' | 'delete';
+
+/**
+ * Canonical (verb, sub-path) mapping for every CRUD endpoint slot. This is
+ * the single source of truth shared in spirit with `registerCrud(...)` in
+ * `src/utils.ts` — the relative sub-paths and HTTP verbs are kept
+ * byte-identical so the emitted document matches the routes that
+ * `registerCrud` would actually register. Sub-paths are relative to the
+ * resource root; `''` means the collection root.
+ *
+ * Ordering mirrors `registerCrud` (collection routes, then batch/named
+ * sub-routes, then `:id` item routes, then `:id`-scoped sub-routes) so a
+ * caller iterating the result sees a stable, sensible order.
+ */
+const ENDPOINT_ROUTES: ReadonlyArray<
+  readonly [keyof GeneratedEndpoints, RouteMethod, string]
+> = [
+  ['create', 'post', ''],
+  ['list', 'get', ''],
+  ['batchCreate', 'post', '/batch'],
+  ['batchUpdate', 'patch', '/batch'],
+  ['batchDelete', 'delete', '/batch'],
+  ['batchRestore', 'post', '/batch/restore'],
+  ['batchUpsert', 'post', '/batch/upsert'],
+  ['search', 'get', '/search'],
+  ['aggregate', 'get', '/aggregate'],
+  ['export', 'get', '/export'],
+  ['import', 'post', '/import'],
+  ['upsert', 'post', '/upsert'],
+  ['read', 'get', '/:id'],
+  ['update', 'patch', '/:id'],
+  ['delete', 'delete', '/:id'],
+  ['restore', 'post', '/:id/restore'],
+  ['clone', 'post', '/:id/clone'],
+];
+
+/**
+ * Convert Express-style `:param` segments to OpenAPI `{param}` form. Mirrors
+ * `HonoOpenAPIHandler.convertPath` so emitted path keys match what the live
+ * router documents.
+ */
+function toOpenApiPath(path: string): string {
+  return path.replace(/:([a-zA-Z_][a-zA-Z0-9_]*)/g, '{$1}');
+}
+
+/**
+ * Join + normalize a base path and a relative sub-path into a single
+ * OpenAPI path key: always one leading slash, no duplicate slashes, no
+ * trailing slash (except the root `'/'`).
+ */
+function normalizePath(basePath: string, subPath: string): string {
+  const joined = `/${basePath}/${subPath}`;
+  const collapsed = joined.replace(/\/{2,}/g, '/');
+  if (collapsed.length > 1 && collapsed.endsWith('/')) {
+    return collapsed.slice(0, -1);
+  }
+  return collapsed;
+}
+
+/**
+ * Turn a `defineEndpoints(...)` result into an OpenAPI 3.1 paths fragment.
+ *
+ * Pure and synchronous: no `await`, no server start, no
+ * `Model.resolveSchema()` invocation. Returns plain JSON-serializable
+ * objects. Covers *every* endpoint `defineEndpoints` actually generated
+ * (list/read/create/update/delete plus search/aggregate/upsert/restore/
+ * clone/export/import and all `batch*` verbs) — completeness vs a
+ * hand-rolled 5-verb subset is the entire point.
+ *
+ * @example
+ * ```ts
+ * const endpoints = defineEndpoints({ meta: userMeta, list: {}, create: {} }, MemoryAdapters);
+ * const paths = toOpenApiPaths(endpoints, { basePath: '/api/users' });
+ * // => { '/api/users': { get: {...}, post: {...} } }
+ * ```
+ */
+export function toOpenApiPaths(
+  endpoints: GeneratedEndpoints,
+  options: ToOpenApiPathsOptions = {}
+): Record<string, OpenApiPathItem> {
+  const basePath = options.basePath ?? '';
+  const tagOverride = options.tag;
+
+  // Accumulate every generated route on a throwaway OpenAPIHono, then ask
+  // it for a single 3.1 document and lift out `.paths`. This reuses the
+  // exact zod -> JSON-Schema conversion the live router uses, so the
+  // fragment is byte-identical to what `registerCrud` + `app.doc(...)`
+  // would emit for the same endpoints.
+  const app = new OpenAPIHono();
+  let registered = 0;
+
+  for (const [name, method, subPath] of ENDPOINT_ROUTES) {
+    const EndpointClass = endpoints[name];
+    if (!EndpointClass) continue;
+
+    // Instantiate purely to read the authoritative schema. No
+    // setContext()/resolveModelSchema() — for a static model this yields
+    // fully-populated request/response schemas (see module docstring).
+    const instance = new EndpointClass();
+    const schema = instance.getSchema();
+
+    const effectiveSchema: OpenAPIRouteSchema =
+      tagOverride !== undefined
+        ? { ...schema, tags: [tagOverride] }
+        : schema;
+
+    const path = normalizePath(basePath, toOpenApiPath(subPath));
+
+    const routeConfig = createRoute({
+      // `OpenAPIRouteSchema` is a structural subset of zod-openapi's
+      // `RouteConfig` (no required `method`/`path`); the cast widens the
+      // `responses` union TS can't unify on its own. Same cast shape used
+      // by `openapi/lazy.ts`.
+      ...(effectiveSchema as Parameters<typeof createRoute>[0]),
+      method,
+      path,
+      responses: effectiveSchema.responses ?? {
+        200: {
+          description: 'Success',
+          content: {
+            // `z.unknown()` (not `z.any()`, which the edge-safety static
+            // scan bans) is the unconstrained placeholder; both serialize
+            // to the same open OpenAPI schema.
+            'application/json': { schema: z.unknown() },
+          },
+        },
+      },
+    });
+
+    // Dummy handler — never invoked; we only want the schema registered
+    // so the generator can emit it.
+    app.openapi(routeConfig, () => new Response());
+    registered += 1;
+  }
+
+  if (registered === 0) {
+    return {};
+  }
+
+  const doc = app.getOpenAPI31Document({
+    openapi: '3.1.0',
+    info: { title: 'hono-crud', version: '1.0.0' },
+  });
+
+  // `paths` is optional on the OpenAPI object type; an empty document
+  // would omit it. We registered at least one route, so it's present —
+  // fall back to `{}` defensively rather than asserting non-null.
+  const paths = (doc as { paths?: Record<string, OpenApiPathItem> }).paths;
+  return paths ?? {};
+}

--- a/tests/openapi-paths.test.ts
+++ b/tests/openapi-paths.test.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import {
+  defineEndpoints,
+  MemoryAdapters,
+  defineMeta,
+  defineModel,
+  toOpenApiPaths,
+} from '../src/index.js';
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+const ProductSchema = z.object({
+  id: z.uuid(),
+  name: z.string().min(1),
+  price: z.number().nonnegative(),
+  sku: z.string(),
+  inStock: z.boolean().default(true),
+});
+
+const ProductModel = defineModel({
+  tableName: 'products',
+  schema: ProductSchema,
+  primaryKeys: ['id'],
+});
+
+const productMeta = defineMeta({ model: ProductModel });
+
+/** A full-featured config exercising every enabled endpoint slot. */
+function fullEndpoints() {
+  return defineEndpoints(
+    {
+      meta: productMeta,
+      create: { openapi: { summary: 'Create product' } },
+      list: {
+        filtering: { fields: ['sku'] },
+        pagination: { defaultPerPage: 25, maxPerPage: 100 },
+      },
+      read: {},
+      update: {},
+      delete: {},
+      search: { fields: ['name', 'sku'] },
+      aggregate: {},
+      upsert: { conflictTarget: 'sku' },
+      restore: {},
+      clone: {},
+      export: {},
+      import: {},
+      batchCreate: {},
+      batchUpdate: {},
+      batchDelete: {},
+      batchRestore: {},
+      batchUpsert: { conflictTarget: 'sku' },
+    },
+    MemoryAdapters
+  );
+}
+
+// ============================================================================
+// 1. Full-featured model: every enabled endpoint emitted with populated
+//    request/response schemas.
+// ============================================================================
+
+describe('toOpenApiPaths — completeness', () => {
+  it('emits a path item for every enabled endpoint (all 17 verbs)', () => {
+    const paths = toOpenApiPaths(fullEndpoints());
+
+    // Collection root
+    expect(paths['/']?.post).toBeDefined(); // create
+    expect(paths['/']?.get).toBeDefined(); // list
+    // Named collection sub-routes
+    expect(paths['/batch']?.post).toBeDefined(); // batchCreate
+    expect(paths['/batch']?.patch).toBeDefined(); // batchUpdate
+    expect(paths['/batch']?.delete).toBeDefined(); // batchDelete
+    expect(paths['/batch/restore']?.post).toBeDefined();
+    expect(paths['/batch/upsert']?.post).toBeDefined();
+    expect(paths['/search']?.get).toBeDefined();
+    expect(paths['/aggregate']?.get).toBeDefined();
+    expect(paths['/export']?.get).toBeDefined();
+    expect(paths['/import']?.post).toBeDefined();
+    expect(paths['/upsert']?.post).toBeDefined();
+    // Item routes
+    expect(paths['/{id}']?.get).toBeDefined(); // read
+    expect(paths['/{id}']?.patch).toBeDefined(); // update
+    expect(paths['/{id}']?.delete).toBeDefined(); // delete
+    expect(paths['/{id}/restore']?.post).toBeDefined();
+    expect(paths['/{id}/clone']?.post).toBeDefined();
+  });
+
+  it('create op has a requestBody schema derived from the model', () => {
+    const paths = toOpenApiPaths(fullEndpoints());
+    const post = paths['/'].post as {
+      requestBody: {
+        content: { 'application/json': { schema: Record<string, unknown> } };
+      };
+    };
+    const schema = post.requestBody.content['application/json'].schema as {
+      type: string;
+      properties: Record<string, unknown>;
+      required: string[];
+    };
+    expect(schema.type).toBe('object');
+    // Model fields minus the primary key (id) flow into the create body.
+    expect(Object.keys(schema.properties).sort()).toEqual(
+      ['inStock', 'name', 'price', 'sku'].sort()
+    );
+    expect(schema.properties).not.toHaveProperty('id');
+    // `name` is .min(1) and non-optional => required; `inStock` has a
+    // default => not required.
+    expect(schema.required).toContain('name');
+    expect(schema.required).not.toContain('inStock');
+  });
+
+  it('list op response carries the pagination/result envelope', () => {
+    const paths = toOpenApiPaths(fullEndpoints());
+    const get = paths['/'].get as {
+      responses: Record<
+        string,
+        { content: { 'application/json': { schema: Record<string, unknown> } } }
+      >;
+    };
+    const ok = get.responses['200'].content['application/json'].schema as {
+      type: string;
+      properties: Record<string, { type?: string }>;
+    };
+    expect(ok.type).toBe('object');
+    expect(ok.properties).toHaveProperty('success');
+    expect(ok.properties).toHaveProperty('result');
+    expect(ok.properties).toHaveProperty('result_info');
+    // result is the array of model rows.
+    expect(ok.properties.result.type).toBe('array');
+  });
+
+  it('returns plain JSON-serializable objects (no Zod instances leak)', () => {
+    const paths = toOpenApiPaths(fullEndpoints());
+    // Round-trips cleanly — proves the values are pure JSON.
+    expect(() => JSON.stringify(paths)).not.toThrow();
+    const round = JSON.parse(JSON.stringify(paths));
+    expect(round['/'].post.requestBody).toBeDefined();
+  });
+
+  it('returns an empty object when no endpoints are generated', () => {
+    const empty = defineEndpoints({ meta: productMeta }, MemoryAdapters);
+    expect(toOpenApiPaths(empty)).toEqual({});
+  });
+});
+
+// ============================================================================
+// 2. basePath prefixing + slash normalization.
+// ============================================================================
+
+describe('toOpenApiPaths — basePath', () => {
+  it('prefixes basePath onto every path key', () => {
+    const paths = toOpenApiPaths(fullEndpoints(), { basePath: '/api/v1/products' });
+    expect(paths['/api/v1/products']?.post).toBeDefined();
+    expect(paths['/api/v1/products/{id}']?.get).toBeDefined();
+    expect(paths['/api/v1/products/search']?.get).toBeDefined();
+    expect(paths['/']).toBeUndefined();
+  });
+
+  it('normalizes duplicate / leading / trailing slashes', () => {
+    const paths = toOpenApiPaths(fullEndpoints(), {
+      basePath: '///api//products///',
+    });
+    expect(paths['/api/products']?.post).toBeDefined();
+    expect(paths['/api/products/{id}']?.get).toBeDefined();
+    // No double slashes anywhere.
+    for (const key of Object.keys(paths)) {
+      expect(key).not.toMatch(/\/\//);
+      expect(key.startsWith('/')).toBe(true);
+      if (key.length > 1) expect(key.endsWith('/')).toBe(false);
+    }
+  });
+
+  it('defaults basePath to "" (resource-relative keys)', () => {
+    const paths = toOpenApiPaths(
+      defineEndpoints({ meta: productMeta, list: {} }, MemoryAdapters)
+    );
+    expect(Object.keys(paths)).toEqual(['/']);
+  });
+});
+
+// ============================================================================
+// 3. tag option override / model tag / tableName fallback.
+// ============================================================================
+
+describe('toOpenApiPaths — tag resolution', () => {
+  it('falls back to tableName when no model tag / no override', () => {
+    const paths = toOpenApiPaths(
+      defineEndpoints({ meta: productMeta, list: {} }, MemoryAdapters)
+    );
+    const get = paths['/'].get as { tags?: string[] };
+    expect(get.tags).toEqual(['products']);
+  });
+
+  it('uses the model tag when set', () => {
+    const taggedModel = defineModel({
+      tableName: 'products',
+      tag: 'Catalog',
+      schema: ProductSchema,
+      primaryKeys: ['id'],
+    });
+    const endpoints = defineEndpoints(
+      { meta: defineMeta({ model: taggedModel }), list: {}, create: {} },
+      MemoryAdapters
+    );
+    const paths = toOpenApiPaths(endpoints);
+    expect((paths['/'].get as { tags?: string[] }).tags).toEqual(['Catalog']);
+    expect((paths['/'].post as { tags?: string[] }).tags).toEqual(['Catalog']);
+  });
+
+  it('the tag option overrides per-endpoint / model tags', () => {
+    const taggedModel = defineModel({
+      tableName: 'products',
+      tag: 'Catalog',
+      schema: ProductSchema,
+      primaryKeys: ['id'],
+    });
+    const endpoints = defineEndpoints(
+      {
+        meta: defineMeta({ model: taggedModel }),
+        list: { openapi: { tags: ['ExplicitlyTagged'] } },
+        create: {},
+      },
+      MemoryAdapters
+    );
+    const paths = toOpenApiPaths(endpoints, { tag: 'Override' });
+    expect((paths['/'].get as { tags?: string[] }).tags).toEqual(['Override']);
+    expect((paths['/'].post as { tags?: string[] }).tags).toEqual(['Override']);
+  });
+
+  it('preserves an explicit per-endpoint openapi.tags when no override', () => {
+    const endpoints = defineEndpoints(
+      {
+        meta: productMeta,
+        list: { openapi: { tags: ['CustomList'] } },
+        create: {},
+      },
+      MemoryAdapters
+    );
+    const paths = toOpenApiPaths(endpoints);
+    // Explicit per-endpoint tag wins over the model/tableName default.
+    expect((paths['/'].get as { tags?: string[] }).tags).toEqual(['CustomList']);
+    // Untagged sibling falls back to tableName.
+    expect((paths['/'].post as { tags?: string[] }).tags).toEqual(['products']);
+  });
+});
+
+// ============================================================================
+// 4. Disabled endpoints are absent.
+// ============================================================================
+
+describe('toOpenApiPaths — disabled endpoints', () => {
+  it('omits endpoints not present in the config', () => {
+    const endpoints = defineEndpoints(
+      { meta: productMeta, list: {}, read: {} },
+      MemoryAdapters
+    );
+    const paths = toOpenApiPaths(endpoints);
+    expect(paths['/']?.get).toBeDefined(); // list present
+    expect(paths['/']?.post).toBeUndefined(); // create absent
+    expect(paths['/{id}']?.get).toBeDefined(); // read present
+    expect(paths['/{id}']?.patch).toBeUndefined(); // update absent
+    expect(paths['/{id}']?.delete).toBeUndefined(); // delete absent
+    expect(paths['/search']).toBeUndefined();
+    expect(paths['/batch']).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// 5. Model tag flows into getSchema().tags for a registered endpoint
+//    (proves TASK-A independently of toOpenApiPaths).
+// ============================================================================
+
+describe('Model.tag flows into endpoint getSchema().tags', () => {
+  it('defaults endpoint tags to tableName when model.tag unset', () => {
+    const endpoints = defineEndpoints(
+      { meta: productMeta, create: {}, list: {} },
+      MemoryAdapters
+    );
+    const create = new endpoints.create!();
+    const list = new endpoints.list!();
+    expect(create.getSchema().tags).toEqual(['products']);
+    expect(list.getSchema().tags).toEqual(['products']);
+  });
+
+  it('uses model.tag for every generated endpoint when set', () => {
+    const taggedModel = defineModel({
+      tableName: 'products',
+      tag: 'Inventory',
+      schema: ProductSchema,
+      primaryKeys: ['id'],
+    });
+    const endpoints = defineEndpoints(
+      { meta: defineMeta({ model: taggedModel }), create: {}, update: {} },
+      MemoryAdapters
+    );
+    expect(new endpoints.create!().getSchema().tags).toEqual(['Inventory']);
+    expect(new endpoints.update!().getSchema().tags).toEqual(['Inventory']);
+  });
+
+  it('does not override an explicit per-endpoint openapi.tags', () => {
+    const taggedModel = defineModel({
+      tableName: 'products',
+      tag: 'Inventory',
+      schema: ProductSchema,
+      primaryKeys: ['id'],
+    });
+    const endpoints = defineEndpoints(
+      {
+        meta: defineMeta({ model: taggedModel }),
+        create: { openapi: { tags: ['Special'] } },
+      },
+      MemoryAdapters
+    );
+    expect(new endpoints.create!().getSchema().tags).toEqual(['Special']);
+  });
+});


### PR DESCRIPTION
## Summary

- **New exported `toOpenApiPaths(endpoints, options?)`** — a pure, synchronous function that turns a `defineEndpoints(...)` result (`GeneratedEndpoints`) into an OpenAPI 3.1 paths fragment (`Record<string, OpenApiPathItem>`). No `await`, no server, no `Model.resolveSchema()`. For a statically-defined model, every generated endpoint's `getSchema()` already returns fully-populated request/response Zod schemas synchronously; this feeds them through the *exact same* `createRoute` + `OpenAPIHono` + `getOpenAPI31Document` pipeline the live router (`registerCrud` / `buildPerTenantOpenApi`) uses, then lifts out `.paths`.
- **New optional `Model.tag?: string`** — the canonical "what API group does this resource belong to" home. Wired through the shared `generateEndpointClass` chokepoint so it flows into every generated endpoint's `OpenAPIRouteSchema.tags` for the config, builder, and functional APIs alike.

### Why

Downstream consumers (e.g. NestJS-style wrappers built on hono-crud) currently hand-derive an OpenAPI path fragment from static config because they cannot call hono-crud's authoritative emitter synchronously. hono-crud already owns the authoritative per-endpoint `OpenAPIRouteSchema`; re-deriving it downstream is lossy and drifts from the real routes. This makes hono-crud the single source of truth for its own OpenAPI fragment.

### Behaviour details

- Covers **every** generated verb — CRUD + `search`/`aggregate`/`upsert`/`restore`/`clone`/`export`/`import` + all `batch*` — with path/method mapping kept byte-identical to `registerCrud`.
- `basePath` (default `''`) is prefixed and slash-normalized (single leading slash, no `//`, no trailing slash).
- `tag` option overrides per-endpoint tags; otherwise the model `tag` (falling back to `tableName`) is used; an explicit per-endpoint `openapi.tags` always wins.
- Returns plain JSON-serializable objects.

### Backwards-compat

Purely additive. `registerCrud` / `defineEndpoints` / `getSchema` behaviour is unchanged. Explicit `openapi.tags` overrides are preserved exactly; only endpoints that previously had **no** tag now inherit the resource-level group, defaulting to `tableName` when `Model.tag` is unset.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run typecheck:examples` — clean
- [x] `pnpm run test:unit` — 787 passed (771 pre-existing + 16 new in `tests/openapi-paths.test.ts`)
- [x] `pnpm run test:workers` — 42 passed (edge-safety static scan + Workers-isolate import of the new module)
- [x] `pnpm run test:package-example` — built `dist` consumed & typechecked by the local-consumer example; new export present in `dist/index.{js,d.ts}`
- [ ] `pnpm run test:examples` — requires a live Postgres at `localhost:5432`; fails identically on pristine `main` in this environment (`prisma:push` P1001). Environmental only — this change touches no Prisma/example DB code.

New tests cover: full-featured model emits a path item per enabled endpoint with populated request/response schemas (create requestBody derived from the model; list carries the pagination/result envelope); `basePath` prefixing + slash normalization; `tag` override / model `tag` / `tableName` fallback / explicit `openapi.tags` precedence; disabled endpoints absent; and `Model.tag` flowing into `getSchema().tags` independently of `toOpenApiPaths`.