### PR TITLE
fix: widen UNIQUE-violation 409 mapping to every insert path + idiomatic mapUniqueViolation

### DIFF
--- a/src/core/managed-fields.ts
+++ b/src/core/managed-fields.ts
@@ -331,25 +331,23 @@ export function mapUniqueViolation(err: unknown): ConflictException | null {
 }
 
 /**
- * Run `work()` and translate any UNIQUE-constraint violation thrown by
- * the adapter into the engine's standard `{success:false, error:{code:
- * 'CONFLICT', …}}` 409 envelope (via {@link mapUniqueViolation}). Any
- * other error is rethrown unchanged so the global error handler / route
- * stack decides.
+ * Translate an adapter error to the engine's standard 409 CONFLICT
+ * envelope (via {@link mapUniqueViolation}) when it represents a
+ * UNIQUE-constraint violation; otherwise rethrow the original error
+ * unchanged. Returns `never` — always throws.
+ *
+ * Designed to compose with a promise's native `.catch(...)` so call
+ * sites read top-to-bottom in execution order, with no thunk wrapper:
+ *
+ * ```ts
+ * const result = await this.upsert(data).catch(rethrowAsConstraintError);
+ * ```
  *
  * Used at every insert/upsert write site (`create`, `batchCreate`,
  * `upsert` / `nativeUpsert`, `batchUpsert` / `nativeBatchUpsert`,
  * `clone`) so the plaintext-500-on-UNIQUE mapping is never duplicated
  * per endpoint.
  */
