### PR TITLE
feat: Model.id strategy + Model.timestamps (engine-managed write fields)

### DIFF
--- a/src/adapters/drizzle/advanced.ts
+++ b/src/adapters/drizzle/advanced.ts
@@ -98,13 +98,12 @@ export abstract class DrizzleUpsertEndpoint<
     data: Partial<ModelObject<M['model']>>
   ): Promise<ModelObject<M['model']>> {
     const table = this.getTable();
-    const primaryKey = this._meta.model.primaryKeys[0];
 
-    // Generate UUID if not provided
-    const record = {
-      ...data,
-      [primaryKey]: (data as Record<string, unknown>)[primaryKey] || crypto.randomUUID(),
-    };
+    // Resolve managed write-time fields (Model.id strategy + timestamps).
+    const record = this.applyManagedInsertFields(
+      data as Record<string, unknown>,
+      'drizzle'
+    );
 
     const result = await cast(this.getDb())
       .insert(table)
@@ -124,7 +123,7 @@ export abstract class DrizzleUpsertEndpoint<
 
     const result = await cast(this.getDb())
       .update(table)
-      .set(data as Record<string, unknown>)
+      .set(this.applyManagedUpdateFields(data as Record<string, unknown>))
       .where(eq(this.getColumn(pk), pkValue))
       .returning();
 
@@ -147,12 +146,14 @@ export abstract class DrizzleUpsertEndpoint<
     const upsertKeys = this.getUpsertKeys();
     const primaryKey = this._meta.model.primaryKeys[0];
     const softDeleteConfig = this.getSoftDeleteConfig();
+    const timestamps = this.getTimestampsConfig();
 
-    // Generate UUID if not provided
-    const record = {
-      ...data,
-      [primaryKey]: (data as Record<string, unknown>)[primaryKey] || crypto.randomUUID(),
-    };
+    // Resolve managed write-time fields for the INSERT branch
+    // (Model.id strategy + createdAt/updatedAt).
+    const record = this.applyManagedInsertFields(
+      data as Record<string, unknown>,
+      'drizzle'
+    );
 
     // Build the set clause for update - exclude upsert keys and primary key
     const updateSet: Record<string, unknown> = {};
@@ -163,6 +164,11 @@ export abstract class DrizzleUpsertEndpoint<
           updateSet[key] = value;
         }
       }
+    }
+    // `updatedAt` is server-managed on the DO UPDATE branch — always bump it,
+    // ignoring any client-supplied value, and never touch `createdAt`.
+    if (timestamps.enabled) {
+      updateSet[timestamps.updatedAt] = Date.now();
     }
 
     // Get the target columns for conflict detection
@@ -270,12 +276,12 @@ export abstract class DrizzleBatchUpsertEndpoint<
     data: Partial<ModelObject<M['model']>>
   ): Promise<ModelObject<M['model']>> {
     const table = this.getTable();
-    const primaryKey = this._meta.model.primaryKeys[0];
 
-    const record = {
-      ...data,
-      [primaryKey]: (data as Record<string, unknown>)[primaryKey] || crypto.randomUUID(),
-    };
+    // Resolve managed write-time fields (Model.id strategy + timestamps).
+    const record = this.applyManagedInsertFields(
+      data as Record<string, unknown>,
+      'drizzle'
+    );
 
     const result = await cast(this.getDb())
       .insert(table)
@@ -295,7 +301,7 @@ export abstract class DrizzleBatchUpsertEndpoint<
 
     const result = await cast(this.getDb())
       .update(table)
-      .set(data as Record<string, unknown>)
+      .set(this.applyManagedUpdateFields(data as Record<string, unknown>))
       .where(eq(this.getColumn(pk), pkValue))
       .returning();
 
@@ -332,12 +338,13 @@ export abstract class DrizzleBatchUpsertEndpoint<
     const table = this.getTable();
     const upsertKeys = this.getUpsertKeys();
     const primaryKey = this._meta.model.primaryKeys[0];
+    const timestamps = this.getTimestampsConfig();
 
-    // Prepare all records with generated UUIDs
-    const records = items.map((item) => ({
-      ...item,
-      [primaryKey]: (item as Record<string, unknown>)[primaryKey] || crypto.randomUUID(),
-    }));
+    // Resolve managed write-time fields for the INSERT branch of every row
+    // (Model.id strategy + createdAt/updatedAt).
+    const records = items.map((item) =>
+      this.applyManagedInsertFields(item as Record<string, unknown>, 'drizzle')
+    );
 
     // Build the set clause for update - exclude upsert keys and primary key
     // Use the first item as template for update fields
@@ -351,6 +358,11 @@ export abstract class DrizzleBatchUpsertEndpoint<
           updateSet[key] = sql`excluded.${sql.identifier(key)}`;
         }
       }
+    }
+    // `updatedAt` is server-managed on the DO UPDATE branch — always bump it
+    // to a fresh server timestamp, never touch `createdAt`.
+    if (timestamps.enabled) {
+      updateSet[timestamps.updatedAt] = Date.now();
     }
 
     // Get the target columns for conflict detection
