### PR TITLE
fix: complete managed-fields coverage — import strip, clone stamping, clone 409, batch defaults

### DIFF
--- a/src/core/managed-fields.ts
+++ b/src/core/managed-fields.ts
@@ -9,7 +9,7 @@
  * `audit`, `versioning` and `multiTenant`.
  */
 import type { IdStrategy, Model } from './types';
-import { ConfigurationException } from './exceptions';
+import { ConfigurationException, ConflictException } from './exceptions';
 
 /**
  * Adapter identity used to reject `id:'database'` where there is no
@@ -208,4 +208,91 @@ export function assertIdStrategySupported(
       "MemoryAdapter does not support id:'database' (no database to generate the key)"
     );
   }
+}
+
+/**
+ * Strip the engine-managed write-time fields from a record so the
+ * downstream {@link applyManagedInsertFields} call can stamp fresh
+ * values. The clone endpoint's source row carries the source's
+ * `createdAt` / `updatedAt` (and the source PK); those must NOT be
+ * copied into the new row — the new row is a brand-new write site and
+ * must get engine-fresh values exactly as a single-create does.
+ *
+ * Returns a NEW object — the input is never mutated. The set of stripped
+ * names mirrors {@link getManagedInputExclusions} (same PK + timestamps
+ * resolution), so the rule is never duplicated.
+ */
+export function stripManagedInsertFields<T extends Record<string, unknown>>(
+  record: T,
+  model: Pick<Model, 'id' | 'timestamps' | 'primaryKeys'>
+): T {
+  const out: Record<string, unknown> = { ...record };
+  for (const field of getManagedInputExclusions(model)) {
+    delete out[field];
+  }
+  return out as T;
+}
+
+/**
+ * Detect a UNIQUE-constraint violation from any adapter's underlying
+ * driver and surface it as a {@link ConflictException} (HTTP 409) so the
+ * engine's standard `{success:false, error:{code:'CONFLICT', …}}`
+ * envelope is returned to the caller instead of a plaintext 500.
+ *
+ * Returns the mapped exception when the input matches a known
+ * unique-violation shape, or `null` for anything else (so the caller
+ * rethrows the original and the global error handler decides). The
+ * recognised shapes are:
+ *
+ *  - **Drizzle (libsql / better-sqlite3 / D1)**: `LibsqlError` /
+ *    `SqliteError` with `code === 'SQLITE_CONSTRAINT_UNIQUE'` or a
+ *    message containing `UNIQUE constraint failed`.
+ *  - **Drizzle (postgres-js / node-postgres)**: PostgresError with
+ *    `code === '23505'` (`unique_violation`).
+ *  - **Drizzle (MySQL)**: `code === 'ER_DUP_ENTRY'`.
+ *  - **Prisma**: `PrismaClientKnownRequestError` with `code === 'P2002'`.
+ *
+ * The detector inspects properties (no `instanceof`) so adapters keep
+ * their dependencies optional — a Prisma-free build never imports
+ * `@prisma/client/runtime` just to check an error.
+ */
+export function mapUniqueViolation(err: unknown): ConflictException | null {
+  // Walk the `cause` chain so a wrapper (e.g. drizzle's `DrizzleQueryError`
+  // wrapping a `LibsqlError`, or any adapter that re-throws with extra
+  // context) doesn't hide the underlying driver error. Bounded depth to
+  // be safe against accidentally cyclical chains.
+  let cursor: unknown = err;
+  for (let depth = 0; depth < 8 && cursor && typeof cursor === 'object'; depth++) {
+    const e = cursor as { code?: unknown; name?: unknown; message?: unknown; cause?: unknown };
+    const code = typeof e.code === 'string' ? e.code : typeof e.code === 'number' ? e.code : '';
+    const name = typeof e.name === 'string' ? e.name : '';
+    const message = typeof e.message === 'string' ? e.message : '';
+
+    // Prisma: P2002 "Unique constraint failed on the {constraint}"
+    if (code === 'P2002') {
+      return new ConflictException('Unique constraint violation');
+    }
+    // SQLite / libSQL / D1
+    if (
+      code === 'SQLITE_CONSTRAINT_UNIQUE' ||
+      code === 'SQLITE_CONSTRAINT' ||
+      /UNIQUE constraint failed/i.test(message)
+    ) {
+      return new ConflictException('Unique constraint violation');
+    }
+    // PostgreSQL: 23505 unique_violation
+    if (code === '23505') {
+      return new ConflictException('Unique constraint violation');
+    }
+    // MySQL / MariaDB
+    if (code === 'ER_DUP_ENTRY' || code === 1062 || code === '1062') {
+      return new ConflictException('Unique constraint violation');
+    }
+    // PrismaClientKnownRequestError (defensive: name match for build variations)
+    if (name === 'PrismaClientKnownRequestError' && code === 'P2002') {
+      return new ConflictException('Unique constraint violation');
+    }
+    cursor = e.cause;
+  }
+  return null;
 }