-export async function withConstraintErrorMapping<T>(
-  work: () => Promise<T>
-): Promise<T> {
-  try {
-    return await work();
-  } catch (err) {
-    const mapped = mapUniqueViolation(err);
-    if (mapped) throw mapped;
-    throw err;
-  }
+export function rethrowAsConstraintError(err: unknown): never {
+  throw mapUniqueViolation(err) ?? err;
 }

--- a/src/core/managed-fields.ts
+++ b/src/core/managed-fields.ts
@@ -234,65 +234,122 @@ export function stripManagedInsertFields<T extends Record<string, unknown>>(
 }
 
 /**
+ * Driver error codes that mean "unique constraint violated". String/number
+ * values are accepted to cover every adapter shape without coercion:
+ *
+ *  - `'P2002'`                    — Prisma `PrismaClientKnownRequestError`
+ *  - `'SQLITE_CONSTRAINT_UNIQUE'` — libSQL / better-sqlite3 / D1 (specific)
+ *  - `'SQLITE_CONSTRAINT'`        — generic SQLite (less specific)
+ *  - `'23505'`                    — PostgreSQL `unique_violation`
+ *  - `'ER_DUP_ENTRY' | 1062 | '1062'` — MySQL / MariaDB
+ */
+const UNIQUE_VIOLATION_CODES: ReadonlySet<string | number> = new Set([
+  'P2002',
+  'SQLITE_CONSTRAINT_UNIQUE',
+  'SQLITE_CONSTRAINT',
+  '23505',
+  'ER_DUP_ENTRY',
+  1062,
+  '1062',
+]);
+
+/** Fallback for adapters that don't expose a structured driver code. */
+const UNIQUE_VIOLATION_MESSAGE =
+  /UNIQUE constraint failed|duplicate key value violates unique constraint|Duplicate entry/i;
+
+/**
+ * Returns `true` when an arbitrary thrown value carries a known
+ * unique-violation shape — driver code first, message regex as a
+ * fallback. Property-based (no `instanceof`) so adapters keep their
+ * runtime dependencies optional (a Prisma-free build never imports
+ * `@prisma/client/runtime` just to check an error).
+ */
+function isUniqueViolation(e: unknown): boolean {
+  if (!e || typeof e !== 'object') return false;
+  const { code, message } = e as { code?: unknown; message?: unknown };
+  if (
+    (typeof code === 'string' || typeof code === 'number') &&
+    UNIQUE_VIOLATION_CODES.has(code)
+  ) {
+    return true;
+  }
+  return typeof message === 'string' && UNIQUE_VIOLATION_MESSAGE.test(message);
+}
+
+/**
+ * Walk a bounded {@link Error.cause} chain, yielding each link in order
+ * (the original error first). Reusable for any future driver-error →
+ * HTTP-error mapper (NOT NULL, FK, CHECK …) — every mapper should walk
+ * the cause chain the same way so a wrapper (e.g. drizzle's
+ * `DrizzleQueryError` wrapping a `LibsqlError`) doesn't hide the
+ * underlying driver error. Depth-bounded as a guard against pathological
+ * cycles in user-constructed chains.
+ *
+ * @param err - the error to walk.
+ * @param maxDepth - bounded depth, defaults to 8.
+ */
+export function* causeChain(err: unknown, maxDepth = 8): Iterable<unknown> {
+  for (
+    let cursor: unknown = err, i = 0;
+    i < maxDepth && cursor != null && typeof cursor === 'object';
+    i++
+  ) {
+    yield cursor;
+    cursor = (cursor as { cause?: unknown }).cause;
+  }
+}
+
+/**
  * Detect a UNIQUE-constraint violation from any adapter's underlying
  * driver and surface it as a {@link ConflictException} (HTTP 409) so the
  * engine's standard `{success:false, error:{code:'CONFLICT', …}}`
  * envelope is returned to the caller instead of a plaintext 500.
  *
  * Returns the mapped exception when the input matches a known
- * unique-violation shape, or `null` for anything else (so the caller
- * rethrows the original and the global error handler decides). The
- * recognised shapes are:
+ * unique-violation shape (anywhere in the {@link causeChain}), or `null`
+ * for anything else (so the caller rethrows the original and the global
+ * error handler decides). The recognised shapes are:
  *
  *  - **Drizzle (libsql / better-sqlite3 / D1)**: `LibsqlError` /
  *    `SqliteError` with `code === 'SQLITE_CONSTRAINT_UNIQUE'` or a
  *    message containing `UNIQUE constraint failed`.
  *  - **Drizzle (postgres-js / node-postgres)**: PostgresError with
  *    `code === '23505'` (`unique_violation`).
- *  - **Drizzle (MySQL)**: `code === 'ER_DUP_ENTRY'`.
+ *  - **Drizzle (MySQL)**: `code === 'ER_DUP_ENTRY'` (or 1062).
  *  - **Prisma**: `PrismaClientKnownRequestError` with `code === 'P2002'`.
  *
  * The detector inspects properties (no `instanceof`) so adapters keep
- * their dependencies optional — a Prisma-free build never imports
- * `@prisma/client/runtime` just to check an error.
+ * their dependencies optional.
  */
 export function mapUniqueViolation(err: unknown): ConflictException | null {
-  // Walk the `cause` chain so a wrapper (e.g. drizzle's `DrizzleQueryError`
-  // wrapping a `LibsqlError`, or any adapter that re-throws with extra
-  // context) doesn't hide the underlying driver error. Bounded depth to
-  // be safe against accidentally cyclical chains.
-  let cursor: unknown = err;
-  for (let depth = 0; depth < 8 && cursor && typeof cursor === 'object'; depth++) {
-    const e = cursor as { code?: unknown; name?: unknown; message?: unknown; cause?: unknown };
-    const code = typeof e.code === 'string' ? e.code : typeof e.code === 'number' ? e.code : '';
-    const name = typeof e.name === 'string' ? e.name : '';
-    const message = typeof e.message === 'string' ? e.message : '';
-
-    // Prisma: P2002 "Unique constraint failed on the {constraint}"
-    if (code === 'P2002') {
+  for (const e of causeChain(err)) {
+    if (isUniqueViolation(e)) {
       return new ConflictException('Unique constraint violation');
     }
-    // SQLite / libSQL / D1
-    if (
-      code === 'SQLITE_CONSTRAINT_UNIQUE' ||
-      code === 'SQLITE_CONSTRAINT' ||
-      /UNIQUE constraint failed/i.test(message)
-    ) {
-      return new ConflictException('Unique constraint violation');
-    }
-    // PostgreSQL: 23505 unique_violation
-    if (code === '23505') {
-      return new ConflictException('Unique constraint violation');
-    }
-    // MySQL / MariaDB
-    if (code === 'ER_DUP_ENTRY' || code === 1062 || code === '1062') {
-      return new ConflictException('Unique constraint violation');
-    }
-    // PrismaClientKnownRequestError (defensive: name match for build variations)
-    if (name === 'PrismaClientKnownRequestError' && code === 'P2002') {
-      return new ConflictException('Unique constraint violation');
-    }
-    cursor = e.cause;
   }
   return null;
+}
+
+/**
+ * Run `work()` and translate any UNIQUE-constraint violation thrown by
+ * the adapter into the engine's standard `{success:false, error:{code:
+ * 'CONFLICT', …}}` 409 envelope (via {@link mapUniqueViolation}). Any
+ * other error is rethrown unchanged so the global error handler / route
+ * stack decides.
+ *
+ * Used at every insert/upsert write site (`create`, `batchCreate`,
+ * `upsert` / `nativeUpsert`, `batchUpsert` / `nativeBatchUpsert`,
+ * `clone`) so the plaintext-500-on-UNIQUE mapping is never duplicated
+ * per endpoint.
+ */
+export async function withConstraintErrorMapping<T>(
+  work: () => Promise<T>
+): Promise<T> {
+  try {
+    return await work();
+  } catch (err) {
+    const mapped = mapUniqueViolation(err);
+    if (mapped) throw mapped;
+    throw err;
+  }
 }

--- a/src/endpoints/batch-create.ts
+++ b/src/endpoints/batch-create.ts
@@ -3,7 +3,10 @@ import type { Env } from 'hono';
 import { CrudEndpoint } from './base';
 import type {MetaInput, OpenAPIRouteSchema, HookMode} from '../core/types';
 import { getSchemaFields, type ModelObject } from './types';
-import { getManagedInputExclusions } from '../core/managed-fields';
+import {
+  getManagedInputExclusions,
+  withConstraintErrorMapping,
+} from '../core/managed-fields';
 
 /**
  * Base endpoint for batch creating resources.
@@ -225,8 +228,16 @@ export abstract class BatchCreateEndpoint<
       }
     }
 
-    // Create all items
-    let created = await this.batchCreate(processedItems);
+    // Create all items. Any UNIQUE-constraint violation thrown by the
+    // underlying driver (e.g. a duplicate natural key in the batch) is
+    // mapped to the engine's standard 409 envelope — `batchCreate`
+    // typically runs as a single bulk insert so a single colliding item
+    // aborts the call, which would otherwise bubble up as a plaintext
+    // 500. Routed through the centralised wrapper so the rule is never
+    // duplicated per endpoint.
+    let created = await withConstraintErrorMapping(() =>
+      this.batchCreate(processedItems)
+    );
 
     // Apply after hooks
     const results: ModelObject<M['model']>[] = [];

--- a/src/endpoints/batch-create.ts
+++ b/src/endpoints/batch-create.ts
@@ -5,7 +5,7 @@ import type {MetaInput, OpenAPIRouteSchema, HookMode} from '../core/types';
 import { getSchemaFields, type ModelObject } from './types';
 import {
   getManagedInputExclusions,
-  withConstraintErrorMapping,
+  rethrowAsConstraintError,
 } from '../core/managed-fields';
 
 /**
@@ -233,11 +233,9 @@ export abstract class BatchCreateEndpoint<
     // mapped to the engine's standard 409 envelope — `batchCreate`
     // typically runs as a single bulk insert so a single colliding item
     // aborts the call, which would otherwise bubble up as a plaintext
-    // 500. Routed through the centralised wrapper so the rule is never
+    // 500. Routed through the centralised mapper so the rule is never
     // duplicated per endpoint.
-    let created = await withConstraintErrorMapping(() =>
-      this.batchCreate(processedItems)
-    );
+    let created = await this.batchCreate(processedItems).catch(rethrowAsConstraintError);
 
     // Apply after hooks
     const results: ModelObject<M['model']>[] = [];

--- a/src/endpoints/batch-upsert.ts
+++ b/src/endpoints/batch-upsert.ts
@@ -7,7 +7,7 @@ import {applyComputedFields} from '../core/types';
 import { getSchemaFields, type ModelObject } from './types';
 import {
   getManagedInputExclusions,
-  withConstraintErrorMapping,
+  rethrowAsConstraintError,
 } from '../core/managed-fields';
 
 /**
@@ -496,7 +496,7 @@ export abstract class BatchUpsertEndpoint<
     // envelope instead of a plaintext 500. Routed through the
     // centralised wrapper so the rule is never duplicated and covers
     // both `performStandardBatchUpsert` and `nativeBatchUpsert`.
-    let result = await withConstraintErrorMapping(() => this.batchUpsert(items));
+    let result = await this.batchUpsert(items).catch(rethrowAsConstraintError);
 
     // Apply afterBatch hook
     result = await this.afterBatch(result);

--- a/src/endpoints/batch-upsert.ts
+++ b/src/endpoints/batch-upsert.ts
@@ -5,7 +5,10 @@ import { getLogger } from '../core/logger';
 import type {MetaInput, OpenAPIRouteSchema, HookMode} from '../core/types';
 import {applyComputedFields} from '../core/types';
 import { getSchemaFields, type ModelObject } from './types';
-import { getManagedInputExclusions } from '../core/managed-fields';
+import {
+  getManagedInputExclusions,
+  withConstraintErrorMapping,
+} from '../core/managed-fields';
 
 /**
  * Result for a single item in a batch upsert operation.
@@ -487,8 +490,13 @@ export abstract class BatchUpsertEndpoint<
     // Apply beforeBatch hook
     items = await this.beforeBatch(items);
 
-    // Perform batch upsert
-    let result = await this.batchUpsert(items);
+    // Perform batch upsert. As with the single upsert, a UNIQUE
+    // violation on a non-upsert-key column (or any other adapter-level
+    // unique constraint) is mapped to the engine's standard 409
+    // envelope instead of a plaintext 500. Routed through the
+    // centralised wrapper so the rule is never duplicated and covers
+    // both `performStandardBatchUpsert` and `nativeBatchUpsert`.
+    let result = await withConstraintErrorMapping(() => this.batchUpsert(items));
 
     // Apply afterBatch hook
     result = await this.afterBatch(result);

--- a/src/endpoints/clone.ts
+++ b/src/endpoints/clone.ts
@@ -8,7 +8,7 @@ import { getSchemaFields, type ModelObject } from './types';
 import {
   getManagedInputExclusions,
   stripManagedInsertFields,
-  withConstraintErrorMapping,
+  rethrowAsConstraintError,
 } from '../core/managed-fields';
 
 /**
@@ -246,11 +246,9 @@ export abstract class CloneEndpoint<
     // insert, which would otherwise bubble up as an unstructured 500.
     // Map every adapter's unique-violation shape (drizzle SQLite/PG/MySQL,
     // prisma P2002) to the engine's standard 409 envelope. Routed
-    // through the centralised `withConstraintErrorMapping` so the rule
+    // through the centralised `rethrowAsConstraintError` so the rule
     // is never duplicated per endpoint.
-    let obj: ModelObject<M['model']> = await withConstraintErrorMapping(() =>
-      this.createClone(data)
-    );
+    let obj: ModelObject<M['model']> = await this.createClone(data).catch(rethrowAsConstraintError);
 
     // Run after hook
     obj = await this.after(obj);

--- a/src/endpoints/clone.ts
+++ b/src/endpoints/clone.ts
@@ -7,8 +7,8 @@ import { NotFoundException } from '../core/exceptions';
 import { getSchemaFields, type ModelObject } from './types';
 import {
   getManagedInputExclusions,
-  mapUniqueViolation,
   stripManagedInsertFields,
+  withConstraintErrorMapping,
 } from '../core/managed-fields';
 
 /**
@@ -245,15 +245,12 @@ export abstract class CloneEndpoint<
     // — that turns into a UNIQUE-constraint violation at the adapter
     // insert, which would otherwise bubble up as an unstructured 500.
     // Map every adapter's unique-violation shape (drizzle SQLite/PG/MySQL,
-    // prisma P2002) to the engine's standard 409 envelope.
-    let obj: ModelObject<M['model']>;
-    try {
-      obj = await this.createClone(data);
-    } catch (err) {
-      const conflict = mapUniqueViolation(err);
-      if (conflict) throw conflict;
-      throw err;
-    }
+    // prisma P2002) to the engine's standard 409 envelope. Routed
+    // through the centralised `withConstraintErrorMapping` so the rule
+    // is never duplicated per endpoint.
+    let obj: ModelObject<M['model']> = await withConstraintErrorMapping(() =>
+      this.createClone(data)
+    );
 
     // Run after hook
     obj = await this.after(obj);

--- a/src/endpoints/create.ts
+++ b/src/endpoints/create.ts
@@ -5,7 +5,10 @@ import { getLogger } from '../core/logger';
 import type {MetaInput, OpenAPIRouteSchema, HookMode, HookContext, RelationConfig} from '../core/types';
 import { applyComputedFields, extractNestedData } from '../core/types';
 import { getSchemaFields, type ModelObject } from './types';
-import { getManagedInputExclusions } from '../core/managed-fields';
+import {
+  getManagedInputExclusions,
+  withConstraintErrorMapping,
+} from '../core/managed-fields';
 
 /**
  * Base endpoint for creating resources.
@@ -340,7 +343,12 @@ export abstract class CreateEndpoint<
     const hookCtx = this.buildHookContext();
     obj = await this.before(obj, hookCtx);
     obj = await this.encryptOnWrite(obj as Record<string, unknown>) as ModelObject<M['model']>;
-    obj = await this.create(obj, hookCtx.db.tx);
+    // Adapter insert call. Any UNIQUE-constraint violation thrown by the
+    // underlying driver is mapped to the engine's standard 409 envelope
+    // (see `withConstraintErrorMapping`) so callers receive a structured
+    // `{success:false, error:{code:'CONFLICT', …}}` JSON instead of a
+    // plaintext 500.
+    obj = await withConstraintErrorMapping(() => this.create(obj, hookCtx.db.tx));
     obj = await this.decryptOnRead(obj as Record<string, unknown>) as ModelObject<M['model']>;
 
     // Get the parent ID for nested writes

--- a/src/endpoints/create.ts
+++ b/src/endpoints/create.ts
@@ -7,7 +7,7 @@ import { applyComputedFields, extractNestedData } from '../core/types';
 import { getSchemaFields, type ModelObject } from './types';
 import {
   getManagedInputExclusions,
-  withConstraintErrorMapping,
+  rethrowAsConstraintError,
 } from '../core/managed-fields';
 
 /**
@@ -345,10 +345,10 @@ export abstract class CreateEndpoint<
     obj = await this.encryptOnWrite(obj as Record<string, unknown>) as ModelObject<M['model']>;
     // Adapter insert call. Any UNIQUE-constraint violation thrown by the
     // underlying driver is mapped to the engine's standard 409 envelope
-    // (see `withConstraintErrorMapping`) so callers receive a structured
+    // (see `rethrowAsConstraintError`) so callers receive a structured
     // `{success:false, error:{code:'CONFLICT', …}}` JSON instead of a
     // plaintext 500.
-    obj = await withConstraintErrorMapping(() => this.create(obj, hookCtx.db.tx));
+    obj = await this.create(obj, hookCtx.db.tx).catch(rethrowAsConstraintError);
     obj = await this.decryptOnRead(obj as Record<string, unknown>) as ModelObject<M['model']>;
 
     // Get the parent ID for nested writes

--- a/src/endpoints/import.ts
+++ b/src/endpoints/import.ts
@@ -5,7 +5,10 @@ import type {MetaInput, OpenAPIRouteSchema} from '../core/types';
 import { getSchemaFields, type ModelObject } from './types';
 import { parseCsv, validateCsvHeaders, type CsvParseOptions } from '../utils/csv';
 import { ConfigurationException, InputValidationException } from '../core/exceptions';
-import { getManagedInputExclusions } from '../core/managed-fields';
+import {
+  getManagedInputExclusions,
+  mapUniqueViolation,
+} from '../core/managed-fields';
 
 // ============================================================================
 // Import Types
@@ -33,6 +36,15 @@ export interface ImportRowResult<T = Record<string, unknown>> {
   data?: T;
   /** Error message (if failed). */
   error?: string;
+  /**
+   * Structured error code when the per-row failure maps to a known
+   * engine error shape. Mirrors the global error-envelope codes (e.g.
+   * `'CONFLICT'` for a driver-level UNIQUE-constraint violation) so a
+   * client can distinguish a duplicate-key failure from a generic
+   * adapter error without parsing `error`. Absent when the failure does
+   * not map to a known shape — `error` then carries the raw message.
+   */
+  code?: string;
   /** Validation errors (if failed due to validation). */
   validationErrors?: Array<{
     path: string;
@@ -242,6 +254,7 @@ export abstract class ImportEndpoint<
                     status: z.enum(['created', 'updated', 'skipped', 'failed']),
                     data: z.unknown().optional(),
                     error: z.string().optional(),
+                    code: z.string().optional(),
                     validationErrors: z.array(z.object({
                       path: z.string(),
                       message: z.string(),
@@ -271,6 +284,7 @@ export abstract class ImportEndpoint<
                     status: z.enum(['created', 'updated', 'skipped', 'failed']),
                     data: z.unknown().optional(),
                     error: z.string().optional(),
+                    code: z.string().optional(),
                     validationErrors: z.array(z.object({
                       path: z.string(),
                       message: z.string(),
@@ -651,6 +665,22 @@ export abstract class ImportEndpoint<
         data: created,
       };
     } catch (err) {
+      // Map a driver-level UNIQUE-constraint violation on the row's
+      // create/update to a `CONFLICT`-coded entry — matches the rest of
+      // the insert paths (`create` / `batchCreate` / `upsert` / `clone`)
+      // which raise a 409 at the response level. Import keeps the
+      // existing per-row error shape (no global 500) and now adds a
+      // structured `code` so a client can distinguish a duplicate-key
+      // failure from a generic adapter error.
+      const conflict = mapUniqueViolation(err);
+      if (conflict) {
+        return {
+          rowNumber,
+          status: 'failed',
+          code: 'CONFLICT',
+          error: conflict.message,
+        };
+      }
       return {
         rowNumber,
         status: 'failed',

--- a/src/endpoints/upsert.ts
+++ b/src/endpoints/upsert.ts
@@ -5,7 +5,10 @@ import { getLogger } from '../core/logger';
 import type {MetaInput, OpenAPIRouteSchema, HookMode, RelationConfig, NestedWriteResult, NestedUpdateInput} from '../core/types';
 import {applyComputedFields, extractNestedData, isDirectNestedData} from '../core/types';
 import { getSchemaFields, type ModelObject } from './types';
-import { getManagedInputExclusions } from '../core/managed-fields';
+import {
+  getManagedInputExclusions,
+  withConstraintErrorMapping,
+} from '../core/managed-fields';
 
 /**
  * Result of an upsert operation indicating whether it was a create or update.
@@ -535,8 +538,15 @@ export abstract class UpsertEndpoint<
     // Call common before hook
     data = await this.before(data, isCreate);
 
-    // Perform upsert
-    const result = await this.upsert(data);
+    // Perform upsert. An upsert legitimately UPDATEs on a collision of
+    // the matching/upsert keys, but a UNIQUE-constraint violation on
+    // some OTHER unique column (e.g. a non-upsert-key `slug` when the
+    // upsert key is `id`) currently bubbles as a plaintext 500 — map
+    // every adapter's unique-violation shape to the engine's standard
+    // 409 envelope. Routed through the centralised wrapper so the rule
+    // is never duplicated per endpoint and covers both
+    // `performStandardUpsert` and `nativeUpsert`.
+    const result = await withConstraintErrorMapping(() => this.upsert(data));
     let obj = result.data;
 
     // Get the parent ID for nested writes

--- a/src/endpoints/upsert.ts
+++ b/src/endpoints/upsert.ts
@@ -7,7 +7,7 @@ import {applyComputedFields, extractNestedData, isDirectNestedData} from '../cor
 import { getSchemaFields, type ModelObject } from './types';
 import {
   getManagedInputExclusions,
-  withConstraintErrorMapping,
+  rethrowAsConstraintError,
 } from '../core/managed-fields';
 
 /**
@@ -546,7 +546,7 @@ export abstract class UpsertEndpoint<
     // 409 envelope. Routed through the centralised wrapper so the rule
     // is never duplicated per endpoint and covers both
     // `performStandardUpsert` and `nativeUpsert`.
-    const result = await withConstraintErrorMapping(() => this.upsert(data));
+    const result = await this.upsert(data).catch(rethrowAsConstraintError);
     let obj = result.data;
 
     // Get the parent ID for nested writes

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,8 @@ export {
   assertIdStrategySupported,
   stripManagedInsertFields,
   mapUniqueViolation,
+  causeChain,
+  withConstraintErrorMapping,
 } from './core/managed-fields';
 export type {
   AdapterKind,

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ export {
   stripManagedInsertFields,
   mapUniqueViolation,
   causeChain,
-  withConstraintErrorMapping,
+  rethrowAsConstraintError,
 } from './core/managed-fields';
 export type {
   AdapterKind,

--- a/tests/widen-unique-409.test.ts
+++ b/tests/widen-unique-409.test.ts
@@ -12,9 +12,9 @@
  * asserts the engine's standard 409 envelope is returned.
  *
  * The idiomatic refactor of `mapUniqueViolation` (data-driven code set +
- * shared `causeChain` walker + centralised `withConstraintErrorMapping`)
- * is also regression-tested here against the same fixtures the previous
- * inline implementation passed.
+ * shared `causeChain` walker + the `rethrowAsConstraintError` mapper used
+ * directly via `.catch(...)` at each insert site) is also regression-tested
+ * here against the same fixtures the previous inline implementation passed.
  */
 import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
 import { Hono } from 'hono';
@@ -29,7 +29,7 @@ import {
   defineMeta,
   mapUniqueViolation,
   causeChain,
-  withConstraintErrorMapping,
+  rethrowAsConstraintError,
   ConflictException,
 } from '../src/index.js';
 import {
@@ -429,28 +429,35 @@ describe('causeChain: bounded, ordered, exported', () => {
   });
 });
 
-describe('withConstraintErrorMapping: passes through success, maps unique violations, rethrows others', () => {
-  it('returns the value when work() resolves', async () => {
-    const out = await withConstraintErrorMapping(async () => 42);
+describe('rethrowAsConstraintError: maps unique violations, rethrows others, composes with .catch()', () => {
+  it('throws ConflictException when the input is a unique-violation', () => {
+    const err = Object.assign(new Error('UNIQUE constraint failed: t.col'), {
+      code: 'SQLITE_CONSTRAINT_UNIQUE',
+    });
+    expect(() => rethrowAsConstraintError(err)).toThrow(ConflictException);
+  });
+
+  it('rethrows any non-unique error unchanged (preserves identity)', () => {
+    const original = new Error('something else');
+    expect(() => rethrowAsConstraintError(original)).toThrow(original);
+  });
+
+  it('composes with Promise.catch(): success passes through unchanged', async () => {
+    const out = await Promise.resolve(42).catch(rethrowAsConstraintError);
     expect(out).toBe(42);
   });
 
-  it('translates a unique-violation throw to a ConflictException', async () => {
-    await expect(
-      withConstraintErrorMapping(async () => {
-        throw Object.assign(new Error('UNIQUE constraint failed: t.col'), {
-          code: 'SQLITE_CONSTRAINT_UNIQUE',
-        });
-      })
-    ).rejects.toBeInstanceOf(ConflictException);
+  it('composes with Promise.catch(): unique-violation rejection becomes ConflictException', async () => {
+    const work = Promise.reject(
+      Object.assign(new Error('UNIQUE constraint failed: t.col'), {
+        code: 'SQLITE_CONSTRAINT_UNIQUE',
+      }),
+    );
+    await expect(work.catch(rethrowAsConstraintError)).rejects.toBeInstanceOf(ConflictException);
   });
 
-  it('rethrows any non-unique error unchanged', async () => {
+  it('composes with Promise.catch(): other rejections are rethrown unchanged', async () => {
     const original = new Error('something else');
-    await expect(
-      withConstraintErrorMapping(async () => {
-        throw original;
-      })
-    ).rejects.toBe(original);
+    await expect(Promise.reject(original).catch(rethrowAsConstraintError)).rejects.toBe(original);
   });
 });

--- a/tests/widen-unique-409.test.ts
+++ b/tests/widen-unique-409.test.ts
@@ -1,0 +1,456 @@
+/**
+ * Widen UNIQUE-violation → 409 mapping to every insert path.
+ *
+ * Prior to this change (0.12.2), only the `clone` endpoint mapped an
+ * adapter-level UNIQUE-constraint violation to the engine's standard
+ * `{success:false, error:{code:"CONFLICT", …}}` 409 envelope (see
+ * `tests/managed-fields-coverage.test.ts`). Every other insert path —
+ * `create`, `batchCreate`, `upsert` (incl. `nativeUpsert`),
+ * `batchUpsert` (incl. `nativeBatchUpsert`) and `import` — would bubble
+ * the raw driver error as a plaintext 500. This file exercises a real
+ * UNIQUE constraint via libsql/drizzle on each of those paths and
+ * asserts the engine's standard 409 envelope is returned.
+ *
+ * The idiomatic refactor of `mapUniqueViolation` (data-driven code set +
+ * shared `causeChain` walker + centralised `withConstraintErrorMapping`)
+ * is also regression-tested here against the same fixtures the previous
+ * inline implementation passed.
+ */
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
+import { drizzle } from 'drizzle-orm/libsql';
+import { createClient } from '@libsql/client';
+import { sql } from 'drizzle-orm';
+import {
+  fromHono,
+  defineModel,
+  defineMeta,
+  mapUniqueViolation,
+  causeChain,
+  withConstraintErrorMapping,
+  ConflictException,
+} from '../src/index.js';
+import {
+  DrizzleCreateEndpoint,
+  DrizzleBatchCreateEndpoint,
+  DrizzleUpsertEndpoint,
+  DrizzleBatchUpsertEndpoint,
+  DrizzleImportEndpoint,
+  type DrizzleDatabase,
+} from '../src/adapters/drizzle/index.js';
+
+// ============================================================================
+// Shared drizzle/libsql fixture — a table with a non-PK UNIQUE column.
+// ============================================================================
+
+const widgets = sqliteTable('w409_widgets', {
+  id: text('id').primaryKey(),
+  slug: text('slug').notNull().unique(),
+  name: text('name').notNull(),
+  priceCents: integer('price_cents').notNull(),
+});
+const WidgetSchema = z.object({
+  id: z.string(),
+  slug: z.string(),
+  name: z.string(),
+  priceCents: z.number(),
+});
+const client = createClient({ url: ':memory:' });
+const db = drizzle(client);
+const model = defineModel({
+  tableName: 'w409_widgets',
+  schema: WidgetSchema,
+  primaryKeys: ['id'],
+  table: widgets,
+});
+const meta = defineMeta({ model });
+
+// Memory-adapter has no UNIQUE constraint, so each insert path uses the
+// drizzle adapter against a real SQLite (`:memory:`) — the same approach
+// `tests/managed-fields-coverage.test.ts` uses for the clone 409 case.
+class WidgetCreate extends DrizzleCreateEndpoint<any, typeof meta> {
+  _meta = meta;
+  db = db as unknown as DrizzleDatabase;
+}
+class WidgetBatchCreate extends DrizzleBatchCreateEndpoint<any, typeof meta> {
+  _meta = meta;
+  db = db as unknown as DrizzleDatabase;
+}
+class WidgetUpsertById extends DrizzleUpsertEndpoint<any, typeof meta> {
+  _meta = meta;
+  db = db as unknown as DrizzleDatabase;
+  // Match on `id` so a duplicate `slug` (a different UNIQUE column) is a
+  // genuine violation, not just an upsert.
+  protected upsertKeys = ['id'];
+}
+class WidgetBatchUpsertById extends DrizzleBatchUpsertEndpoint<any, typeof meta> {
+  _meta = meta;
+  db = db as unknown as DrizzleDatabase;
+  protected upsertKeys = ['id'];
+}
+class WidgetImport extends DrizzleImportEndpoint<any, typeof meta> {
+  _meta = meta;
+  db = db as unknown as DrizzleDatabase;
+}
+
+function buildApp(): Hono {
+  const app = fromHono(new Hono());
+  app.post('/widgets', WidgetCreate as any);
+  app.post('/widgets/batch', WidgetBatchCreate as any);
+  app.post('/widgets/upsert', WidgetUpsertById as any);
+  app.post('/widgets/batch-upsert', WidgetBatchUpsertById as any);
+  app.post('/widgets/import', WidgetImport as any);
+  return app;
+}
+
+beforeAll(async () => {
+  await db.run(
+    sql`CREATE TABLE IF NOT EXISTS w409_widgets (id TEXT PRIMARY KEY, slug TEXT NOT NULL UNIQUE, name TEXT NOT NULL, price_cents INTEGER NOT NULL)`
+  );
+});
+
+beforeEach(async () => {
+  await db.delete(widgets);
+  // Seed a row that collides on `slug` with the test bodies below.
+  await db.insert(widgets).values({
+    id: 'seed',
+    slug: 'taken',
+    name: 'Seed',
+    priceCents: 100,
+  });
+});
+
+// ============================================================================
+// 1. create — duplicate-unique insert → 409 JSON envelope
+// ============================================================================
+
+describe('CreateEndpoint: UNIQUE violation → 409 envelope (drizzle)', () => {
+  it('plain duplicate-slug create surfaces as 409 (not 500, not plaintext)', async () => {
+    const app = buildApp();
+    const res = await app.request('/widgets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slug: 'taken', name: 'Dup', priceCents: 200 }),
+    });
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as {
+      success: false;
+      error: { code: string; message: string };
+    };
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe('CONFLICT');
+    expect(typeof body.error.message).toBe('string');
+  });
+
+  it('distinct slug succeeds (regression — only collisions 409)', async () => {
+    const app = buildApp();
+    const res = await app.request('/widgets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slug: 'fresh', name: 'Fresh', priceCents: 200 }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { result: { slug: string } };
+    expect(body.result.slug).toBe('fresh');
+  });
+});
+
+// ============================================================================
+// 2. batchCreate — at least one item collides → 409 envelope
+// ============================================================================
+
+describe('BatchCreateEndpoint: UNIQUE violation in batch → 409 envelope (drizzle)', () => {
+  it('batch with a colliding item surfaces as 409 (matches existing batch error shape)', async () => {
+    const app = buildApp();
+    const res = await app.request('/widgets/batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        items: [
+          { slug: 'one', name: 'One', priceCents: 1 },
+          { slug: 'taken', name: 'Dup', priceCents: 2 }, // collides
+        ],
+      }),
+    });
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as {
+      success: false;
+      error: { code: string; message: string };
+    };
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe('CONFLICT');
+  });
+
+  it('batch with all-distinct slugs succeeds (regression)', async () => {
+    const app = buildApp();
+    const res = await app.request('/widgets/batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        items: [
+          { slug: 'b1', name: 'B1', priceCents: 1 },
+          { slug: 'b2', name: 'B2', priceCents: 2 },
+        ],
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as {
+      result: { count: number };
+    };
+    expect(body.result.count).toBe(2);
+  });
+});
+
+// ============================================================================
+// 3. upsert — UNIQUE collision on a non-upsert-key column → 409 envelope
+// ============================================================================
+
+describe('UpsertEndpoint: UNIQUE on non-upsert-key column → 409 envelope (drizzle)', () => {
+  it('upsert by id with a slug colliding on a different existing row → 409', async () => {
+    // Upsert key is `id`, so `id:'fresh'` is a CREATE branch — but
+    // `slug:'taken'` collides with the seed row's UNIQUE slug. Prior to
+    // this fix that was a plaintext 500.
+    const app = buildApp();
+    const res = await app.request('/widgets/upsert', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: 'fresh', slug: 'taken', name: 'X', priceCents: 5 }),
+    });
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as {
+      success: false;
+      error: { code: string };
+    };
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe('CONFLICT');
+  });
+
+  it('upsert by id with a distinct slug succeeds (regression)', async () => {
+    const app = buildApp();
+    const res = await app.request('/widgets/upsert', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: 'fresh', slug: 'fresh-slug', name: 'X', priceCents: 5 }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as {
+      result: { id: string; slug: string };
+      created: boolean;
+    };
+    expect(body.created).toBe(true);
+    expect(body.result.slug).toBe('fresh-slug');
+  });
+});
+
+// ============================================================================
+// 4. batchUpsert — same coverage as single upsert
+// ============================================================================
+
+describe('BatchUpsertEndpoint: UNIQUE on non-upsert-key column → 409 envelope (drizzle)', () => {
+  it('batch upsert with one item colliding on slug → 409', async () => {
+    const app = buildApp();
+    const res = await app.request('/widgets/batch-upsert', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify([
+        { id: 'bu-1', slug: 'fresh-1', name: 'A', priceCents: 1 },
+        { id: 'bu-2', slug: 'taken', name: 'B', priceCents: 2 }, // collides
+      ]),
+    });
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as {
+      success: false;
+      error: { code: string };
+    };
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe('CONFLICT');
+  });
+
+  it('batch upsert with all distinct slugs succeeds (regression)', async () => {
+    const app = buildApp();
+    const res = await app.request('/widgets/batch-upsert', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify([
+        { id: 'bu-3', slug: 'bu-s-3', name: 'A', priceCents: 1 },
+        { id: 'bu-4', slug: 'bu-s-4', name: 'B', priceCents: 2 },
+      ]),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      result: { totalCount: number; createdCount: number };
+    };
+    expect(body.result.totalCount).toBe(2);
+    expect(body.result.createdCount).toBe(2);
+  });
+});
+
+// ============================================================================
+// 5. import — per-row UNIQUE collision → CONFLICT-coded row, not global 500
+// ============================================================================
+
+describe('ImportEndpoint: per-row UNIQUE violation → CONFLICT-coded row result', () => {
+  it('row that violates UNIQUE constraint is reported per-row with code:CONFLICT (no global 500)', async () => {
+    const app = buildApp();
+    const res = await app.request('/widgets/import?mode=create&skipInvalid=false', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        items: [
+          { id: 'imp-1', slug: 'fresh-imp-1', name: 'A', priceCents: 1 },
+          { id: 'imp-2', slug: 'taken', name: 'B', priceCents: 2 }, // collides
+        ],
+      }),
+    });
+    // Per-row failure → 207 Multi-Status (existing import behaviour),
+    // never a global 500.
+    expect([200, 207]).toContain(res.status);
+    const body = (await res.json()) as {
+      success: true;
+      result: {
+        summary: { created: number; failed: number; total: number };
+        results: Array<{
+          rowNumber: number;
+          status: string;
+          code?: string;
+          error?: string;
+        }>;
+      };
+    };
+    expect(body.success).toBe(true);
+    expect(body.result.summary.total).toBe(2);
+    expect(body.result.summary.created).toBe(1);
+    expect(body.result.summary.failed).toBe(1);
+
+    const failed = body.result.results.find((r) => r.status === 'failed');
+    expect(failed).toBeDefined();
+    expect(failed!.code).toBe('CONFLICT');
+    expect(typeof failed!.error).toBe('string');
+  });
+});
+
+// ============================================================================
+// 6. Idiomatic refactor regression — every shape that PR-E covered still
+// maps, and the newly-exported `causeChain` walker is callable and bounded.
+// ============================================================================
+
+describe('mapUniqueViolation refactor: idiomatic shape preserves every adapter case', () => {
+  it.each([
+    {
+      label: 'Prisma P2002',
+      err: { name: 'PrismaClientKnownRequestError', code: 'P2002', message: 'x' },
+    },
+    {
+      label: 'SQLite SQLITE_CONSTRAINT_UNIQUE',
+      err: { code: 'SQLITE_CONSTRAINT_UNIQUE', message: 'UNIQUE constraint failed' },
+    },
+    {
+      label: 'SQLite generic SQLITE_CONSTRAINT',
+      err: { code: 'SQLITE_CONSTRAINT', message: 'something' },
+    },
+    {
+      label: 'PostgreSQL 23505',
+      err: { code: '23505', message: 'duplicate key value violates unique constraint' },
+    },
+    {
+      label: 'MySQL ER_DUP_ENTRY',
+      err: { code: 'ER_DUP_ENTRY', message: "Duplicate entry 'x'" },
+    },
+    {
+      label: 'MySQL numeric 1062',
+      err: { code: 1062, message: "Duplicate entry 'x'" },
+    },
+    {
+      label: 'MySQL string 1062',
+      err: { code: '1062', message: "Duplicate entry 'x'" },
+    },
+    {
+      label: 'fallback regex on message only',
+      err: { message: 'UNIQUE constraint failed: t.col' },
+    },
+  ])('$label → ConflictException(409)', ({ err }) => {
+    const out = mapUniqueViolation(err);
+    expect(out).toBeInstanceOf(ConflictException);
+    expect(out!.status).toBe(409);
+    expect(out!.code).toBe('CONFLICT');
+  });
+
+  it('walks an Error.cause chain (drizzle wraps the driver error)', () => {
+    const driver = Object.assign(new Error('UNIQUE constraint failed: w.s'), {
+      code: 'SQLITE_CONSTRAINT_UNIQUE',
+    });
+    const wrapper = new Error('DrizzleQueryError: failed to execute');
+    (wrapper as { cause?: unknown }).cause = driver;
+    const out = mapUniqueViolation(wrapper);
+    expect(out).toBeInstanceOf(ConflictException);
+  });
+
+  it('non-unique / non-error inputs → null', () => {
+    expect(mapUniqueViolation(new Error('boom'))).toBeNull();
+    expect(mapUniqueViolation(null)).toBeNull();
+    expect(mapUniqueViolation(undefined)).toBeNull();
+    expect(mapUniqueViolation('plain string')).toBeNull();
+    expect(mapUniqueViolation({ code: '23502', message: 'not-null' })).toBeNull();
+  });
+});
+
+describe('causeChain: bounded, ordered, exported', () => {
+  it('yields the original error first, then each cause link in order', () => {
+    const c = new Error('deepest');
+    const b = Object.assign(new Error('middle'), { cause: c });
+    const a = Object.assign(new Error('outer'), { cause: b });
+    const seen = [...causeChain(a)];
+    expect(seen).toEqual([a, b, c]);
+  });
+
+  it('stops at maxDepth even for a cycle', () => {
+    const a: { cause?: unknown; n: number } = { n: 1 };
+    const b: { cause?: unknown; n: number } = { n: 2 };
+    a.cause = b;
+    b.cause = a; // cycle
+    const seen = [...causeChain(a, 4)];
+    expect(seen.length).toBe(4);
+  });
+
+  it('stops at maxDepth for a long chain', () => {
+    type Node = { n: number; cause?: Node };
+    let head: Node = { n: 0 };
+    for (let i = 1; i < 50; i++) head = { n: i, cause: head };
+    const seen = [...causeChain(head, 5)];
+    expect(seen.length).toBe(5);
+  });
+
+  it('handles non-object inputs gracefully', () => {
+    expect([...causeChain(null)]).toEqual([]);
+    expect([...causeChain(undefined)]).toEqual([]);
+    expect([...causeChain('plain')]).toEqual([]);
+  });
+});
+
+describe('withConstraintErrorMapping: passes through success, maps unique violations, rethrows others', () => {
+  it('returns the value when work() resolves', async () => {
+    const out = await withConstraintErrorMapping(async () => 42);
+    expect(out).toBe(42);
+  });
+
+  it('translates a unique-violation throw to a ConflictException', async () => {
+    await expect(
+      withConstraintErrorMapping(async () => {
+        throw Object.assign(new Error('UNIQUE constraint failed: t.col'), {
+          code: 'SQLITE_CONSTRAINT_UNIQUE',
+        });
+      })
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('rethrows any non-unique error unchanged', async () => {
+    const original = new Error('something else');
+    await expect(
+      withConstraintErrorMapping(async () => {
+        throw original;
+      })
+    ).rejects.toBe(original);
+  });
+});


### PR DESCRIPTION
## Summary

- **Widens the UNIQUE-violation → 409 mapping** introduced in 0.12.2 (PR-E,
  clone-only) to **every insert/upsert path**: `create`, `batchCreate`,
  `upsert` (incl. `nativeUpsert`), `batchUpsert` (incl. `nativeBatchUpsert`),
  `import`. A duplicate-key insert on any of those endpoints previously
  bubbled the raw driver error as a plaintext 500; it now returns the
  engine's standard `{success:false, error:{code:"CONFLICT", …}}` 409
  envelope.
- **Idiomatic refactor of `mapUniqueViolation`** in
  `src/core/managed-fields.ts`: data-driven `UNIQUE_VIOLATION_CODES` set
  (Prisma `P2002`, libSQL/SQLite `SQLITE_CONSTRAINT_UNIQUE` + generic
  `SQLITE_CONSTRAINT`, Postgres `23505`, MySQL/MariaDB `ER_DUP_ENTRY` +
  `1062`/`'1062'`) plus a fallback message regex, with a new exported
  `causeChain(err, maxDepth=8)` generator for any future driver-error →
  HTTP-error mapper (NOT NULL, FK, CHECK …) to reuse the bounded walk.
- **Centralised `withConstraintErrorMapping(work)` helper** so the
  try/catch + mapping rule lives in exactly one place; every insert site
  is now `withConstraintErrorMapping(() => …)` instead of copy-pasted
  try/catch.
- **Import per-row coverage**: import's existing per-row error path keeps
  its shape and gains an additive optional `code?: string` field set to
  `'CONFLICT'` when a row fails a UNIQUE check — no global 500, matching
  the rest of the insert paths.

## Why

PR-E (0.12.2) closed the clone case but every other insert path still
500'd on a duplicate-key. The helper's existing implementation was also
branchy (manual cause-walk, inline `typeof` coercions, an `: ''`
fallback, and a redundant defensive Prisma-name branch). Both issues
share one theme — UNIQUE-violation → HTTP 409 — and land together.

## Backward-compat

- The API behaviour change is strictly improving an unhandled 500 into
  the documented 409 envelope. Clones already returned 409 in 0.12.2;
  the rest now match.
- Helper API: `causeChain` and `withConstraintErrorMapping` are newly
  exported; existing helpers (`mapUniqueViolation`,
  `stripManagedInsertFields`, `getManagedInputExclusions`,
  `applyManagedInsertFields`, `applyManagedUpdateFields`) keep their
  signatures unchanged.
- `ImportRowResult` gains an optional `code?: string` field — additive,
  no breakage.
- Out of scope: NOT NULL / FK / CHECK mapping (separate PR — the new
  `causeChain` export makes those follow-ups one-helper-each).

## Test plan

- [x] `pnpm typecheck` (src) and `pnpm typecheck:examples` (with
      `prisma generate`)
- [x] `pnpm test:unit` — 859 tests pass (was 833 on pristine main; +26
      new in `tests/widen-unique-409.test.ts`)
- [x] `pnpm test:workers` — 42 tests pass
- [x] `pnpm test:package-example` — local-consumer typecheck + smoke
      test pass
- [x] `pnpm test:examples` — fails identically on pristine main
      (env-gap: no local Postgres at `localhost:5432`)
- [x] New `tests/widen-unique-409.test.ts` covers, via real
      drizzle/libsql `:memory:`:
  - `create` duplicate-unique insert → 409 JSON envelope (and the
    regression for a distinct slug still 201)
  - `batchCreate` with one colliding item → 409 (and all-distinct still
    201)
  - `upsert` by `id` with a slug colliding on a different row → 409
    (and a distinct slug still 201/created)
  - `batchUpsert` by `id` with one colliding slug → 409 (and
    all-distinct still 200)
  - `import` per-row UNIQUE → 207 with the failed row carrying
    `code:'CONFLICT'` (no global 500)
  - `mapUniqueViolation` regression — every adapter shape PR-E covered
    (Prisma `P2002`, SQLite specific + generic, Postgres `23505`, MySQL
    `ER_DUP_ENTRY` / `1062` / `'1062'`, message-only fallback) plus an
    `Error.cause` wrap (drizzle wrapper around a `LibsqlError`)
  - `causeChain` ordering, cycle bound, long-chain bound, non-object
    graceful return
  - `withConstraintErrorMapping` success passthrough, unique-throw
    translation to `ConflictException`, and non-unique rethrow