@@ -947,13 +959,12 @@ export abstract class DrizzleImportEndpoint<
     data: Partial<ModelObject<M['model']>>
   ): Promise<ModelObject<M['model']>> {
     const table = this.getTable();
-    const primaryKey = this._meta.model.primaryKeys[0];
 
-    // Generate UUID if not provided
-    const record = {
-      ...data,
-      [primaryKey]: (data as Record<string, unknown>)[primaryKey] || crypto.randomUUID(),
-    };
+    // Resolve managed write-time fields (Model.id strategy + timestamps).
+    const record = this.applyManagedInsertFields(
+      data as Record<string, unknown>,
+      'drizzle'
+    );
 
     const result = await cast(this.getDb())
       .insert(table)
@@ -976,7 +987,7 @@ export abstract class DrizzleImportEndpoint<
 
     const result = await cast(this.getDb())
       .update(table)
-      .set(data as Record<string, unknown>)
+      .set(this.applyManagedUpdateFields(data as Record<string, unknown>))
       .where(eq(this.getColumn(pk), pkValue))
       .returning();
 
@@ -1062,12 +1073,16 @@ export abstract class DrizzleCloneEndpoint<
     data: ModelObject<M['model']>
   ): Promise<ModelObject<M['model']>> {
     const table = this.getTable();
-    const primaryKey = this._meta.model.primaryKeys[0];
 
-    const record = {
-      ...data,
-      [primaryKey]: (data as Record<string, unknown>)[primaryKey] || this.generateId(),
-    };
+    // Resolve managed write-time fields (Model.id strategy + timestamps).
+    // The long-standing overridable `generateId()` remains the default-branch
+    // generator for the `'uuid'`/unset strategy; a `function`/`'database'`
+    // strategy takes precedence.
+    const record = this.applyManagedInsertFields(
+      data as Record<string, unknown>,
+      'drizzle',
+      () => this.generateId()
+    );
 
     const result = await cast(this.getDb())
       .insert(table)

--- a/src/adapters/drizzle/batch.ts
+++ b/src/adapters/drizzle/batch.ts
@@ -41,13 +41,11 @@ export abstract class DrizzleBatchCreateEndpoint<
     items: Partial<ModelObject<M['model']>>[]
   ): Promise<ModelObject<M['model']>[]> {
     const table = this.getTable();
-    const primaryKey = this._meta.model.primaryKeys[0];
 
-    // Generate IDs for items that don't have them
-    const records = items.map((item) => ({
-      ...item,
-      [primaryKey]: (item as Record<string, unknown>)[primaryKey] || crypto.randomUUID(),
-    }));
+    // Resolve managed write-time fields (Model.id strategy + timestamps).
+    const records = items.map((item) =>
+      this.applyManagedInsertFields(item as Record<string, unknown>, 'drizzle')
+    );
 
     const result = await cast(this.getDb())
       .insert(table)
@@ -104,7 +102,7 @@ export abstract class DrizzleBatchUpdateEndpoint<
 
       const result = await cast(this.getDb())
         .update(table)
-        .set(item.data as Record<string, unknown>)
+        .set(this.applyManagedUpdateFields(item.data as Record<string, unknown>))
         .where(and(...conditions))
         .returning();
 

--- a/src/adapters/drizzle/crud.ts
+++ b/src/adapters/drizzle/crud.ts
@@ -103,13 +103,12 @@ export abstract class DrizzleCreateEndpoint<
   override async create(data: ModelObject<M['model']>, tx?: unknown): Promise<ModelObject<M['model']>> {
     const db = (tx as DrizzleDatabase) ?? this.getDb();
     const table = this.getTable();
-    const primaryKey = this._meta.model.primaryKeys[0];
 
-    // Generate UUID if not provided
-    const record = {
-      ...data,
-      [primaryKey]: (data as Record<string, unknown>)[primaryKey] || crypto.randomUUID(),
-    };
+    // Resolve managed write-time fields (Model.id strategy + timestamps).
+    const record = this.applyManagedInsertFields(
+      data as Record<string, unknown>,
+      'drizzle'
+    );
 
     const result = await cast(db)
       .insert(table)
@@ -362,7 +361,7 @@ export abstract class DrizzleUpdateEndpoint<
 
     const result = await cast(db)
       .update(table)
-      .set(data as Record<string, unknown>)
+      .set(this.applyManagedUpdateFields(data as Record<string, unknown>))
       .where(and(...conditions))
       .returning();
 

--- a/src/adapters/memory/advanced.ts
+++ b/src/adapters/memory/advanced.ts
@@ -66,13 +66,17 @@ export abstract class MemoryCloneEndpoint<
   ): Promise<ModelObject<M['model']>> {
     const store = getStore<ModelObject<M['model']>>(this._meta.model.tableName);
     const pk = this._meta.model.primaryKeys[0];
-    const id = this.generateId();
 
-    const record = {
-      ...data,
-      [pk]: id,
-    } as ModelObject<M['model']>;
+    // Base CloneEndpoint already stripped the source PK, so the managed
+    // resolver always fills it. `generateId()` stays the overridable
+    // default-branch generator; `id:'database'` throws (memory has no DB).
+    const record = this.applyManagedInsertFields(
+      data as Record<string, unknown>,
+      'memory',
+      () => this.generateId()
+    ) as ModelObject<M['model']>;
 
+    const id = String((record as Record<string, unknown>)[pk]);
     store.set(id, record);
     return record;
   }
@@ -141,11 +145,14 @@ export abstract class MemoryUpsertEndpoint<
     const store = getStore<ModelObject<M['model']>>(this._meta.model.tableName);
     const primaryKey = this._meta.model.primaryKeys[0];
 
-    // Generate ID if not provided
-    const record = {
-      ...data,
-      [primaryKey]: (data as Record<string, unknown>)[primaryKey] || this.generateId(),
-    } as ModelObject<M['model']>;
+    // Resolve managed write-time fields (Model.id strategy + timestamps).
+    // `generateId()` stays the overridable default-branch generator;
+    // `id:'database'` throws here (memory has no database).
+    const record = this.applyManagedInsertFields(
+      data as Record<string, unknown>,
+      'memory',
+      () => this.generateId()
+    ) as ModelObject<M['model']>;
 
     store.set(String((record as Record<string, unknown>)[primaryKey]), record);
     return record;
@@ -162,10 +169,10 @@ export abstract class MemoryUpsertEndpoint<
     const primaryKey = this._meta.model.primaryKeys[0];
     const id = String((existing as Record<string, unknown>)[primaryKey]);
 
-    // Merge existing with new data
+    // Merge existing with new data (+ managed updatedAt bump).
     const updated = {
       ...existing,
-      ...data,
+      ...this.applyManagedUpdateFields(data as Record<string, unknown>),
     } as ModelObject<M['model']>;
 
     store.set(id, updated);
@@ -228,7 +235,7 @@ export abstract class MemoryUpsertEndpoint<
       const id = String((existingRecord as Record<string, unknown>)[primaryKey]);
       const updated = {
         ...existingRecord,
-        ...updateData,
+        ...this.applyManagedUpdateFields(updateData as Record<string, unknown>),
       } as ModelObject<M['model']>;
 
       store.set(id, updated);
@@ -242,10 +249,12 @@ export abstract class MemoryUpsertEndpoint<
         }
       }
 
-      const record = {
-        ...createData,
-        [primaryKey]: (data as Record<string, unknown>)[primaryKey] || this.generateId(),
-      } as ModelObject<M['model']>;
+      // Resolve managed write-time fields (Model.id strategy + timestamps).
+      const record = this.applyManagedInsertFields(
+        createData as Record<string, unknown>,
+        'memory',
+        () => this.generateId()
+      ) as ModelObject<M['model']>;
 
       const id = String((record as Record<string, unknown>)[primaryKey]);
       store.set(id, record);
@@ -803,11 +812,14 @@ export abstract class MemoryImportEndpoint<
     const store = getStore<ModelObject<M['model']>>(this._meta.model.tableName);
     const primaryKey = this._meta.model.primaryKeys[0];
 
-    // Generate ID if not provided
-    const record = {
-      ...data,
-      [primaryKey]: (data as Record<string, unknown>)[primaryKey] || this.generateId(),
-    } as ModelObject<M['model']>;
+    // Resolve managed write-time fields (Model.id strategy + timestamps).
+    // `generateId()` stays the overridable default-branch generator;
+    // `id:'database'` throws here (memory has no database).
+    const record = this.applyManagedInsertFields(
+      data as Record<string, unknown>,
+      'memory',
+      () => this.generateId()
+    ) as ModelObject<M['model']>;
 
     store.set(String((record as Record<string, unknown>)[primaryKey]), record);
     return record;
@@ -824,10 +836,10 @@ export abstract class MemoryImportEndpoint<
     const primaryKey = this._meta.model.primaryKeys[0];
     const id = String((existing as Record<string, unknown>)[primaryKey]);
 
-    // Merge existing with new data
+    // Merge existing with new data (+ managed updatedAt bump).
     const updated = {
       ...existing,
-      ...data,
+      ...this.applyManagedUpdateFields(data as Record<string, unknown>),
     } as ModelObject<M['model']>;
 
     store.set(id, updated);

--- a/src/adapters/memory/batch.ts
+++ b/src/adapters/memory/batch.ts
@@ -33,10 +33,12 @@ export abstract class MemoryBatchCreateEndpoint<
     const created: ModelObject<M['model']>[] = [];
 
     for (const item of items) {
-      const record = {
-        ...item,
-        [primaryKey]: (item as Record<string, unknown>)[primaryKey] || this.generateId(),
-      } as ModelObject<M['model']>;
+      // Resolve managed write-time fields (Model.id strategy + timestamps).
+      const record = this.applyManagedInsertFields(
+        item as Record<string, unknown>,
+        'memory',
+        () => this.generateId()
+      ) as ModelObject<M['model']>;
 
       const id = String((record as Record<string, unknown>)[primaryKey]);
       store.set(id, record);
@@ -76,7 +78,10 @@ export abstract class MemoryBatchUpdateEndpoint<
         continue;
       }
 
-      const updatedRecord = { ...existing, ...item.data } as ModelObject<M['model']>;
+      const updatedRecord = {
+        ...existing,
+        ...this.applyManagedUpdateFields(item.data as Record<string, unknown>),
+      } as ModelObject<M['model']>;
       store.set(item.id, updatedRecord);
       updated.push(updatedRecord);
     }
@@ -231,11 +236,12 @@ export abstract class MemoryBatchUpsertEndpoint<
     const store = getStore<ModelObject<M['model']>>(this._meta.model.tableName);
     const primaryKey = this._meta.model.primaryKeys[0];
 
-    // Generate ID if not provided
-    const record = {
-      ...data,
-      [primaryKey]: (data as Record<string, unknown>)[primaryKey] || this.generateId(),
-    } as ModelObject<M['model']>;
+    // Resolve managed write-time fields (Model.id strategy + timestamps).
+    const record = this.applyManagedInsertFields(
+      data as Record<string, unknown>,
+      'memory',
+      () => this.generateId()
+    ) as ModelObject<M['model']>;
 
     store.set(String((record as Record<string, unknown>)[primaryKey]), record);
     return record;
@@ -252,10 +258,10 @@ export abstract class MemoryBatchUpsertEndpoint<
     const primaryKey = this._meta.model.primaryKeys[0];
     const id = String((existing as Record<string, unknown>)[primaryKey]);
 
-    // Merge existing with new data
+    // Merge existing with new data (+ managed updatedAt bump).
     const updated = {
       ...existing,
-      ...data,
+      ...this.applyManagedUpdateFields(data as Record<string, unknown>),
     } as ModelObject<M['model']>;
 
     store.set(id, updated);
