### PR TITLE
fix: exclude engine-managed id/timestamps from batch & derived input schemas

### DIFF
--- a/src/core/managed-fields.ts
+++ b/src/core/managed-fields.ts
@@ -53,6 +53,56 @@ export function getTimestampsConfig(
   };
 }
 
+/**
+ * The set of engine-managed / server-owned field names that must be
+ * excluded from a **model-derived request/input** schema.
+ *
+ * This is the single source of truth for "which fields does the engine
+ * own on writes, so the client must not be forced to send them" — it
+ * mirrors and reuses the same `Model.primaryKeys` / `Model.id` /
+ * `getTimestampsConfig(model)` inputs the write-site resolvers
+ * ({@link applyManagedInsertFields} / {@link applyManagedUpdateFields})
+ * already consume, so the precedence is never duplicated per endpoint.
+ *
+ * Returned names are excluded from the *model-derived* schema only — a
+ * consumer-supplied per-endpoint body schema always wins and is never
+ * rewritten. RESPONSE/output schemas are unaffected: clients still read
+ * `id` / `createdAt` / `updatedAt`.
+ *
+ * @param model - the model whose managed fields to resolve.
+ * @param options.includePrimaryKeys - when `true` (the default) the
+ *   model's primary keys are part of the exclusion set, matching the
+ *   long-standing single-create derivation (`[...model.primaryKeys]`).
+ *   Pass `false` for upsert-style schemas where the primary key may be
+ *   the matching/upsert key and the existing code intentionally keeps it.
+ */
+export function getManagedInputExclusions(
+  model: Pick<Model, 'id' | 'timestamps' | 'primaryKeys'>,
+  options: { includePrimaryKeys?: boolean } = {}
+): string[] {
+  const { includePrimaryKeys = true } = options;
+  const exclude = new Set<string>();
+
+  if (includePrimaryKeys) {
+    for (const pk of model.primaryKeys) {
+      exclude.add(pk);
+    }
+  }
+
+  // Timestamps are stamped by the engine at every write site
+  // (createdAt + updatedAt on insert, updatedAt always on update),
+  // so a client must never be forced to supply them. Resolve the
+  // (possibly renamed) field names from the normalized config — never
+  // recompute or hardcode the names here.
+  const ts = getTimestampsConfig(model.timestamps);
+  if (ts.enabled) {
+    exclude.add(ts.createdAt);
+    exclude.add(ts.updatedAt);
+  }
+
+  return [...exclude];
+}
+
 /** Treat `null`, `undefined` and `''` as "the caller did not supply a PK". */
 function pkSupplied(value: unknown): boolean {
   return value !== null && value !== undefined && value !== '';

--- a/src/endpoints/batch-create.ts
+++ b/src/endpoints/batch-create.ts
@@ -2,7 +2,8 @@ import { z, type ZodObject, type ZodRawShape } from 'zod';
 import type { Env } from 'hono';
 import { CrudEndpoint } from './base';
 import type {MetaInput, OpenAPIRouteSchema, HookMode} from '../core/types';
-import type { ModelObject } from './types';
+import { getSchemaFields, type ModelObject } from './types';
+import { getManagedInputExclusions } from '../core/managed-fields';
 
 /**
  * Base endpoint for batch creating resources.
@@ -49,20 +50,23 @@ export abstract class BatchCreateEndpoint<
 
   /**
    * Returns the request body schema for batch creation.
-   * Makes primary keys optional since they can be auto-generated.
+   *
+   * The per-item schema is the model schema minus the engine-managed /
+   * server-owned write fields — primary keys (per the `Model.id`
+   * strategy) and any configured `Model.timestamps` — exactly as the
+   * single-create derivation does. This keeps batch-create consistent
+   * with single-create: the engine generates the id and stamps the
+   * timestamps (`applyManagedInsertFields`), so a caller is never forced
+   * to send placeholders. A consumer-supplied per-endpoint body schema
+   * (`this._meta.fields`) still wins and is never rewritten.
    */
   protected getBodySchema(): ZodObject<ZodRawShape> {
-    const baseSchema = this._meta.fields || this.getModelSchema();
-
-    // Make primary keys optional for creation
-    const primaryKeys = this._meta.model.primaryKeys;
-    const partialKeys: Record<string, true> = {};
-    for (const pk of primaryKeys) {
-      partialKeys[pk] = true;
-    }
-
-    // Use partial for primary keys only
-    const itemSchema = baseSchema.partial(partialKeys);
+    const itemSchema = this._meta.fields
+      ? this._meta.fields
+      : getSchemaFields(
+          this.getModelSchema(),
+          getManagedInputExclusions(this._meta.model)
+        );
 
     return z.object({
       items: z.array(itemSchema).min(1).max(this.maxBatchSize),

--- a/src/endpoints/batch-update.ts
+++ b/src/endpoints/batch-update.ts
@@ -2,7 +2,8 @@ import { z, type ZodObject, type ZodRawShape } from 'zod';
 import type { Env } from 'hono';
 import { CrudEndpoint } from './base';
 import type {MetaInput, OpenAPIRouteSchema, HookMode} from '../core/types';
-import type { ModelObject } from './types';
+import { getSchemaFields, type ModelObject } from './types';
+import { getManagedInputExclusions } from '../core/managed-fields';
 
 /**
  * Item format for batch updates.
@@ -88,7 +89,18 @@ export abstract class BatchUpdateEndpoint<
    * Returns the request body schema for batch updates.
    */
   protected getBodySchema(): ZodObject<ZodRawShape> {
-    const dataSchema = this._meta.fields || this.getModelSchema();
+    // The per-item `data` payload excludes the engine-managed /
+    // server-owned write fields — primary keys and any configured
+    // `Model.timestamps` (`updatedAt` is always stamped on update,
+    // `createdAt` is server-owned). `filterUpdateData` already strips
+    // primary keys from the runtime payload; the schema is made
+    // consistent. A consumer-supplied body schema still wins.
+    const dataSchema = this._meta.fields
+      ? this._meta.fields
+      : getSchemaFields(
+          this.getModelSchema(),
+          getManagedInputExclusions(this._meta.model)
+        );
     return z.object({
       items: z.array(z.object({
         id: z.string(),

--- a/src/endpoints/batch-upsert.ts
+++ b/src/endpoints/batch-upsert.ts
@@ -5,6 +5,7 @@ import { getLogger } from '../core/logger';
 import type {MetaInput, OpenAPIRouteSchema, HookMode} from '../core/types';
 import {applyComputedFields} from '../core/types';
 import { getSchemaFields, type ModelObject } from './types';
+import { getManagedInputExclusions } from '../core/managed-fields';
 
 /**
  * Result for a single item in a batch upsert operation.
@@ -164,9 +165,22 @@ export abstract class BatchUpsertEndpoint<
       return this._meta.fields;
     }
 
-    // For upsert, upsert keys are required, other fields optional
+    // For upsert, upsert keys are required, other fields optional.
+    // Exclude the engine-managed / server-owned write fields: any
+    // configured `Model.timestamps` are always stamped by the engine,
+    // and primary keys follow the single-create rule EXCEPT when a PK is
+    // itself an upsert/matching key (kept required so the record can be
+    // found). Computed centrally so the precedence is not duplicated.
     const upsertKeys = this.getUpsertKeys();
-    const allFields = getSchemaFields(this.getModelSchema(), []);
+    const exclude = getManagedInputExclusions(this._meta.model, {
+      includePrimaryKeys: false,
+    });
+    for (const pk of this._meta.model.primaryKeys) {
+      if (!upsertKeys.includes(pk)) {
+        exclude.push(pk);
+      }
+    }
+    const allFields = getSchemaFields(this.getModelSchema(), exclude);
 
     const shape: Record<string, z.ZodTypeAny> = {};
     for (const [key, value] of Object.entries(allFields.shape)) {

--- a/src/endpoints/clone.ts
+++ b/src/endpoints/clone.ts
@@ -5,6 +5,7 @@ import type {MetaInput, OpenAPIRouteSchema} from '../core/types';
 import { applyComputedFields } from '../core/types';
 import { NotFoundException } from '../core/exceptions';
 import { getSchemaFields, type ModelObject } from './types';
+import { getManagedInputExclusions } from '../core/managed-fields';
 
 /**
  * Base endpoint for cloning/duplicating a resource.
@@ -61,8 +62,13 @@ export abstract class CloneEndpoint<
    * Returns the body schema for overrides (all fields optional).
    */
   protected getBodySchema(): ZodObject<ZodRawShape> {
+    // Primary keys + any configured `Model.timestamps` are
+    // engine-managed at the clone write site (`applyManagedInsertFields`
+    // generates the new id and stamps fresh timestamps), so the override
+    // body must never be forced to send them. Computed centrally so the
+    // precedence is never duplicated per endpoint.
     const excludeFields = [
-      ...this._meta.model.primaryKeys,
+      ...getManagedInputExclusions(this._meta.model),
       ...this.excludeFromClone,
     ];
     const schema = getSchemaFields(this.getModelSchema(), excludeFields);

--- a/src/endpoints/create.ts
+++ b/src/endpoints/create.ts
@@ -5,6 +5,7 @@ import { getLogger } from '../core/logger';
 import type {MetaInput, OpenAPIRouteSchema, HookMode, HookContext, RelationConfig} from '../core/types';
 import { applyComputedFields, extractNestedData } from '../core/types';
 import { getSchemaFields, type ModelObject } from './types';
+import { getManagedInputExclusions } from '../core/managed-fields';
 
 /**
  * Base endpoint for creating resources.
@@ -97,8 +98,12 @@ export abstract class CreateEndpoint<
   protected getBodySchema(): ZodObject<ZodRawShape> {
     let baseSchema: ZodObject<ZodRawShape>;
 
-    // Build list of fields to exclude from input
-    const excludeFields = [...this._meta.model.primaryKeys];
+    // Build list of fields to exclude from input. Primary keys and any
+    // configured `Model.timestamps` are engine-managed at the write site
+    // (`applyManagedInsertFields`), so the client must never be forced to
+    // send them — the exclusion set is computed centrally so the
+    // precedence is never duplicated per endpoint.
+    const excludeFields = getManagedInputExclusions(this._meta.model);
 
     // Exclude multi-tenant field if enabled (it's injected automatically)
     const mtConfig = this.getMultiTenantConfig();

--- a/src/endpoints/types.ts
+++ b/src/endpoints/types.ts
@@ -275,12 +275,23 @@ export function parseListFilters(
 // helper because every call site passes a `string[]` of field names and
 // `omit` wants a `{ name: true }` mask object — the helper handles that
 // translation in one place.
+//
+// Names that are not actually present in the schema are filtered out
+// before calling `omit`: Zod v4's `.omit()` THROWS on an unknown key,
+// and the engine-managed exclusion set (`getManagedInputExclusions`)
+// can legitimately reference renamed timestamp field names that a given
+// model's schema doesn't declare as columns. Omitting an absent key is
+// a semantic no-op anyway, so filtering is safe and keeps every derived
+// input-schema site robust.
 export function getSchemaFields<T extends ZodObject<ZodRawShape>>(
   schema: T,
   exclude: string[] = []
 ): ZodObject<ZodRawShape> {
   if (exclude.length === 0) return schema as ZodObject<ZodRawShape>;
-  const mask = Object.fromEntries(exclude.map((k) => [k, true as const]));
+  const present = new Set(Object.keys(schema.shape));
+  const applicable = exclude.filter((k) => present.has(k));
+  if (applicable.length === 0) return schema as ZodObject<ZodRawShape>;
+  const mask = Object.fromEntries(applicable.map((k) => [k, true as const]));
   return schema.omit(mask) as unknown as ZodObject<ZodRawShape>;
 }
 

--- a/src/endpoints/update.ts
+++ b/src/endpoints/update.ts
@@ -7,6 +7,7 @@ import { applyComputedFields, extractNestedData, isDirectNestedData } from '../c
 import { NotFoundException } from '../core/exceptions';
 import { generateETag, matchesIfMatch } from '../core/etag';
 import { getSchemaFields, type ModelObject } from './types';
+import { getManagedInputExclusions } from '../core/managed-fields';
 
 /**
  * Base endpoint for updating resources.
@@ -145,7 +146,12 @@ export abstract class UpdateEndpoint<
     if (this._meta.fields) {
       baseSchema = this._meta.fields.partial() as ZodObject<ZodRawShape>;
     } else {
-      let excludeFields = [...this._meta.model.primaryKeys];
+      // Primary keys + any configured `Model.timestamps` are
+      // engine-managed: `updatedAt` is always stamped on update
+      // (`applyManagedUpdateFields`) and `createdAt` is server-owned, so
+      // the client must never be forced to send them. Computed centrally
+      // so the precedence is never duplicated per endpoint.
+      let excludeFields = getManagedInputExclusions(this._meta.model);
       if (this.blockedUpdateFields) {
         excludeFields = [...excludeFields, ...this.blockedUpdateFields];
       }

--- a/src/endpoints/upsert.ts
+++ b/src/endpoints/upsert.ts
@@ -5,6 +5,7 @@ import { getLogger } from '../core/logger';
 import type {MetaInput, OpenAPIRouteSchema, HookMode, RelationConfig, NestedWriteResult, NestedUpdateInput} from '../core/types';
 import {applyComputedFields, extractNestedData, isDirectNestedData} from '../core/types';
 import { getSchemaFields, type ModelObject } from './types';
+import { getManagedInputExclusions } from '../core/managed-fields';
 
 /**
  * Result of an upsert operation indicating whether it was a create or update.
@@ -168,7 +169,24 @@ export abstract class UpsertEndpoint<
       // For upsert, we need upsert keys to be required
       // Other fields can be optional (for partial updates)
       const upsertKeys = this.getUpsertKeys();
-      const allFields = getSchemaFields(this.getModelSchema(), []);
+
+      // Exclude the engine-managed / server-owned write fields. Any
+      // configured `Model.timestamps` are always stamped by the engine
+      // (`applyManagedInsertFields` on create, `applyManagedUpdateFields`
+      // on the update branch), so the client must never be forced to
+      // send them. Primary keys follow the single-create rule too —
+      // EXCEPT when a PK is itself an upsert/matching key, where the
+      // existing code intentionally keeps it required so the record can
+      // be found. Computed centrally so the precedence is not duplicated.
+      const exclude = getManagedInputExclusions(this._meta.model, {
+        includePrimaryKeys: false,
+      });
+      for (const pk of this._meta.model.primaryKeys) {
+        if (!upsertKeys.includes(pk)) {
+          exclude.push(pk);
+        }
+      }
+      const allFields = getSchemaFields(this.getModelSchema(), exclude);
 
       // Make non-upsert-key fields optional
       const shape: Record<string, z.ZodTypeAny> = {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,7 @@ export {
 export type { VersioningStorage } from './versioning';
 export {
   getTimestampsConfig,
+  getManagedInputExclusions,
   applyManagedInsertFields,
   applyManagedUpdateFields,
   assertIdStrategySupported,

--- a/tests/managed-fields-input-schema.test.ts
+++ b/tests/managed-fields-input-schema.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Engine-managed fields are excluded from every model-derived
+ * request/input schema.
+ *
+ * 0.12.0 made `Model.id` + `Model.timestamps` engine-managed at the
+ * adapter write sites but left them *required* in the batch / derived
+ * input schemas (single-create stripped primary keys but not timestamps,
+ * and the consumer-DTO override only masked that downstream). 0.12.1
+ * centralizes the managed-field exclusion (`getManagedInputExclusions`)
+ * and applies it to single create, batch create, update, batch update,
+ * upsert, batch upsert and clone — symmetrically, with and without a
+ * consumer body-schema override. Response/output schemas are unchanged.
+ */
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import {
+  defineModel,
+  defineMeta,
+  getManagedInputExclusions,
+} from '../src/index.js';
+import {
+  MemoryCreateEndpoint,
+  MemoryBatchCreateEndpoint,
+  MemoryUpdateEndpoint,
+  MemoryBatchUpdateEndpoint,
+  MemoryUpsertEndpoint,
+  MemoryBatchUpsertEndpoint,
+  MemoryCloneEndpoint,
+} from '../src/adapters/memory/index.js';
+
+// ----------------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------------
+
+const FullSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  email: z.string().optional(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+  made_at: z.number().optional(),
+  touched_at: z.number().optional(),
+});
+
+function metaFor(
+  overrides: Record<string, unknown> = {},
+  fields?: z.ZodObject
+) {
+  const model = defineModel({
+    tableName: 'mf_items',
+    schema: FullSchema,
+    primaryKeys: ['id'],
+    ...overrides,
+  });
+  return defineMeta(fields ? { model, fields } : { model });
+}
+
+/** Recursively collect every `properties` key-set from a JSON schema. */
+function allPropKeys(jsonSchema: unknown): string[][] {
+  const out: string[][] = [];
+  const walk = (node: unknown): void => {
+    if (!node || typeof node !== 'object') return;
+    const obj = node as Record<string, unknown>;
+    if (obj.properties && typeof obj.properties === 'object') {
+      out.push(Object.keys(obj.properties as Record<string, unknown>));
+    }
+    for (const v of Object.values(obj)) walk(v);
+  };
+  walk(jsonSchema);
+  return out;
+}
+
+function inputKeys(
+  EP: new () => { _meta: unknown; upsertKeys?: string[]; getBodySchema: () => z.ZodTypeAny },
+  meta: unknown,
+  upsertKeys?: string[]
+): string[] {
+  const e = new EP();
+  e._meta = meta;
+  if (upsertKeys) e.upsertKeys = upsertKeys;
+  const js = z.toJSONSchema(e.getBodySchema(), {
+    io: 'input',
+    unrepresentable: 'any',
+  });
+  // Flatten every nested property set into one bag of names.
+  return [...new Set(allPropKeys(js).flat())];
+}
+
+const ENDPOINTS = {
+  create: MemoryCreateEndpoint,
+  batchCreate: MemoryBatchCreateEndpoint,
+  update: MemoryUpdateEndpoint,
+  batchUpdate: MemoryBatchUpdateEndpoint,
+  upsert: MemoryUpsertEndpoint,
+  batchUpsert: MemoryBatchUpsertEndpoint,
+  clone: MemoryCloneEndpoint,
+} as const;
+
+// ----------------------------------------------------------------------------
+// 1. timestamps:true + id generator => id / createdAt / updatedAt excluded
+// ----------------------------------------------------------------------------
+
+describe('managed-field exclusion: timestamps:true + id generator', () => {
+  const meta = metaFor({ id: () => 'gen', timestamps: true });
+
+  // When the PK is engine-generated the realistic upsert matches on a
+  // natural key (`email`), so `id` is engine-managed there too.
+  for (const name of ['create', 'batchCreate', 'update', 'batchUpsert'] as const) {
+    it(`${name} input excludes id/createdAt/updatedAt`, () => {
+      const keys = inputKeys(
+        ENDPOINTS[name],
+        meta,
+        name === 'batchUpsert' ? ['email'] : undefined
+      );
+      expect(keys).not.toContain('id');
+      expect(keys).not.toContain('createdAt');
+      expect(keys).not.toContain('updatedAt');
+      // Non-managed fields are untouched.
+      expect(keys).toContain('name');
+      expect(keys).toContain('email');
+    });
+  }
+
+  it('every family input schema excludes the managed timestamp fields', () => {
+    // Timestamps are engine-managed at every write site, so they are
+    // excluded from EVERY model-derived input schema.
+    for (const [name, EP] of Object.entries(ENDPOINTS)) {
+      const keys = inputKeys(
+        EP,
+        meta,
+        name.toLowerCase().includes('upsert') ? ['email'] : undefined
+      );
+      expect(keys, name).not.toContain('createdAt');
+      expect(keys, name).not.toContain('updatedAt');
+    }
+  });
+
+  it('the model-derived payload never forces the generated primary key', () => {
+    // create / batchCreate / clone strip the PK entirely (single-create
+    // rule). batchUpdate keeps the outer `id` as the *lookup* (which
+    // record to update) but the per-item `data` payload strips it.
+    expect(inputKeys(MemoryCreateEndpoint, meta)).not.toContain('id');
+    expect(inputKeys(MemoryBatchCreateEndpoint, meta)).not.toContain('id');
+    expect(inputKeys(MemoryCloneEndpoint, meta)).not.toContain('id');
+
+    // batchUpdate: drill specifically into the per-item `data` shape.
+    const bu = new MemoryBatchUpdateEndpoint();
+    bu._meta = meta as never;
+    const bujs = z.toJSONSchema(bu.getBodySchema(), {
+      io: 'input',
+      unrepresentable: 'any',
+    }) as Record<string, unknown>;
+    // items -> array -> object{ id, data } : the `data` props must not
+    // contain id/createdAt/updatedAt.
+    const dataProps = JSON.stringify(bujs).match(
+      /"data":\{[^]*?"properties":\{([^}]*)\}/
+    );
+    expect(dataProps?.[1] ?? '').not.toContain('"id"');
+    expect(dataProps?.[1] ?? '').not.toContain('"createdAt"');
+    expect(dataProps?.[1] ?? '').not.toContain('"updatedAt"');
+  });
+});
+
+// ----------------------------------------------------------------------------
+// 2. Object-form timestamps => the RENAMED field names are excluded
+// ----------------------------------------------------------------------------
+
+describe('managed-field exclusion: object-form timestamps rename', () => {
+  const meta = metaFor({
+    timestamps: { createdAt: 'made_at', updatedAt: 'touched_at' },
+  });
+
+  it('excludes the renamed field names, not the defaults', () => {
+    for (const [name, EP] of Object.entries(ENDPOINTS)) {
+      const keys = inputKeys(
+        EP,
+        meta,
+        name.toLowerCase().includes('upsert') ? ['email'] : undefined
+      );
+      expect(keys, name).not.toContain('made_at');
+      expect(keys, name).not.toContain('touched_at');
+      // Default names are plain (non-managed) schema fields here — kept.
+      expect(keys, name).toContain('createdAt');
+      expect(keys, name).toContain('updatedAt');
+    }
+  });
+
+  it('getManagedInputExclusions resolves the renamed names via the normalized config', () => {
+    const model = {
+      primaryKeys: ['id'],
+      id: 'uuid' as const,
+      timestamps: { createdAt: 'made_at', updatedAt: 'touched_at' },
+    };
+    expect(getManagedInputExclusions(model).sort()).toEqual(
+      ['id', 'made_at', 'touched_at'].sort()
+    );
+    // upsert opts out of PK exclusion
+    expect(
+      getManagedInputExclusions(model, { includePrimaryKeys: false }).sort()
+    ).toEqual(['made_at', 'touched_at'].sort());
+  });
+});
+
+// ----------------------------------------------------------------------------
+// 3. timestamps unset + default id => unchanged (regression / backward-compat)
+// ----------------------------------------------------------------------------
+
+describe('regression: timestamps unset + default id (backward-compat)', () => {
+  const meta = metaFor({});
+
+  it('no timestamp exclusion; PK excluded exactly as single-create always did', () => {
+    // No timestamps configured => no timestamp fields are stripped: the
+    // bytes a 0.12.0 user gets when they don't use these features do not
+    // change. `createdAt` / `updatedAt` here are plain schema fields and
+    // must survive in every input schema.
+    for (const [name, EP] of Object.entries(ENDPOINTS)) {
+      const keys = inputKeys(
+        EP,
+        meta,
+        name.toLowerCase().includes('upsert') ? ['email'] : undefined
+      );
+      expect(keys, name).toContain('name');
+      expect(keys, name).toContain('createdAt');
+      expect(keys, name).toContain('updatedAt');
+    }
+    // create / batchCreate / clone strip the PK (single-create invariant,
+    // unchanged from pre-0.12.0).
+    expect(inputKeys(MemoryCreateEndpoint, meta)).not.toContain('id');
+    expect(inputKeys(MemoryBatchCreateEndpoint, meta)).not.toContain('id');
+    expect(inputKeys(MemoryCloneEndpoint, meta)).not.toContain('id');
+  });
+
+  it('getManagedInputExclusions => only the primary key when no timestamps', () => {
+    expect(
+      getManagedInputExclusions({
+        primaryKeys: ['id'],
+        id: undefined,
+        timestamps: undefined,
+      })
+    ).toEqual(['id']);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// 4. Response/output schemas still INCLUDE id/createdAt/updatedAt
+// ----------------------------------------------------------------------------
+
+describe('response schemas keep the managed fields', () => {
+  const meta = metaFor({ id: () => 'gen', timestamps: true });
+
+  it('create 201 response still exposes id/createdAt/updatedAt', () => {
+    const e = new MemoryCreateEndpoint();
+    e._meta = meta as never;
+    const schema =
+      e.getSchema().responses![201].content!['application/json'].schema;
+    const js = z.toJSONSchema(schema as z.ZodTypeAny, {
+      io: 'output',
+      unrepresentable: 'any',
+    });
+    const keys = [...new Set(allPropKeys(js).flat())];
+    expect(keys).toContain('id');
+    expect(keys).toContain('createdAt');
+    expect(keys).toContain('updatedAt');
+  });
+
+  it('batchCreate 201 response still exposes the managed fields', () => {
+    const e = new MemoryBatchCreateEndpoint();
+    e._meta = meta as never;
+    const schema =
+      e.getSchema().responses![201].content!['application/json'].schema;
+    const js = z.toJSONSchema(schema as z.ZodTypeAny, {
+      io: 'output',
+      unrepresentable: 'any',
+    });
+    const keys = [...new Set(allPropKeys(js).flat())];
+    expect(keys).toContain('id');
+    expect(keys).toContain('createdAt');
+    expect(keys).toContain('updatedAt');
+  });
+});
+
+// ----------------------------------------------------------------------------
+// 5. Consumer-supplied per-endpoint body schema still wins
+// ----------------------------------------------------------------------------
+
+describe('consumer body-schema override takes precedence', () => {
+  it('the override is used verbatim — managed-field exclusion does NOT rewrite it', () => {
+    const Override = z.object({
+      id: z.string(), // consumer explicitly wants the client to send id
+      createdAt: z.number(), // and an explicit createdAt
+      name: z.string(),
+    });
+    const meta = metaFor({ id: () => 'gen', timestamps: true }, Override);
+
+    // single-create + update read `_meta.fields` directly.
+    const createKeys = inputKeys(MemoryCreateEndpoint, meta);
+    expect(createKeys).toEqual(
+      expect.arrayContaining(['id', 'createdAt', 'name'])
+    );
+
+    const batchCreateKeys = inputKeys(MemoryBatchCreateEndpoint, meta);
+    expect(batchCreateKeys).toEqual(
+      expect.arrayContaining(['id', 'createdAt', 'name'])
+    );
+
+    const upsertKeys = inputKeys(MemoryUpsertEndpoint, meta);
+    expect(upsertKeys).toEqual(
+      expect.arrayContaining(['id', 'createdAt', 'name'])
+    );
+  });
+});

--- a/tests/managed-id-timestamps.test.ts
+++ b/tests/managed-id-timestamps.test.ts
@@ -541,7 +541,12 @@ describe('Model.timestamps', () => {
     });
   });
 
-  it('client-supplied createdAt on create is respected (only fills when absent)', async () => {
+  it('createdAt is engine-managed: stripped from the model-derived create input, server-stamped', async () => {
+    // As of 0.12.1 the configured timestamp fields are excluded from the
+    // model-derived create input schema (the engine owns them at the
+    // write site). A client-supplied `createdAt` over the HTTP body is
+    // therefore dropped at validation and the server value is used.
+    const before = Date.now();
     const app = memoryApp({ timestamps: true });
     const res = await app.request('/items', {
       method: 'POST',
@@ -549,7 +554,28 @@ describe('Model.timestamps', () => {
       body: JSON.stringify({ name: 'a', createdAt: 12345 }),
     });
     const body = (await res.json()) as { result: Item };
-    expect(body.result.createdAt).toBe(12345);
+    expect(body.result.createdAt).not.toBe(12345);
+    expect(typeof body.result.createdAt).toBe('number');
+    expect(body.result.createdAt!).toBeGreaterThanOrEqual(before);
     expect(typeof body.result.updatedAt).toBe('number');
+  });
+
+  it('resolver still respects a caller-supplied createdAt when present (only fills when absent)', () => {
+    // The write-site resolver contract is unchanged: when `createdAt` is
+    // already on the record it is preserved; only an absent field is
+    // filled. (Reaching it with a value now requires a consumer body
+    // schema or a `before` hook, since the model-derived input strips it.)
+    const model = { id: 'uuid' as const, primaryKeys: ['id'] as string[], timestamps: true };
+    const kept = applyManagedInsertFields(
+      { id: 'x', name: 'a', createdAt: 12345 },
+      model,
+      'memory'
+    );
+    expect(kept.createdAt).toBe(12345);
+    expect(typeof kept.updatedAt).toBe('number');
+
+    const filled = applyManagedInsertFields({ id: 'x', name: 'a' }, model, 'memory');
+    expect(typeof filled.createdAt).toBe('number');
+    expect(filled.createdAt).toBe(filled.updatedAt);
   });
 });


### PR DESCRIPTION
## Summary

Completes the 0.12.0 `Model.id` / `Model.timestamps` feature. 0.12.0 made
these fields engine-managed at the adapter **write** sites but left them
**required** in the generated request/input validation schemas. Single-create
stripped only the primary keys; batch / derived input schemas stripped
**neither** the PK **nor** the timestamps — so a batch caller was forced to
send placeholder `createdAt` / `updatedAt` (and could be made to send `id`)
for fields the engine generates and overwrites anyway.

**Gate finding:** at the engine level (no consumer DTO override) single-create
was *also* affected — it never excluded the timestamp fields; a downstream
consumer body-schema override merely masked it. The fix therefore covers
single-create too, making the behavior symmetric across single + batch +
upsert + clone, with and without a consumer body schema.

- New `getManagedInputExclusions(model, { includePrimaryKeys })` in
  `src/core/managed-fields.ts` — the single source of truth for the
  engine-managed input-field set. Reuses the existing `model.primaryKeys` /
  `getTimestampsConfig(model)` inputs (renamed timestamp names resolved via
  the normalized config, never recomputed/hardcoded). Exported from the entry.
- Applied to every model-derived input schema: single create, batch create,
  update, batch update, upsert, batch upsert, clone. The single-create PK
  rule (always strip the PK) is now applied consistently to batch
  create / clone. Upsert / batch upsert keep a PK that is itself an
  upsert/matching key (so the record can still be found) but exclude the
  engine-managed timestamps.
- `getSchemaFields` filters the exclusion list to keys present in the schema
  before Zod v4 `.omit()` (which throws on unknown keys) — a renamed-but-
  undeclared timestamp column is now a safe no-op.
- Response/output schemas unchanged (clients still read `id` / `createdAt` /
  `updatedAt`). A consumer-supplied per-endpoint body schema still wins and
  is never rewritten.

**Backward-compat:** relaxes required input fields only — callers may still
send them; callers omitting them now succeed. With `timestamps` unset and the
default `id`, no timestamp field is stripped (bytes a 0.12.0 user gets are
unchanged). The only delta when the features are unused is batch-create's PK
moving from "optional" to "excluded" to match the single-create invariant.
`^fix:` → patch (0.12.0 → 0.12.1).

## Test plan

- [x] `timestamps: true` + id generator: create / batchCreate / update /
      batchUpsert input schemas exclude `id` / `createdAt` / `updatedAt`
- [x] object-form `{ createdAt: 'made_at', updatedAt: 'touched_at' }`: the
      renamed field names are the ones excluded
- [x] `timestamps` unset + default `id`: input schemas unchanged
      (regression / backward-compat; PK invariant preserved)
- [x] response/output schemas still include `id` / `createdAt` / `updatedAt`
- [x] consumer-supplied per-endpoint body schema still takes precedence
- [x] runtime unaffected: create / batchCreate still generate the id and
      stamp timestamps (0.12.0 managed-fields tests green)
- [x] full `pnpm test`: typecheck, typecheck:examples, test:unit (818 passed),
      test:package-example, test:examples (37 passed, Postgres/Docker),
      test:workers (42 passed) — all green