--- a/src/endpoints/clone.ts
+++ b/src/endpoints/clone.ts
@@ -5,7 +5,11 @@ import type {MetaInput, OpenAPIRouteSchema} from '../core/types';
 import { applyComputedFields } from '../core/types';
 import { NotFoundException } from '../core/exceptions';
 import { getSchemaFields, type ModelObject } from './types';
-import { getManagedInputExclusions } from '../core/managed-fields';
+import {
+  getManagedInputExclusions,
+  mapUniqueViolation,
+  stripManagedInsertFields,
+} from '../core/managed-fields';
 
 /**
  * Base endpoint for cloning/duplicating a resource.
@@ -118,6 +122,20 @@ export abstract class CloneEndpoint<
             },
           },
         },
+        409: {
+          description: 'Unique-constraint violation (e.g. natural-key collision)',
+          content: {
+            'application/json': {
+              schema: z.object({
+                success: z.literal(false),
+                error: z.object({
+                  code: z.string(),
+                  message: z.string(),
+                }),
+              }),
+            },
+          },
+        },
       },
     };
   }
@@ -197,13 +215,19 @@ export abstract class CloneEndpoint<
       throw new NotFoundException(this._meta.model.tableName, lookupValue);
     }
 
-    // Build clone data: source minus PKs and excluded fields, plus overrides
-    const cloneData = { ...source } as Record<string, unknown>;
-
-    // Remove primary keys
-    for (const pk of this._meta.model.primaryKeys) {
-      delete cloneData[pk];
-    }
+    // Build clone data: source minus engine-managed write fields
+    // (primary keys + any configured `Model.timestamps`) and minus
+    // any `excludeFromClone` fields, plus overrides. The managed-field
+    // strip ensures the new row is a brand-new write site —
+    // `applyManagedInsertFields` (called by the adapter `createClone`)
+    // will generate a fresh primary key and stamp fresh
+    // `createdAt` / `updatedAt`, instead of copying the source's
+    // values. Computed centrally so the precedence is never
+    // duplicated.
+    const cloneData = stripManagedInsertFields(
+      source as Record<string, unknown>,
+      this._meta.model
+    );
 
     // Remove excluded fields
     for (const field of this.excludeFromClone) {
@@ -216,8 +240,20 @@ export abstract class CloneEndpoint<
     // Run before hook
     let data = await this.before(cloneData as ModelObject<M['model']>);
 
-    // Create the clone
-    let obj = await this.createClone(data);
+    // Create the clone. A clone shares the source row's natural
+    // identifiers (e.g. a `slug`) until the caller supplies an override
+    // — that turns into a UNIQUE-constraint violation at the adapter
+    // insert, which would otherwise bubble up as an unstructured 500.
+    // Map every adapter's unique-violation shape (drizzle SQLite/PG/MySQL,
+    // prisma P2002) to the engine's standard 409 envelope.
+    let obj: ModelObject<M['model']>;
+    try {
+      obj = await this.createClone(data);
+    } catch (err) {
+      const conflict = mapUniqueViolation(err);
+      if (conflict) throw conflict;
+      throw err;
+    }
 
     // Run after hook
     obj = await this.after(obj);

--- a/src/endpoints/import.ts
+++ b/src/endpoints/import.ts
@@ -2,9 +2,10 @@ import { z, type ZodObject, type ZodRawShape } from 'zod';
 import type { Env } from 'hono';
 import { CrudEndpoint } from './base';
 import type {MetaInput, OpenAPIRouteSchema} from '../core/types';
-import type { ModelObject } from './types';
+import { getSchemaFields, type ModelObject } from './types';
 import { parseCsv, validateCsvHeaders, type CsvParseOptions } from '../utils/csv';
 import { ConfigurationException, InputValidationException } from '../core/exceptions';
+import { getManagedInputExclusions } from '../core/managed-fields';
 
 // ============================================================================
 // Import Types
@@ -180,9 +181,23 @@ export abstract class ImportEndpoint<
 
   /**
    * Returns the schema for import request body.
+   *
+   * Engine-managed write fields (the `Model.id` strategy's primary key
+   * and any configured `Model.timestamps`) are excluded from the
+   * model-derived item schema — same rule the single-create and
+   * batch-create derivations follow. The engine stamps them at the
+   * write site (`applyManagedInsertFields` on create, an `UPDATE`-side
+   * stamp on upsert), so an import row must not be forced to supply
+   * them. A consumer-supplied per-endpoint body schema
+   * (`this._meta.fields`) wins verbatim and is never rewritten.
    */
   protected getImportSchema(): ZodObject<ZodRawShape> {
-    const baseSchema = this._meta.fields || this.getModelSchema();
+    const baseSchema = this._meta.fields
+      ? this._meta.fields
+      : getSchemaFields(
+          this.getModelSchema(),
+          getManagedInputExclusions(this._meta.model)
+        );
 
     // Make all fields optional for partial validation
     // The actual validation will be done per-row with detailed errors
@@ -452,11 +467,17 @@ export abstract class ImportEndpoint<
   ): { valid: boolean; errors?: Array<{ path: string; message: string }> } {
     const schema = this._meta.fields || this.getModelSchema();
 
-    // Make primary keys optional for create (they can be auto-generated)
-    const primaryKeys = this._meta.model.primaryKeys;
+    // Engine-managed fields (`Model.id` PK + `Model.timestamps`) are
+    // generated/stamped at the write site, so a row must never be
+    // forced to supply them. Mirrors the single-create / batch-create
+    // / clone derivation — same exclusion set, computed centrally so
+    // the precedence is never duplicated. Marked optional (vs
+    // omitted) here so `validateRow` keeps reporting unexpected /
+    // unknown keys for everything else, matching the long-standing
+    // per-row error format.
     const partialKeys: Record<string, true> = {};
-    for (const pk of primaryKeys) {
-      partialKeys[pk] = true;
+    for (const field of getManagedInputExclusions(this._meta.model)) {
+      partialKeys[field] = true;
     }
 
     // Also make optional import fields partial

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,8 @@ export {
   applyManagedInsertFields,
   applyManagedUpdateFields,
   assertIdStrategySupported,
+  stripManagedInsertFields,
+  mapUniqueViolation,
 } from './core/managed-fields';
 export type {
   AdapterKind,

--- a/tests/managed-fields-coverage.test.ts
+++ b/tests/managed-fields-coverage.test.ts
@@ -1,0 +1,465 @@
+/**
+ * Managed-field coverage gaps closed in 0.12.2 (follow-up to 0.12.1).
+ *
+ * 0.12.1 centralized `getManagedInputExclusions` /
+ * `applyManagedInsertFields` / `applyManagedUpdateFields` and applied
+ * them to single create, batch create, update, batch update, upsert,
+ * batch upsert and clone — but four follow-up gaps stayed open:
+ *
+ *  1. `import` per-row validation still forced the engine-managed
+ *     fields, so a minimal import body errored with
+ *     `validationErrors:[items.0.createdAt: undefined, …]`.
+ *  2. `clone` copied the source row's `createdAt` / `updatedAt` into
+ *     the new row instead of letting `applyManagedInsertFields` stamp
+ *     fresh values.
+ *  3. `clone` without a slug override surfaced the adapter's UNIQUE
+ *     violation as a plaintext 500 instead of the engine's standard
+ *     `{success:false, error:{code:"CONFLICT", …}}` 409 envelope.
+ *  4. `batch-create`'s model-derived item schema must keep every
+ *     `ZodDefault` wrapper so an item that omits a defaulted field
+ *     still parses (the engine should apply the default).
+ *
+ * All four are the same theme — managed-fields coverage — so they land
+ * together. The existing 0.12.0 / 0.12.1 tests (managed-id-timestamps,
+ * managed-fields-input-schema) stay green; this file covers only the
+ * follow-up surface.
+ */
+import { describe, it, expect, beforeEach, beforeAll } from 'vitest';
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
+import { drizzle } from 'drizzle-orm/libsql';
+import { createClient } from '@libsql/client';
+import { sql } from 'drizzle-orm';
+import {
+  fromHono,
+  defineModel,
+  defineMeta,
+  mapUniqueViolation,
+  stripManagedInsertFields,
+} from '../src/index.js';
+import {
+  MemoryImportEndpoint,
+  MemoryCloneEndpoint,
+  MemoryBatchCreateEndpoint,
+  clearStorage,
+  getStorage,
+} from '../src/adapters/memory/index.js';
+import {
+  DrizzleCloneEndpoint,
+  type DrizzleDatabase,
+} from '../src/adapters/drizzle/index.js';
+
+// ============================================================================
+// Schemas / app helpers
+// ============================================================================
+
+const ProductSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  slug: z.string(),
+  priceCents: z.number(),
+  currency: z.string().default('USD'),
+  stock: z.number().default(0),
+  createdAt: z.number().optional(),
+  updatedAt: z.number().optional(),
+});
+type Product = z.infer<typeof ProductSchema>;
+
+function memoryProductsApp() {
+  const model = defineModel({
+    tableName: 'mfc_products',
+    schema: ProductSchema,
+    primaryKeys: ['id'],
+    timestamps: true,
+  });
+  const meta = defineMeta({ model });
+
+  class ProductImport extends MemoryImportEndpoint<any, typeof meta> {
+    _meta = meta;
+    protected upsertKeys = ['slug'];
+    // No `optionalImportFields` => proves the managed-field exclusion
+    // (not `optionalImportFields`) is what makes the minimal row pass.
+    async create(data: any) {
+      // Re-use the adapter's create path so engine-managed fields are stamped.
+      const record = this.applyManagedInsertFields(
+        data as Record<string, unknown>,
+        'memory'
+      );
+      const store = getStorage<Product>('mfc_products');
+      store.set(String((record as any).id), record as Product);
+      return record as Product;
+    }
+    async update(existing: Product, data: any) {
+      const store = getStorage<Product>('mfc_products');
+      const merged = { ...existing, ...data, updatedAt: Date.now() } as Product;
+      store.set(existing.id, merged);
+      return merged;
+    }
+    async findExisting(data: any) {
+      const store = getStorage<Product>('mfc_products');
+      for (const v of store.values()) {
+        if (v.slug === data.slug) return v;
+      }
+      return null;
+    }
+  }
+  class ProductClone extends MemoryCloneEndpoint<any, typeof meta> {
+    _meta = meta;
+  }
+  class ProductBatch extends MemoryBatchCreateEndpoint<any, typeof meta> {
+    _meta = meta;
+  }
+  class ProductCreate extends MemoryImportEndpoint<any, typeof meta> {
+    // Only used to seed the store in tests; never registered.
+    _meta = meta;
+    async create(data: any) {
+      const record = this.applyManagedInsertFields(
+        data as Record<string, unknown>,
+        'memory'
+      );
+      const store = getStorage<Product>('mfc_products');
+      store.set(String((record as any).id), record as Product);
+      return record as Product;
+    }
+    async update() {
+      throw new Error('unused');
+    }
+    async findExisting() {
+      return null;
+    }
+  }
+
+  const app = fromHono(new Hono());
+  app.onError((err, c) => c.json({ error: { message: err.message } }, 500));
+  app.post('/products/import', ProductImport as any);
+  app.post('/products/batch', ProductBatch as any);
+  app.post('/products/:id/clone', ProductClone as any);
+  return { app, meta, ProductImport, ProductClone, ProductBatch, ProductCreate };
+}
+
+// ============================================================================
+// 1. Import strip — engine-managed fields excluded from the import schema
+// ============================================================================
+
+describe('import strip: engine-managed fields excluded from per-row validation', () => {
+  beforeEach(() => clearStorage());
+
+  it('minimal item (no id/createdAt/updatedAt) imports successfully', async () => {
+    const { app } = memoryProductsApp();
+    const res = await app.request('/products/import', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        items: [
+          { name: 'A', slug: 'a', priceCents: 100, currency: 'USD', stock: 0 },
+        ],
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      result: {
+        summary: { created: number; skipped: number; failed: number; total: number };
+        results: Array<{ status: string; data?: Product; validationErrors?: unknown }>;
+      };
+    };
+    expect(body.result.summary.created).toBe(1);
+    expect(body.result.summary.skipped).toBe(0);
+    expect(body.result.summary.failed).toBe(0);
+    const row = body.result.results[0];
+    expect(row.status).toBe('created');
+    // Engine-stamped fields surfaced on the created record.
+    expect(typeof row.data?.id).toBe('string');
+    expect(typeof row.data?.createdAt).toBe('number');
+    expect(typeof row.data?.updatedAt).toBe('number');
+    // No validationErrors for the managed fields.
+    expect(row.validationErrors).toBeUndefined();
+  });
+
+  it('per-row schema excludes id/createdAt/updatedAt (matches getManagedInputExclusions)', () => {
+    const { ProductImport, meta } = memoryProductsApp();
+    const inst = new ProductImport();
+    (inst as any)._meta = meta;
+    const schema = (inst as any).getImportSchema() as z.ZodTypeAny;
+    const js = z.toJSONSchema(schema, { io: 'input', unrepresentable: 'any' });
+    // The items array's element schema must not contain the managed names.
+    const text = JSON.stringify(js);
+    expect(text).not.toContain('"id"');
+    expect(text).not.toContain('"createdAt"');
+    expect(text).not.toContain('"updatedAt"');
+    // Non-managed fields are kept.
+    expect(text).toContain('"slug"');
+    expect(text).toContain('"priceCents"');
+  });
+});
+
+// ============================================================================
+// 2. Clone fresh-stamping — new record gets engine-fresh id + timestamps
+// ============================================================================
+
+describe('clone fresh-stamping: timestamps + id are engine-fresh, not copied from source', () => {
+  beforeEach(() => clearStorage());
+
+  it('cloned row has fresh createdAt/updatedAt and a fresh id', async () => {
+    const { app } = memoryProductsApp();
+
+    // Seed directly into the in-memory store with an old timestamp so a
+    // copy-vs-stamp difference is unambiguous.
+    const sourceCreatedAt = 1_000;
+    const store = getStorage<Product>('mfc_products');
+    store.set('src-1', {
+      id: 'src-1',
+      name: 'Source',
+      slug: 'source',
+      priceCents: 100,
+      currency: 'USD',
+      stock: 0,
+      createdAt: sourceCreatedAt,
+      updatedAt: sourceCreatedAt,
+    } as Product);
+
+    const before = Date.now();
+    const res = await app.request('/products/src-1/clone', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slug: 'clone-1' }),
+    });
+    const after = Date.now();
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { result: Product };
+    expect(body.result.id).not.toBe('src-1');
+    expect(body.result.slug).toBe('clone-1');
+    // Stamped fresh — not equal to the source's timestamps.
+    expect(body.result.createdAt).not.toBe(sourceCreatedAt);
+    expect(body.result.updatedAt).not.toBe(sourceCreatedAt);
+    // Stamped between the request's bracket times.
+    expect(body.result.createdAt!).toBeGreaterThanOrEqual(before);
+    expect(body.result.createdAt!).toBeLessThanOrEqual(after);
+    expect(body.result.updatedAt!).toBeGreaterThanOrEqual(before);
+    expect(body.result.updatedAt!).toBeLessThanOrEqual(after);
+  });
+
+  it('stripManagedInsertFields removes id + (resolved) timestamps from the source row', () => {
+    const out = stripManagedInsertFields(
+      {
+        id: 'x',
+        createdAt: 1,
+        updatedAt: 2,
+        name: 'keep',
+        slug: 'keep',
+      } as Record<string, unknown>,
+      { primaryKeys: ['id'], id: 'uuid', timestamps: true }
+    );
+    expect('id' in out).toBe(false);
+    expect('createdAt' in out).toBe(false);
+    expect('updatedAt' in out).toBe(false);
+    expect(out.name).toBe('keep');
+    expect(out.slug).toBe('keep');
+  });
+
+  it('stripManagedInsertFields resolves the renamed timestamp names', () => {
+    const out = stripManagedInsertFields(
+      { id: 'x', made_at: 1, touched_at: 2, name: 'keep' } as Record<string, unknown>,
+      {
+        primaryKeys: ['id'],
+        id: 'uuid',
+        timestamps: { createdAt: 'made_at', updatedAt: 'touched_at' },
+      }
+    );
+    expect('made_at' in out).toBe(false);
+    expect('touched_at' in out).toBe(false);
+    expect(out.name).toBe('keep');
+  });
+});
+
+// ============================================================================
+// 3. Clone slug-collision → 409 JSON envelope (drizzle adapter)
+// ============================================================================
+
+describe('clone unique-violation → 409 JSON envelope', () => {
+  // Memory adapter has no UNIQUE constraint, so use a real SQLite via
+  // libsql/drizzle to exercise the actual `UNIQUE constraint failed`
+  // error → 409 mapping.
+  const products = sqliteTable('mfc_products_drizzle', {
+    id: text('id').primaryKey(),
+    name: text('name').notNull(),
+    slug: text('slug').notNull().unique(),
+    priceCents: integer('price_cents').notNull(),
+  });
+  const Schema = z.object({
+    id: z.string(),
+    name: z.string(),
+    slug: z.string(),
+    priceCents: z.number(),
+  });
+  const client = createClient({ url: ':memory:' });
+  const db = drizzle(client);
+  const model = defineModel({
+    tableName: 'mfc_products_drizzle',
+    schema: Schema,
+    primaryKeys: ['id'],
+    table: products,
+  });
+  const meta = defineMeta({ model });
+
+  class ProdClone extends DrizzleCloneEndpoint<any, typeof meta> {
+    _meta = meta;
+    db = db as unknown as DrizzleDatabase;
+  }
+
+  let app: Hono;
+
+  beforeAll(async () => {
+    await db.run(
+      sql`CREATE TABLE IF NOT EXISTS mfc_products_drizzle (id TEXT PRIMARY KEY, name TEXT NOT NULL, slug TEXT NOT NULL UNIQUE, price_cents INTEGER NOT NULL)`
+    );
+  });
+
+  beforeEach(async () => {
+    await db.delete(products);
+    app = fromHono(new Hono());
+    app.post('/products/:id/clone', ProdClone as any);
+    await db.insert(products).values({
+      id: 'p-1',
+      name: 'P',
+      slug: 'p-slug',
+      priceCents: 100,
+    });
+  });
+
+  it('clone with no slug override → 409 + standard error envelope (drizzle)', async () => {
+    const res = await app.request('/products/p-1/clone', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as {
+      success: false;
+      error: { code: string; message: string };
+    };
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe('CONFLICT');
+    expect(typeof body.error.message).toBe('string');
+  });
+
+  it('clone with a distinct slug override succeeds (regression — only collisions 409)', async () => {
+    const res = await app.request('/products/p-1/clone', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slug: 'p-slug-2' }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { result: { id: string; slug: string } };
+    expect(body.result.slug).toBe('p-slug-2');
+    expect(body.result.id).not.toBe('p-1');
+  });
+});
+
+// ============================================================================
+// 3b. mapUniqueViolation — adapter-specific shapes → 409 envelope
+// ============================================================================
+
+describe('mapUniqueViolation: every adapter shape → ConflictException(409)', () => {
+  it('SQLite / libSQL / D1: SQLITE_CONSTRAINT_UNIQUE → 409', () => {
+    const out = mapUniqueViolation({
+      code: 'SQLITE_CONSTRAINT_UNIQUE',
+      message: 'UNIQUE constraint failed: products.slug',
+    });
+    expect(out).not.toBeNull();
+    expect(out!.status).toBe(409);
+    expect(out!.code).toBe('CONFLICT');
+  });
+
+  it('SQLite / libSQL / D1: bare "UNIQUE constraint failed" message → 409', () => {
+    const out = mapUniqueViolation({
+      message: 'SQLite error: UNIQUE constraint failed: products.slug',
+    });
+    expect(out).not.toBeNull();
+    expect(out!.status).toBe(409);
+  });
+
+  it('PostgreSQL: code 23505 → 409', () => {
+    const out = mapUniqueViolation({
+      code: '23505',
+      message: 'duplicate key value violates unique constraint',
+    });
+    expect(out).not.toBeNull();
+    expect(out!.status).toBe(409);
+  });
+
+  it('MySQL / MariaDB: ER_DUP_ENTRY → 409', () => {
+    const out = mapUniqueViolation({
+      code: 'ER_DUP_ENTRY',
+      message: "Duplicate entry 'x' for key 'slug'",
+    });
+    expect(out).not.toBeNull();
+    expect(out!.status).toBe(409);
+  });
+
+  it('Prisma: P2002 → 409', () => {
+    const out = mapUniqueViolation({
+      name: 'PrismaClientKnownRequestError',
+      code: 'P2002',
+      message: 'Unique constraint failed on the constraint: `products_slug_key`',
+    });
+    expect(out).not.toBeNull();
+    expect(out!.status).toBe(409);
+  });
+
+  it('non-unique errors → null (the global handler decides)', () => {
+    expect(mapUniqueViolation(new Error('boom'))).toBeNull();
+    expect(mapUniqueViolation(null)).toBeNull();
+    expect(mapUniqueViolation(undefined)).toBeNull();
+    expect(mapUniqueViolation({ code: '23502', message: 'not-null violation' })).toBeNull();
+    expect(mapUniqueViolation('plain string')).toBeNull();
+  });
+});
+
+// ============================================================================
+// 4. Batch-create preserves `.default()` wrappers on the per-item schema
+// ============================================================================
+
+describe('batch-create: ZodDefault wrappers preserved on the per-item schema', () => {
+  beforeEach(() => clearStorage());
+
+  it('an item that omits a defaulted field gets the default — not a 400', async () => {
+    const { app } = memoryProductsApp();
+    const res = await app.request('/products/batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        items: [{ name: 'A', slug: 'a', priceCents: 100 }],
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as {
+      result: { created: Product[]; count: number };
+    };
+    expect(body.result.count).toBe(1);
+    expect(body.result.created[0].currency).toBe('USD');
+    expect(body.result.created[0].stock).toBe(0);
+  });
+
+  it('OpenAPI per-item schema shape marks defaulted fields as not-required', () => {
+    const { ProductBatch, meta } = memoryProductsApp();
+    const inst = new ProductBatch();
+    (inst as any)._meta = meta;
+    const schema = (inst as any).getBodySchema() as z.ZodTypeAny;
+    const js = z.toJSONSchema(schema, { io: 'input', unrepresentable: 'any' }) as any;
+    // Navigate body.items[].properties + required.
+    const itemDef = js.properties?.items?.items as any;
+    expect(itemDef).toBeTruthy();
+    const required: string[] = itemDef.required ?? [];
+    // Defaulted fields are NOT in `required` (Zod v4 marks ZodDefault input as optional).
+    expect(required).not.toContain('currency');
+    expect(required).not.toContain('stock');
+    // Plain required fields stay required.
+    expect(required).toContain('name');
+    expect(required).toContain('slug');
+    expect(required).toContain('priceCents');
+    // The properties bag carries the defaulted fields (they're still accepted on input).
+    expect(itemDef.properties).toHaveProperty('currency');
+    expect(itemDef.properties).toHaveProperty('stock');
+  });
+});


### PR DESCRIPTION
## Summary

Closes four follow-up gaps from 0.12.1's centralized managed-fields work (`getManagedInputExclusions` / `applyManagedInsertFields` / `applyManagedUpdateFields`). All four sit in the same family — write sites that should let the engine own `id` / timestamps and surface adapter unique violations through the standard error envelope. One coherent `fix:` PR → patch 0.12.1 → **0.12.2**.

### 1. Import per-row validation strips engine-managed fields

`POST /products/import {items:[{name,slug,priceCents,currency,stock}]}` was 200ing with `summary.skipped:1` and `validationErrors:[items.0.createdAt: undefined, items.0.updatedAt: undefined]` because `validateRow()` only marked the primary key (and `optionalImportFields`) as partial — the timestamps stayed required.

`src/endpoints/import.ts` now routes both `getImportSchema()` and `validateRow()` through `getManagedInputExclusions(this._meta.model)`. Mirrors the create / batch-create / clone derivation rule, so a minimal item passes and the engine stamps `id` / `createdAt` / `updatedAt`.

### 2. Clone stamps fresh `id` + timestamps

`POST /{srcId}/clone {slug:'new'}` was returning a row whose `createdAt` / `updatedAt` matched the source's — `applyManagedInsertFields` uses `if (!(ts.createdAt in record))`, and the source row carries those keys.

The base `CloneEndpoint.handle()` now strips the source row's engine-managed fields via the new `stripManagedInsertFields(source, model)` helper before handing off to the adapter's `createClone()`. The downstream `applyManagedInsertFields` then stamps engine-fresh values exactly as it does for a single-create. The strip uses the same resolved field names (`Model.id` + `Model.timestamps`) so the precedence is never duplicated.

### 3. Clone unique-violation → 409 envelope

`POST /{srcId}/clone` with no slug override was bubbling SQLite's `UNIQUE constraint failed` up as a plaintext 500.

New `mapUniqueViolation(err): ConflictException | null` in `src/core/managed-fields.ts` recognises every supported adapter's driver shape:

| Adapter | Detection |
|---|---|
| Drizzle (libSQL / better-sqlite3 / D1) | `code === 'SQLITE_CONSTRAINT_UNIQUE'` or message matches `/UNIQUE constraint failed/i` |
| Drizzle (postgres-js / pg) | `code === '23505'` (`unique_violation`) |
| Drizzle (MySQL / MariaDB) | `code === 'ER_DUP_ENTRY'` or `code === 1062` |
| Prisma | `code === 'P2002'` (also `name === 'PrismaClientKnownRequestError'`) |

The mapper walks the error's `cause` chain (bounded depth) so wrapper errors like Drizzle's `DrizzleQueryError` don't hide the underlying driver code. On match it returns a `ConflictException` (HTTP 409 with the standard `{success:false, error:{code:'CONFLICT', message, …}}` envelope) — on non-match it returns `null` and the caller rethrows so the global handler decides.

The clone endpoint's response schema now advertises the 409.

### 4. Batch-create preserves `ZodDefault` wrappers

`POST /products/batch {items:[{name,slug,priceCents}]}` (omitting `currency` / `stock` which have `.default('USD')` / `.default(0)`) needed to apply the defaults at parse time, not 400. Zod v4's `.omit()` (which `getSchemaFields` uses) does preserve `ZodDefault` wrappers — the per-item schema was already correct; this PR adds the missing regression test so the contract is locked.

## What ships in the helper module

The two new helpers live next to the existing managed-field primitives in `src/core/managed-fields.ts` and are exported from the package root:

```ts
export function stripManagedInsertFields<T>(record: T, model): T;
export function mapUniqueViolation(err: unknown): ConflictException | null;
```

Adapters can adopt the same unique-violation mapping at other write sites (create / batch-create / upsert) later without duplicating the per-adapter shape table.

## Out of scope

- `description` / `archivedAt` `.nullable()`-required-key (downstream)
- soft-delete wiring
- `archivedAt`-writable-in-upsert

## Test plan

- [x] New `tests/managed-fields-coverage.test.ts` — 15 cases:
  - Import strip: minimal item imports, per-row schema excludes `id` / `createdAt` / `updatedAt`
  - Clone fresh-stamping: cloned row's `id` / `createdAt` / `updatedAt` ≠ source's, stamped within the request bracket
  - `stripManagedInsertFields` — default + renamed timestamps
  - Clone unique-violation → 409 envelope via the **drizzle libSQL adapter** (real SQLite `UNIQUE constraint failed`); regression test asserts a distinct slug still 201s
  - `mapUniqueViolation` — every adapter shape (SQLite code + message, Postgres `23505`, MySQL `ER_DUP_ENTRY`, Prisma `P2002`) + null on non-unique / null / undefined / strings
  - Batch-create defaults: end-to-end POST verifies `currency:'USD'` / `stock:0` populated when omitted; OpenAPI per-item schema marks defaulted fields not-required
- [x] `pnpm run typecheck` — green
- [x] `pnpm run typecheck:examples` — green
- [x] `pnpm run test:unit` — **833 passed** (was 818 on pristine main; +15 new, 0 regressions)
- [x] `pnpm run test:package-example` — green
- [x] `pnpm run test:workers` — 42 passed
- [ ] `pnpm run test:examples` — requires Postgres on `localhost:5432`; fails identically on pristine `origin/main` in this environment (known env gap, unrelated)

## Release

- Conventional commit prefix `fix:` → release action bumps **0.12.1 → 0.12.2** (patch).
- No `!`, no `BREAKING CHANGE` in the commit body.
- Does not touch `package.json#version` or `CHANGELOG.md` (auto-generated).