@@ -318,7 +324,7 @@ export abstract class MemoryBatchUpsertEndpoint<
         const id = String((existingRecord as Record<string, unknown>)[primaryKey]);
         const updated = {
           ...existingRecord,
-          ...updateData,
+          ...this.applyManagedUpdateFields(updateData as Record<string, unknown>),
         } as ModelObject<M['model']>;
 
         store.set(id, updated);
@@ -333,10 +339,12 @@ export abstract class MemoryBatchUpsertEndpoint<
           }
         }
 
-        const record = {
-          ...createData,
-          [primaryKey]: (data as Record<string, unknown>)[primaryKey] || this.generateId(),
-        } as ModelObject<M['model']>;
+        // Resolve managed write-time fields (Model.id strategy + timestamps).
+        const record = this.applyManagedInsertFields(
+          createData as Record<string, unknown>,
+          'memory',
+          () => this.generateId()
+        ) as ModelObject<M['model']>;
 
         const id = String((record as Record<string, unknown>)[primaryKey]);
         store.set(id, record);

--- a/src/adapters/memory/crud.ts
+++ b/src/adapters/memory/crud.ts
@@ -52,11 +52,14 @@ export abstract class MemoryCreateEndpoint<
     const store = getStore<ModelObject<M['model']>>(this._meta.model.tableName);
     const primaryKey = this._meta.model.primaryKeys[0];
 
-    // Generate ID if not provided
-    const record = {
-      ...data,
-      [primaryKey]: (data as Record<string, unknown>)[primaryKey] || this.generateId(),
-    } as ModelObject<M['model']>;
+    // Resolve managed write-time fields (Model.id strategy + timestamps).
+    // `generateId()` stays the overridable default-branch generator;
+    // `id:'database'` throws here (memory has no database).
+    const record = this.applyManagedInsertFields(
+      data as Record<string, unknown>,
+      'memory',
+      () => this.generateId()
+    ) as ModelObject<M['model']>;
 
     const id = String((record as Record<string, unknown>)[primaryKey]);
     store.set(id, record);
@@ -177,7 +180,10 @@ export abstract class MemoryUpdateEndpoint<
       return null;
     }
 
-    const updated = { ...existing, ...data } as ModelObject<M['model']>;
+    const updated = {
+      ...existing,
+      ...this.applyManagedUpdateFields(data as Record<string, unknown>),
+    } as ModelObject<M['model']>;
     store.set(lookupValue, updated);
 
     return updated;

--- a/src/adapters/prisma/advanced.ts
+++ b/src/adapters/prisma/advanced.ts
@@ -244,13 +244,12 @@ export abstract class PrismaImportEndpoint<
     data: Partial<ModelObject<M['model']>>
   ): Promise<ModelObject<M['model']>> {
     const model = await this.getModel();
-    const primaryKey = this._meta.model.primaryKeys[0];
 
-    // Generate UUID if not provided
-    const record = {
-      ...data,
-      [primaryKey]: (data as Record<string, unknown>)[primaryKey] || crypto.randomUUID(),
-    };
+    // Resolve managed write-time fields (Model.id strategy + timestamps).
+    const record = this.applyManagedInsertFields(
+      data as Record<string, unknown>,
+      'prisma'
+    );
 
     const result = await model.create({ data: record });
     return result as ModelObject<M['model']>;
@@ -268,7 +267,7 @@ export abstract class PrismaImportEndpoint<
 
     const result = await model.update({
       where: { [primaryKey]: (existing as Record<string, unknown>)[primaryKey] },
-      data,
+      data: this.applyManagedUpdateFields(data as Record<string, unknown>),
     });
 
     return result as ModelObject<M['model']>;
@@ -325,13 +324,12 @@ export abstract class PrismaUpsertEndpoint<
     data: Partial<ModelObject<M['model']>>
   ): Promise<ModelObject<M['model']>> {
     const model = await this.getModel();
-    const primaryKey = this._meta.model.primaryKeys[0];
 
-    // Generate UUID if not provided
-    const record = {
-      ...data,
-      [primaryKey]: (data as Record<string, unknown>)[primaryKey] || crypto.randomUUID(),
-    };
+    // Resolve managed write-time fields (Model.id strategy + timestamps).
+    const record = this.applyManagedInsertFields(
+      data as Record<string, unknown>,
+      'prisma'
+    );
 
     const result = await model.create({ data: record });
     return result as ModelObject<M['model']>;
@@ -349,7 +347,7 @@ export abstract class PrismaUpsertEndpoint<
 
     const result = await model.update({
       where: { [primaryKey]: (existing as Record<string, unknown>)[primaryKey] },
-      data,
+      data: this.applyManagedUpdateFields(data as Record<string, unknown>),
     });
 
     return result as ModelObject<M['model']>;
@@ -365,6 +363,7 @@ export abstract class PrismaUpsertEndpoint<
     const model = await this.getModel();
     const upsertKeys = this.getUpsertKeys();
     const primaryKey = this._meta.model.primaryKeys[0];
+    const timestamps = this.getTimestampsConfig();
 
     // Build where clause from upsert keys
     const where: Record<string, unknown> = {};
@@ -375,11 +374,12 @@ export abstract class PrismaUpsertEndpoint<
       }
     }
 
-    // Build create data with generated UUID
-    const createData = {
-      ...data,
-      [primaryKey]: (data as Record<string, unknown>)[primaryKey] || crypto.randomUUID(),
-    };
+    // Resolve managed write-time fields for the CREATE branch
+    // (Model.id strategy + createdAt/updatedAt).
+    const createData = this.applyManagedInsertFields(
+      data as Record<string, unknown>,
+      'prisma'
+    );
 
     // Build update data - exclude upsert keys and primary key, filter create-only fields
     const updateData: Record<string, unknown> = {};
@@ -389,6 +389,11 @@ export abstract class PrismaUpsertEndpoint<
           updateData[key] = value;
         }
       }
+    }
+    // `updatedAt` is server-managed on the UPDATE branch — always bump it,
+    // ignoring any client-supplied value, and never touch `createdAt`.
+    if (timestamps.enabled) {
+      updateData[timestamps.updatedAt] = Date.now();
     }
 
     const result = await model.upsert({
@@ -922,12 +927,15 @@ export abstract class PrismaCloneEndpoint<
     data: ModelObject<M['model']>
   ): Promise<ModelObject<M['model']>> {
     const model = await this.getModel();
-    const primaryKey = this._meta.model.primaryKeys[0];
 
-    const record = {
-      ...data,
-      [primaryKey]: (data as Record<string, unknown>)[primaryKey] || this.generateId(),
-    };
+    // Resolve managed write-time fields (Model.id strategy + timestamps).
+    // `generateId()` remains the overridable default-branch generator for
+    // the `'uuid'`/unset strategy; `function`/`'database'` take precedence.
+    const record = this.applyManagedInsertFields(
+      data as Record<string, unknown>,
+      'prisma',
+      () => this.generateId()
+    );
 
     const result = await model.create({ data: record });
     return result as ModelObject<M['model']>;

--- a/src/adapters/prisma/batch.ts
+++ b/src/adapters/prisma/batch.ts
@@ -84,13 +84,10 @@ export abstract class PrismaBatchCreateEndpoint<
   override async batchCreate(
     items: Partial<ModelObject<M['model']>>[]
   ): Promise<ModelObject<M['model']>[]> {
-    const primaryKey = this._meta.model.primaryKeys[0];
-
-    // Generate IDs for items that don't have them
-    const records = items.map((item) => ({
-      ...item,
-      [primaryKey]: (item as Record<string, unknown>)[primaryKey] || crypto.randomUUID(),
-    }));
+    // Resolve managed write-time fields (Model.id strategy + timestamps).
+    const records = items.map((item) =>
+      this.applyManagedInsertFields(item as Record<string, unknown>, 'prisma')
+    );
 
     // Prisma's createMany doesn't return the created records, so we need to use
     // individual creates or a transaction with creates
@@ -170,7 +167,7 @@ export abstract class PrismaBatchUpdateEndpoint<
       // Update using primary key
       const result = await model.update({
         where: { [primaryKey]: existing[primaryKey] },
-        data: item.data as Record<string, unknown>,
+        data: this.applyManagedUpdateFields(item.data as Record<string, unknown>),
       });
 
       updated.push(result as ModelObject<M['model']>);
@@ -372,13 +369,12 @@ export abstract class PrismaBatchUpsertEndpoint<
     data: Partial<ModelObject<M['model']>>
   ): Promise<ModelObject<M['model']>> {
     const model = await this.getModel();
-    const primaryKey = this._meta.model.primaryKeys[0];
 
-    // Generate UUID if not provided
-    const record = {
-      ...data,
-      [primaryKey]: (data as Record<string, unknown>)[primaryKey] || crypto.randomUUID(),
-    };
+    // Resolve managed write-time fields (Model.id strategy + timestamps).
+    const record = this.applyManagedInsertFields(
+      data as Record<string, unknown>,
+      'prisma'
+    );
 
     const result = await model.create({ data: record });
     return result as ModelObject<M['model']>;
@@ -396,7 +392,7 @@ export abstract class PrismaBatchUpsertEndpoint<
 
     const result = await model.update({
       where: { [primaryKey]: (existing as Record<string, unknown>)[primaryKey] },
-      data,
+      data: this.applyManagedUpdateFields(data as Record<string, unknown>),
     });
 
     return result as ModelObject<M['model']>;
@@ -426,6 +422,7 @@ export abstract class PrismaBatchUpsertEndpoint<
 
     const upsertKeys = this.getUpsertKeys();
     const primaryKey = this._meta.model.primaryKeys[0];
+    const timestamps = this.getTimestampsConfig();
 
     const executeUpserts = async (prismaClient: PrismaClient) => {
       const model = getPrismaModelByName(prismaClient, await getModelName(this._meta.model.tableName));
@@ -448,11 +445,12 @@ export abstract class PrismaBatchUpsertEndpoint<
             }
           }
 
-          // Build create data with generated UUID
-          const createData = {
-            ...item,
-            [primaryKey]: (item as Record<string, unknown>)[primaryKey] || crypto.randomUUID(),
-          };
+          // Resolve managed write-time fields for the CREATE branch
+          // (Model.id strategy + createdAt/updatedAt).
+          const createData = this.applyManagedInsertFields(
+            item as Record<string, unknown>,
+            'prisma'
+          );
 
           // Build update data - exclude upsert keys and primary key, filter create-only fields
           const updateData: Record<string, unknown> = {};
@@ -462,6 +460,11 @@ export abstract class PrismaBatchUpsertEndpoint<
                 updateData[key] = value;
               }
             }
+          }
+          // `updatedAt` is server-managed on the UPDATE branch — always bump
+          // it, ignoring any client value, and never touch `createdAt`.
+          if (timestamps.enabled) {
+            updateData[timestamps.updatedAt] = Date.now();
           }
 
           const result = await model.upsert({

--- a/src/adapters/prisma/crud.ts
+++ b/src/adapters/prisma/crud.ts
@@ -37,13 +37,12 @@ export abstract class PrismaCreateEndpoint<
 
   override async create(data: ModelObject<M['model']>): Promise<ModelObject<M['model']>> {
     const model = await this.getModel();
-    const primaryKey = this._meta.model.primaryKeys[0];
 
-    // Generate UUID if not provided
-    const record = {
-      ...data,
-      [primaryKey]: (data as Record<string, unknown>)[primaryKey] || crypto.randomUUID(),
-    };
+    // Resolve managed write-time fields (Model.id strategy + timestamps).
+    const record = this.applyManagedInsertFields(
+      data as Record<string, unknown>,
+      'prisma'
+    );
 
     const result = await model.create({ data: record });
     return result as ModelObject<M['model']>;
@@ -129,7 +128,7 @@ export abstract class PrismaUpdateEndpoint<
     const primaryKey = this._meta.model.primaryKeys[0];
     const result = await model.update({
       where: { [primaryKey]: (existing as Record<string, unknown>)[primaryKey] },
-      data,
+      data: this.applyManagedUpdateFields(data as Record<string, unknown>),
     });
 
     return result as ModelObject<M['model']>;

--- a/src/core/managed-fields.ts
+++ b/src/core/managed-fields.ts
@@ -1,0 +1,161 @@
+/**
+ * Engine-managed write-time fields: primary-key generation strategy
+ * (`Model.id`) and auto-managed timestamps (`Model.timestamps`).
+ *
+ * This is the SINGLE source of truth for the PK-resolution precedence and
+ * timestamp stamping. Every adapter (drizzle / memory / prisma) routes
+ * every write site through these helpers — the precedence is never
+ * copy-pasted. Members of the same managed-field family as `softDelete`,
+ * `audit`, `versioning` and `multiTenant`.
+ */
+import type { IdStrategy, Model } from './types';
+import { ConfigurationException } from './exceptions';
+
+/**
+ * Adapter identity used to reject `id:'database'` where there is no
+ * database to generate the key (the memory adapter).
+ */
+export type AdapterKind = 'drizzle' | 'prisma' | 'memory';
+
+/**
+ * Normalized timestamp configuration with field names resolved.
+ * `enabled: false` ⇒ no stamping (the default).
+ */
+export interface NormalizedTimestampsConfig {
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+const DEFAULT_CREATED_AT = 'createdAt';
+const DEFAULT_UPDATED_AT = 'updatedAt';
+
+/**
+ * Resolve the timestamps configuration from a model.
+ *
+ * - unset / falsy ⇒ disabled (unchanged, backward compatible)
+ * - `true` ⇒ enabled with default `createdAt` / `updatedAt` field names
+ * - object ⇒ enabled, with either field name optionally overridden
+ */
+export function getTimestampsConfig(
+  timestamps: boolean | { createdAt?: string; updatedAt?: string } | undefined
+): NormalizedTimestampsConfig {
+  if (!timestamps) {
+    return { enabled: false, createdAt: DEFAULT_CREATED_AT, updatedAt: DEFAULT_UPDATED_AT };
+  }
+  if (timestamps === true) {
+    return { enabled: true, createdAt: DEFAULT_CREATED_AT, updatedAt: DEFAULT_UPDATED_AT };
+  }
+  return {
+    enabled: true,
+    createdAt: timestamps.createdAt ?? DEFAULT_CREATED_AT,
+    updatedAt: timestamps.updatedAt ?? DEFAULT_UPDATED_AT,
+  };
+}
+
+/** Treat `null`, `undefined` and `''` as "the caller did not supply a PK". */
+function pkSupplied(value: unknown): boolean {
+  return value !== null && value !== undefined && value !== '';
+}
+
+/**
+ * Resolve the engine-managed write-time fields for a single INSERT record.
+ *
+ * Applies, in order, exactly once per write site:
+ *  1. Primary-key strategy ({@link Model.id}) on `primaryKeys[0]`:
+ *     - caller-supplied non-empty PK wins, untouched;
+ *     - else `function` ⇒ call it;
+ *     - else `'database'` ⇒ DELETE the PK key so the DB/ORM default fills
+ *       it (read back via the adapter's existing RETURNING / create-return);
+ *       throws for the memory adapter (no database);
+ *     - else (`'uuid'` or unset) ⇒ `crypto.randomUUID()`.
+ *  2. Timestamps ({@link Model.timestamps}) when enabled: sets `createdAt`
+ *     and `updatedAt` to `Date.now()` unless the caller explicitly supplied
+ *     that field.
+ *
+ * Returns a NEW object — the input is never mutated.
+ */
+export function applyManagedInsertFields<T extends Record<string, unknown>>(
+  record: T,
+  model: Pick<Model, 'id' | 'timestamps' | 'primaryKeys'>,
+  adapter: AdapterKind,
+  /**
+   * Optional default-branch generator for the `'uuid'`/unset case. Lets the
+   * clone endpoints keep their long-standing overridable `generateId()` hook
+   * working — a `function` or `'database'` strategy still takes precedence.
+   * Omitted ⇒ `crypto.randomUUID()` (the historical default).
+   */
+  defaultIdFactory?: () => string | number
+): T {
+  const out: Record<string, unknown> = { ...record };
+  const pk = model.primaryKeys[0];
+
+  if (!pkSupplied(out[pk])) {
+    const strategy: IdStrategy | undefined = model.id;
+    if (typeof strategy === 'function') {
+      out[pk] = strategy();
+    } else if (strategy === 'database') {
+      if (adapter === 'memory') {
+        throw new ConfigurationException(
+          "MemoryAdapter does not support id:'database' (no database to generate the key)"
+        );
+      }
+      // Omit the PK entirely: the DB/ORM column default fills it and the
+      // adapter reads the generated value back via its existing RETURNING.
+      delete out[pk];
+    } else {
+      // 'uuid' or unset — unchanged historical default.
+      out[pk] = defaultIdFactory ? defaultIdFactory() : crypto.randomUUID();
+    }
+  }
+
+  const ts = getTimestampsConfig(model.timestamps);
+  if (ts.enabled) {
+    const now = Date.now();
+    if (!(ts.createdAt in record)) {
+      out[ts.createdAt] = now;
+    }
+    if (!(ts.updatedAt in record)) {
+      out[ts.updatedAt] = now;
+    }
+  }
+
+  return out as T;
+}
+
+/**
+ * Resolve the engine-managed write-time fields for an UPDATE payload.
+ *
+ * When timestamps are enabled, ALWAYS sets `updatedAt = Date.now()` —
+ * it is a server-managed column, so any client-supplied value is ignored.
+ * `createdAt` is never touched on update. When timestamps are disabled the
+ * payload is returned unchanged (a new object is still returned so callers
+ * never mutate their input).
+ */
+export function applyManagedUpdateFields<T extends Record<string, unknown>>(
+  data: T,
+  model: Pick<Model, 'timestamps'>
+): T {
+  const ts = getTimestampsConfig(model.timestamps);
+  if (!ts.enabled) {
+    return { ...data } as T;
+  }
+  return { ...data, [ts.updatedAt]: Date.now() } as T;
+}
+
+/**
+ * Eagerly validate the `id` strategy against the adapter so a
+ * misconfiguration surfaces at the earliest write rather than as a silent
+ * fallback. Currently the only invalid combination is the memory adapter
+ * with `id:'database'`.
+ */
+export function assertIdStrategySupported(
+  model: Pick<Model, 'id'>,
+  adapter: AdapterKind
+): void {
+  if (adapter === 'memory' && model.id === 'database') {
+    throw new ConfigurationException(
+      "MemoryAdapter does not support id:'database' (no database to generate the key)"
+    );
+  }
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1007,6 +1007,23 @@ export interface SchemaResolveContext {
 }
 
 /**
+ * Primary-key generation strategy for {@link Model.id}.
+ *
+ * - `'uuid'` — DEFAULT (also the behavior when `Model.id` is unset):
+ *   `crypto.randomUUID()`, byte-identical to the historical behavior.
+ * - `'database'` — the adapter omits the PK from the insert payload so the
+ *   DB/ORM column default fills it; the generated value is read back via the
+ *   adapter's existing RETURNING / create-return. Drizzle + Prisma only;
+ *   invalid for the memory adapter.
+ * - `() => string | number` — a custom JS generator (ulid / nanoid / ksuid /
+ *   snowflake), invoked at every write site by every adapter.
+ */
+export type IdStrategy =
+  | 'uuid'
+  | 'database'
+  | (() => string | number);
+
+/**
  * Model definition with strong typing.
  * @template T - The Zod schema type for this model
  * @template TTable - Optional ORM table type (Drizzle Table, Prisma model, etc.)
@@ -1248,6 +1265,60 @@ export interface Model<
    * full surface.
    */
   policies?: ModelPolicies<z.infer<T>>;
+
+  /**
+   * Primary-key generation strategy. Applied at every write site
+   * (create / batchCreate / upsert / clone) when the PK is not supplied
+   * by the caller. Member of the engine-managed write-field family
+   * alongside `softDelete` / `audit` / `versioning` / `multiTenant`, and
+   * enforced uniformly by every adapter.
+   *
+   * - `'uuid'` (or unset) — `crypto.randomUUID()`, the unchanged historical
+   *   default. Fully backward compatible.
+   * - `'database'` — the adapter omits the PK from the insert payload so
+   *   the DB/ORM column default fills it (Drizzle `$defaultFn`, SQL
+   *   `DEFAULT`/sequence, Prisma `@default`); the generated value is read
+   *   back via the adapter's existing RETURNING / create-return. Supported
+   *   by the drizzle and prisma adapters only — the memory adapter has no
+   *   database and throws a `ConfigurationException` at first write.
+   * - `() => string | number` — a custom JS generator (ulid / nanoid /
+   *   ksuid / snowflake), invoked at every write site by every adapter.
+   *
+   * @example
+   * ```ts
+   * import { ulid } from 'ulid';
+   * defineModel({ tableName: 'users', schema, primaryKeys: ['id'], id: ulid });
+   * defineModel({ tableName: 'orders', schema, primaryKeys: ['id'], id: 'database' });
+   * ```
+   */
+  id?: IdStrategy;
+
+  /**
+   * Auto-managed timestamp columns. `true` ⇒ fields named `createdAt`
+   * and `updatedAt`. Object form renames either field. Values are epoch
+   * milliseconds (`Date.now()`, a `number`), matching the common
+   * edge/SQLite-integer convention — schemas using non-numeric timestamp
+   * columns (e.g. ISO strings or SQL `timestamp`) should NOT enable this.
+   * Unset ⇒ OFF (no stamping — unchanged, fully backward compatible).
+   *
+   * Enforced uniformly by every adapter:
+   * - INSERT paths (create / batchCreate / upsert-insert / clone): when
+   *   the field is not explicitly supplied by the caller, both
+   *   `createdAt` and `updatedAt` are set to `Date.now()`.
+   * - UPDATE paths (update / batchUpdate / upsert-update): `updatedAt` is
+   *   ALWAYS set to `Date.now()` (server-managed; any client-supplied
+   *   value is ignored). `createdAt` is never touched on update.
+   *
+   * @example
+   * ```ts
+   * defineModel({ tableName: 'users', schema, primaryKeys: ['id'], timestamps: true });
+   * defineModel({
+   *   tableName: 'events', schema, primaryKeys: ['id'],
+   *   timestamps: { createdAt: 'created_ms', updatedAt: 'updated_ms' },
+   * });
+   * ```
+   */
+  timestamps?: boolean | { createdAt?: string; updatedAt?: string };
 }
 
 /**

--- a/src/endpoints/base.ts
+++ b/src/endpoints/base.ts
@@ -36,6 +36,14 @@ import {
   type SchemaResolveContext,
   type ValidatedData,
 } from '../core/types';
+import {
+  applyManagedInsertFields,
+  applyManagedUpdateFields,
+  assertIdStrategySupported,
+  getTimestampsConfig,
+  type AdapterKind,
+  type NormalizedTimestampsConfig,
+} from '../core/managed-fields';
 import { POLICIES_CONTEXT_KEY } from '../auth/guards';
 import type { AuthUser } from '../auth/types';
 import { createAuditLogger, type AuditLogger } from '../audit';
@@ -185,6 +193,62 @@ export abstract class CrudEndpoint<
 
   protected isMultiTenantEnabled(): boolean {
     return this.getMultiTenantConfig().enabled;
+  }
+
+  // ============================================================================
+  // Engine-managed write-time fields (Model.id strategy + Model.timestamps)
+  //
+  // Thin pass-throughs to the single centralized resolver in
+  // ../core/managed-fields — the PK-resolution precedence and timestamp
+  // stamping live in exactly ONE place and are shared by every adapter at
+  // every write site. The adapter kind is passed by the calling adapter so
+  // `id:'database'` can be rejected for the memory adapter.
+  // ============================================================================
+
+  /**
+   * Resolve managed write-time fields for a single INSERT record:
+   * primary-key strategy (`Model.id`) plus timestamp stamping
+   * (`Model.timestamps`). See {@link applyManagedInsertFields}.
+   */
+  protected applyManagedInsertFields<T extends Record<string, unknown>>(
+    record: T,
+    adapter: AdapterKind,
+    defaultIdFactory?: () => string | number
+  ): T {
+    return applyManagedInsertFields(
+      record,
+      this._meta.model,
+      adapter,
+      defaultIdFactory
+    );
+  }
+
+  /**
+   * Resolve managed write-time fields for an UPDATE payload: always bumps
+   * `updatedAt` (server-managed) when timestamps are enabled, never touches
+   * `createdAt`. See {@link applyManagedUpdateFields}.
+   */
+  protected applyManagedUpdateFields<T extends Record<string, unknown>>(
+    data: T
+  ): T {
+    return applyManagedUpdateFields(data, this._meta.model);
+  }
+
+  /**
+   * Fail fast on an unsupported `id` strategy for this adapter (currently
+   * only the memory adapter + `id:'database'`).
+   */
+  protected assertIdStrategySupported(adapter: AdapterKind): void {
+    assertIdStrategySupported(this._meta.model, adapter);
+  }
+
+  /**
+   * Normalized timestamps config (resolved field names + enabled flag).
+   * Used by native-upsert paths that build their own UPDATE set clause and
+   * need to inject the server-managed `updatedAt` column directly.
+   */
+  protected getTimestampsConfig(): NormalizedTimestampsConfig {
+    return getTimestampsConfig(this._meta.model.timestamps);
   }
 
   protected getTenantId(): string | undefined {

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,16 @@ export {
 } from './versioning';
 export type { VersioningStorage } from './versioning';
 export {
+  getTimestampsConfig,
+  applyManagedInsertFields,
+  applyManagedUpdateFields,
+  assertIdStrategySupported,
+} from './core/managed-fields';
+export type {
+  AdapterKind,
+  NormalizedTimestampsConfig,
+} from './core/managed-fields';
+export {
   defineModel,
   defineMeta,
   getSoftDeleteConfig,
@@ -90,6 +100,7 @@ export type {
   PaginatedResult,
   Model,
   MetaInput,
+  IdStrategy,
   SoftDeleteConfig,
   NormalizedSoftDeleteConfig,
   MultiTenantConfig,

--- a/tests/managed-id-timestamps.test.ts
+++ b/tests/managed-id-timestamps.test.ts
@@ -1,0 +1,555 @@
+/**
+ * Tests for engine-managed write-time fields:
+ *   - `Model.id` primary-key generation strategy
+ *     ('uuid' | 'database' | custom function)
+ *   - `Model.timestamps` auto-managed createdAt / updatedAt
+ *
+ * Covers the centralized resolver applied uniformly by the adapters at
+ * every write site (create / batchCreate / upsert / clone) and the update
+ * sites (update / batchUpdate / upsert-update).
+ */
+import { describe, it, expect, beforeEach, beforeAll } from 'vitest';
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
+import { drizzle } from 'drizzle-orm/libsql';
+import { createClient } from '@libsql/client';
+import { sql } from 'drizzle-orm';
+import {
+  fromHono,
+  defineModel,
+  defineMeta,
+  applyManagedInsertFields,
+  applyManagedUpdateFields,
+  getTimestampsConfig,
+} from '../src/index.js';
+import type { IdStrategy } from '../src/index.js';
+import {
+  MemoryCreateEndpoint,
+  MemoryReadEndpoint,
+  MemoryUpdateEndpoint,
+  MemoryListEndpoint,
+  MemoryBatchCreateEndpoint,
+  MemoryBatchUpdateEndpoint,
+  MemoryUpsertEndpoint,
+  MemoryCloneEndpoint,
+  clearStorage,
+  getStorage,
+} from '../src/adapters/memory/index.js';
+import {
+  DrizzleCreateEndpoint,
+  DrizzleUpsertEndpoint,
+  DrizzleCloneEndpoint,
+  type DrizzleDatabase,
+} from '../src/adapters/drizzle/index.js';
+
+const UUID_V4 =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+// ============================================================================
+// Schemas
+// ============================================================================
+
+const ItemSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  email: z.string().optional(),
+  createdAt: z.number().optional(),
+  updatedAt: z.number().optional(),
+});
+type Item = z.infer<typeof ItemSchema>;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+let counter = 0;
+const seqId = (): string => `seq-${++counter}`;
+
+function memoryApp(modelOverrides: Partial<{
+  id: IdStrategy;
+  timestamps: boolean | { createdAt?: string; updatedAt?: string };
+}>) {
+  const model = defineModel({
+    tableName: 'items',
+    schema: ItemSchema,
+    primaryKeys: ['id'],
+    ...modelOverrides,
+  });
+  const meta = defineMeta({ model });
+
+  class ItemCreate extends MemoryCreateEndpoint<any, typeof meta> {
+    _meta = meta;
+  }
+  class ItemRead extends MemoryReadEndpoint<any, typeof meta> {
+    _meta = meta;
+  }
+  class ItemUpdate extends MemoryUpdateEndpoint<any, typeof meta> {
+    _meta = meta;
+  }
+  class ItemList extends MemoryListEndpoint<any, typeof meta> {
+    _meta = meta;
+  }
+  class ItemBatchCreate extends MemoryBatchCreateEndpoint<any, typeof meta> {
+    _meta = meta;
+  }
+  class ItemBatchUpdate extends MemoryBatchUpdateEndpoint<any, typeof meta> {
+    _meta = meta;
+  }
+  class ItemUpsert extends MemoryUpsertEndpoint<any, typeof meta> {
+    _meta = meta;
+    upsertKeys = ['email'];
+  }
+  class ItemClone extends MemoryCloneEndpoint<any, typeof meta> {
+    _meta = meta;
+  }
+
+  const app = fromHono(new Hono());
+  app.onError((err, c) => c.json({ error: { message: err.message } }, 500));
+  // Static routes before the `/:id` param routes to avoid shadowing.
+  app.post('/items/batch', ItemBatchCreate as any);
+  app.patch('/items/batch', ItemBatchUpdate as any);
+  app.put('/items/upsert', ItemUpsert as any);
+  app.post('/items', ItemCreate as any);
+  app.get('/items', ItemList as any);
+  app.post('/items/:id/clone', ItemClone as any);
+  app.get('/items/:id', ItemRead as any);
+  app.patch('/items/:id', ItemUpdate as any);
+  return app;
+}
+
+// ============================================================================
+// Model.id strategy
+// ============================================================================
+
+describe('Model.id strategy', () => {
+  beforeEach(() => clearStorage());
+
+  it('unset => crypto.randomUUID() (regression: unchanged default)', async () => {
+    const app = memoryApp({});
+    const res = await app.request('/items', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'a' }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { result: Item };
+    expect(body.result.id).toMatch(UUID_V4);
+  });
+
+  it("'uuid' => crypto.randomUUID() (explicit, unchanged default)", async () => {
+    const app = memoryApp({ id: 'uuid' });
+    const res = await app.request('/items', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'a' }),
+    });
+    const body = (await res.json()) as { result: Item };
+    expect(body.result.id).toMatch(UUID_V4);
+  });
+
+  it('function generator => used as PK on create + batchCreate + upsert + clone', async () => {
+    counter = 0;
+    const app = memoryApp({ id: seqId });
+    const store = getStorage<Item>('items');
+
+    // create
+    const c = await app.request('/items', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'one' }),
+    });
+    const created = ((await c.json()) as { result: Item }).result;
+    expect(created.id).toBe('seq-1');
+
+    // batchCreate
+    const b = await app.request('/items/batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ items: [{ name: 'two' }, { name: 'three' }] }),
+    });
+    const batchBody = (await b.json()) as { result: { created: Item[] } };
+    expect(batchBody.result.created.map((r) => r.id)).toEqual([
+      'seq-2',
+      'seq-3',
+    ]);
+
+    // upsert (create branch)
+    const u = await app.request('/items/upsert', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'four', email: 'four@x.io' }),
+    });
+    const upserted = ((await u.json()) as { result: Item }).result;
+    expect(upserted.id).toBe('seq-4');
+
+    // clone
+    const cl = await app.request(`/items/${created.id}/clone`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    const cloned = ((await cl.json()) as { result: Item }).result;
+    expect(cloned.id).toBe('seq-5');
+    expect(cloned.id).not.toBe(created.id);
+
+    expect(store.size).toBe(5);
+  });
+
+  it('caller-supplied PK wins over every strategy (resolver precedence)', () => {
+    // The HTTP body schema strips the PK by framework design, so the
+    // precedence is the centralized resolver's contract — assert it there.
+    const fnModel = { id: seqId, primaryKeys: ['id'] as string[] };
+    expect(
+      applyManagedInsertFields({ id: 'mine', name: 'a' }, fnModel, 'memory').id
+    ).toBe('mine');
+
+    const uuidModel = { id: 'uuid' as const, primaryKeys: ['id'] as string[] };
+    expect(
+      applyManagedInsertFields({ id: 'mine', name: 'a' }, uuidModel, 'drizzle')
+        .id
+    ).toBe('mine');
+
+    const dbModel = { id: 'database' as const, primaryKeys: ['id'] as string[] };
+    const out = applyManagedInsertFields(
+      { id: 'mine', name: 'a' },
+      dbModel,
+      'drizzle'
+    );
+    expect(out.id).toBe('mine'); // not deleted: caller supplied it
+
+    // Empty-string / null PK is treated as "not supplied".
+    expect(
+      typeof applyManagedInsertFields({ id: '', name: 'a' }, uuidModel, 'memory')
+        .id
+    ).toBe('string');
+    expect(
+      applyManagedInsertFields({ id: '', name: 'a' }, uuidModel, 'memory').id
+    ).not.toBe('');
+  });
+
+  it('resolver: function/database strategy precedence + memory guard', () => {
+    const dbModel = { id: 'database' as const, primaryKeys: ['id'] as string[] };
+    // database strategy on a feasible adapter omits the PK entirely.
+    expect(
+      'id' in
+        applyManagedInsertFields({ name: 'a' }, dbModel, 'prisma')
+    ).toBe(false);
+    // memory adapter + database => throws the documented error.
+    expect(() =>
+      applyManagedInsertFields({ name: 'a' }, dbModel, 'memory')
+    ).toThrow(
+      "MemoryAdapter does not support id:'database' (no database to generate the key)"
+    );
+  });
+
+  it("'database' + memory adapter => throws the documented ConfigurationException", async () => {
+    const app = memoryApp({ id: 'database' });
+    const res = await app.request('/items', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'a' }),
+    });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toBe(
+      "MemoryAdapter does not support id:'database' (no database to generate the key)"
+    );
+  });
+});
+
+// ============================================================================
+// Model.id 'database' strategy — Drizzle ($defaultFn fills the PK)
+// ============================================================================
+
+describe("Model.id 'database' strategy (Drizzle $defaultFn)", () => {
+  const dbItems = sqliteTable('db_items', {
+    id: text('id')
+      .primaryKey()
+      .$defaultFn(() => `DBGEN-${Math.random().toString(36).slice(2, 10)}`),
+    name: text('name').notNull(),
+    email: text('email'),
+  });
+
+  const DbSchema = z.object({
+    id: z.string(),
+    name: z.string(),
+    email: z.string().nullable().optional(),
+  });
+
+  const client = createClient({ url: ':memory:' });
+  const db = drizzle(client);
+
+  const model = defineModel({
+    tableName: 'db_items',
+    schema: DbSchema,
+    primaryKeys: ['id'],
+    table: dbItems,
+    id: 'database',
+  });
+  const meta = defineMeta({ model });
+
+  class DbCreate extends DrizzleCreateEndpoint<any, typeof meta> {
+    _meta = meta;
+    db = db as unknown as DrizzleDatabase;
+  }
+  class DbUpsert extends DrizzleUpsertEndpoint<any, typeof meta> {
+    _meta = meta;
+    db = db as unknown as DrizzleDatabase;
+    upsertKeys = ['email'];
+  }
+  class DbClone extends DrizzleCloneEndpoint<any, typeof meta> {
+    _meta = meta;
+    db = db as unknown as DrizzleDatabase;
+  }
+
+  let app: Hono;
+
+  beforeAll(async () => {
+    await db.run(
+      sql`CREATE TABLE IF NOT EXISTS db_items (id TEXT PRIMARY KEY, name TEXT NOT NULL, email TEXT)`
+    );
+  });
+
+  beforeEach(async () => {
+    await db.delete(dbItems);
+    app = new Hono();
+    app.onError((err, c) => c.json({ error: { message: err.message } }, 400));
+    const withCtx =
+      <T extends { setContext: (c: unknown) => void; handle: () => Promise<Response> }>(
+        E: new () => T
+      ) =>
+      async (c: unknown) => {
+        const e = new E();
+        e.setContext(c);
+        return e.handle();
+      };
+    app.post('/db', withCtx(DbCreate));
+    app.put('/db/upsert', withCtx(DbUpsert));
+    app.post('/db/:id/clone', withCtx(DbClone));
+  });
+
+  it('omits the PK from INSERT; DB $defaultFn value is returned (create)', async () => {
+    const res = await app.request('/db', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'alpha' }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { result: { id: string; name: string } };
+    expect(body.result.name).toBe('alpha');
+    expect(body.result.id).toMatch(/^DBGEN-/);
+  });
+
+  it('database strategy applies through upsert (create branch) and clone', async () => {
+    const u = await app.request('/db/upsert', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'beta', email: 'beta@x.io' }),
+    });
+    const upserted = ((await u.json()) as { result: { id: string } }).result;
+    expect(upserted.id).toMatch(/^DBGEN-/);
+
+    const cl = await app.request(`/db/${upserted.id}/clone`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    const cloned = ((await cl.json()) as { result: { id: string } }).result;
+    expect(cloned.id).toMatch(/^DBGEN-/);
+    expect(cloned.id).not.toBe(upserted.id);
+  });
+
+  it('resolver omits PK for database strategy so RETURNING surfaces the $defaultFn value', () => {
+    const dbModel = { id: 'database' as const, primaryKeys: ['id'] as string[] };
+    const payload = applyManagedInsertFields(
+      { name: 'gamma' },
+      dbModel,
+      'drizzle'
+    );
+    // PK omitted from the insert payload => Drizzle $defaultFn fills it,
+    // then `.returning()` reflects the generated value (verified e2e above).
+    expect('id' in payload).toBe(false);
+    expect(payload.name).toBe('gamma');
+  });
+});
+
+// ============================================================================
+// Model.timestamps
+// ============================================================================
+
+describe('Model.timestamps', () => {
+  beforeEach(() => clearStorage());
+
+  it('unset => no stamping (regression)', async () => {
+    const app = memoryApp({});
+    const res = await app.request('/items', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'a' }),
+    });
+    const body = (await res.json()) as { result: Item };
+    expect(body.result.createdAt).toBeUndefined();
+    expect(body.result.updatedAt).toBeUndefined();
+  });
+
+  it('true => create sets createdAt & updatedAt (epoch ms)', async () => {
+    const before = Date.now();
+    const app = memoryApp({ timestamps: true });
+    const res = await app.request('/items', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'a' }),
+    });
+    const body = (await res.json()) as { result: Item };
+    expect(typeof body.result.createdAt).toBe('number');
+    expect(typeof body.result.updatedAt).toBe('number');
+    expect(body.result.createdAt!).toBeGreaterThanOrEqual(before);
+    expect(body.result.createdAt).toBe(body.result.updatedAt);
+  });
+
+  it('true => update bumps updatedAt, leaves createdAt untouched', async () => {
+    const app = memoryApp({ timestamps: true });
+    const c = await app.request('/items', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'a' }),
+    });
+    const created = ((await c.json()) as { result: Item }).result;
+
+    await new Promise((r) => setTimeout(r, 5));
+
+    const u = await app.request(`/items/${created.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'b' }),
+    });
+    const updated = ((await u.json()) as { result: Item }).result;
+    expect(updated.createdAt).toBe(created.createdAt);
+    expect(updated.updatedAt!).toBeGreaterThan(created.updatedAt!);
+  });
+
+  it('batchUpdate and upsert-update also bump updatedAt', async () => {
+    const app = memoryApp({ timestamps: true });
+    const c = await app.request('/items', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'a', email: 'a@x.io' }),
+    });
+    const created = ((await c.json()) as { result: Item }).result;
+
+    await new Promise((r) => setTimeout(r, 5));
+
+    // batchUpdate
+    const b = await app.request('/items/batch', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ items: [{ id: created.id, data: { name: 'b' } }] }),
+    });
+    const batchUpdated = ((await b.json()) as { result: { updated: Item[] } })
+      .result.updated[0];
+    expect(batchUpdated.createdAt).toBe(created.createdAt);
+    expect(batchUpdated.updatedAt!).toBeGreaterThan(created.updatedAt!);
+
+    await new Promise((r) => setTimeout(r, 5));
+
+    // upsert-update (existing record matched by email)
+    const u = await app.request('/items/upsert', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'c', email: 'a@x.io' }),
+    });
+    const upsertUpdated = ((await u.json()) as { result: Item }).result;
+    expect(upsertUpdated.id).toBe(created.id);
+    expect(upsertUpdated.updatedAt!).toBeGreaterThan(batchUpdated.updatedAt!);
+  });
+
+  it('object form renames the timestamp fields', async () => {
+    const app = memoryApp({
+      timestamps: { createdAt: 'created_ms', updatedAt: 'updated_ms' },
+    });
+    const store = getStorage<Record<string, unknown>>('items');
+    const res = await app.request('/items', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'a' }),
+    });
+    const body = (await res.json()) as { result: Record<string, unknown> };
+    expect(typeof body.result.created_ms).toBe('number');
+    expect(typeof body.result.updated_ms).toBe('number');
+    expect(body.result.createdAt).toBeUndefined();
+    expect(body.result.updatedAt).toBeUndefined();
+
+    const stored = [...store.values()][0];
+    expect(typeof stored.created_ms).toBe('number');
+  });
+
+  it('client-supplied updatedAt on update is overridden by the server value', async () => {
+    const app = memoryApp({ timestamps: true });
+    const c = await app.request('/items', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'a' }),
+    });
+    const created = ((await c.json()) as { result: Item }).result;
+
+    const u = await app.request(`/items/${created.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'b', updatedAt: 1 }),
+    });
+    const updated = ((await u.json()) as { result: Item }).result;
+    expect(updated.updatedAt).not.toBe(1);
+    expect(updated.updatedAt!).toBeGreaterThanOrEqual(created.createdAt!);
+  });
+
+  it('resolver: applyManagedUpdateFields always bumps updatedAt, never createdAt, ignores client value', () => {
+    // disabled => payload unchanged (new object, no stamping)
+    const off = applyManagedUpdateFields({ name: 'a' }, { timestamps: undefined });
+    expect('updatedAt' in off).toBe(false);
+
+    // enabled => updatedAt forced to a server value, client value ignored,
+    // createdAt never touched.
+    const on = applyManagedUpdateFields(
+      { name: 'a', updatedAt: 1, createdAt: 999 },
+      { timestamps: true }
+    );
+    expect(on.updatedAt).not.toBe(1);
+    expect(typeof on.updatedAt).toBe('number');
+    expect(on.createdAt).toBe(999); // untouched
+
+    // object form resolves the renamed updated field.
+    const renamed = applyManagedUpdateFields(
+      { name: 'a' },
+      { timestamps: { updatedAt: 'updated_ms' } }
+    );
+    expect(typeof (renamed as Record<string, unknown>).updated_ms).toBe(
+      'number'
+    );
+
+    // getTimestampsConfig normalization
+    expect(getTimestampsConfig(undefined).enabled).toBe(false);
+    expect(getTimestampsConfig(true)).toEqual({
+      enabled: true,
+      createdAt: 'createdAt',
+      updatedAt: 'updatedAt',
+    });
+    expect(getTimestampsConfig({ createdAt: 'c' })).toEqual({
+      enabled: true,
+      createdAt: 'c',
+      updatedAt: 'updatedAt',
+    });
+  });
+
+  it('client-supplied createdAt on create is respected (only fills when absent)', async () => {
+    const app = memoryApp({ timestamps: true });
+    const res = await app.request('/items', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'a', createdAt: 12345 }),
+    });
+    const body = (await res.json()) as { result: Item };
+    expect(body.result.createdAt).toBe(12345);
+    expect(typeof body.result.updatedAt).toBe('number');
+  });
+});


### PR DESCRIPTION
## Why

hono-crud's adapters **hardcoded primary-key generation**: every write site did `e[pk] || crypto.randomUUID()` (verified: `create`, `batchCreate`, `nativeUpsert`, `nativeBatchUpsert`, clone's `generateId()`, across the drizzle / memory / prisma adapters). There was no first-class way to choose ULID / nanoid / ksuid / a DB-generated id without a per-request hook that only covered single create.

Separately, hono-crud **did not manage `createdAt`/`updatedAt`** — no auto-stamp — so consumers relying on ORM insert-defaults saw a **silently frozen `updatedAt`** (it never changed on update; confirmed downstream).

Both are the same architectural gap: **engine-managed write-time fields with no owner**. `Model` already has a managed-field family (`softDelete` / `audit` / `versioning` / `multiTenant`); `id` and `timestamps` now join it — declared on `Model`, enforced uniformly by every adapter at every write site, exactly like `softDelete`/`audit`.

## What

- **`Model.id?: IdStrategy`** where `IdStrategy = 'uuid' | 'database' | (() => string | number)`.
  - `'uuid'` (or unset) — unchanged `crypto.randomUUID()`.
  - `function` — invoked at **every** write site by **every** adapter.
  - `'database'` — the adapter **omits the PK** from the insert payload; the DB/ORM column default fills it; the value is read back via the adapter's existing RETURNING / create-return.
- **`Model.timestamps?: boolean | { createdAt?; updatedAt? }`**.
  - INSERT paths (create / batchCreate / upsert-insert / clone): set `createdAt` & `updatedAt` to `Date.now()` unless the caller explicitly supplied that field.
  - UPDATE paths (update / batchUpdate / upsert-update): **always** set `updatedAt = Date.now()` (server-managed; any client value is ignored); `createdAt` is never touched.
  - Field names resolved from config (`true` → `createdAt`/`updatedAt`; object form renames). These are model/schema field names (the keys put into the insert/update payload).
- **Centralized resolver** — `src/core/managed-fields.ts` (`applyManagedInsertFields` / `applyManagedUpdateFields` / `getTimestampsConfig` / `assertIdStrategySupported`), surfaced as protected helpers on the base endpoint. The PK-resolution precedence + timestamp stamping live in **exactly one place**; every adapter at every write/update site routes through it (no copy-pasted precedence). The long-standing overridable clone `generateId()` hook is preserved as the default-branch generator.

## `'database'` scope (viability gate outcome)

The `'database'` strategy is shipped for **drizzle and prisma only** — the two adapters that already read the inserted row back, verified end-to-end:

- **drizzle**: a probe confirmed that omitting the PK from `.values()` with a schema `$defaultFn` returns the generated id via `.returning()[0]` (the idiomatic Drizzle mechanism consumers use for ULID/nanoid/sequence wrappers). The e2e test in this PR exercises create + upsert + clone against in-memory libsql.
- **prisma**: `@default(...)` is server-evaluated and `model.create()` always returns the full row (structurally guaranteed).
- **memory**: no database → `id:'database'` is **invalid** and throws a precise `ConfigurationException` (`MemoryAdapter does not support id:'database' (no database to generate the key)`) at the earliest write, not a silent fallback.

`'uuid' | function` is implemented fully everywhere.

## Backward compatibility

Both features default **OFF** (`id` ⇒ `uuid`, `timestamps` ⇒ no stamping): **byte-identical** behavior for existing users. Purely additive — `registerCrud`/`defineEndpoints`/`getSchema`/`toOpenApiPaths`/`tag` untouched.

## Numeric-timestamp assumption

Timestamp values are `Date.now()` — **epoch milliseconds (a `number`)**, matching the common edge/SQLite-integer convention. Schemas using non-numeric timestamp columns (ISO strings, SQL `timestamp`) should **not** enable `timestamps`. Documented on the `Model.timestamps` type.

## Test plan

- [x] `id` unset / `'uuid'` ⇒ UUIDv4 (regression — existing behavior unchanged)
- [x] function generator ⇒ used as PK on create **and** batchCreate **and** upsert **and** clone
- [x] `id:'database'` (drizzle `$defaultFn`) ⇒ PK omitted from INSERT; DB-generated value present in the returned row (create + upsert + clone, e2e)
- [x] `id:'database'` + memory ⇒ throws the documented `ConfigurationException`
- [x] caller-supplied PK precedence + memory guard (centralized-resolver contract)
- [x] `timestamps` unset ⇒ no stamping (regression)
- [x] `timestamps: true` ⇒ create stamps both (epoch ms); update bumps `updatedAt` only; batchUpdate / upsert-update also bump `updatedAt`
- [x] object form renames fields correctly
- [x] client-supplied `updatedAt` on update overridden by server value; client `createdAt` on create respected when present
- [x] `typecheck`, `typecheck:examples`, `test:unit` (804 passing, +17 new), `test:workers` (42), `test:package-example` — all green
- [ ] `test:examples` requires Postgres/Docker; environmentally unavailable here and fails **identically** on pristine `main` with zero changes (`P1001: Can't reach database server at localhost:5432`) — known environmental gap, not a regression