### PR TITLE
fix: SearchEndpoint - Zod 4 field detect + paramName wired + total_count reconciliation

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -305,10 +305,6 @@ interface SearchHooks<M extends MetaInput> {
 
 /**
  * Search endpoint configuration.
- *
- * Note: `paramName` is reserved in the briefed shape but not currently wired —
- * the SearchEndpoint reads its query from a fixed `q` param. Override via a
- * subclass for now; first-class config will follow if there's demand.
  */
 export interface SearchEndpointConfig<M extends MetaInput> {
   openapi?: OpenAPIConfig;
@@ -316,7 +312,11 @@ export interface SearchEndpointConfig<M extends MetaInput> {
   middlewares?: MiddlewareHandler[];
   /** Fields included in the search index (maps to SearchEndpoint.searchFields). */
   fields?: string[];
-  /** Reserved — currently unused; SearchEndpoint reads `q` by default. */
+  /**
+   * Query parameter name carrying the search string. Defaults to `'q'`.
+   * Maps to `SearchEndpoint.searchParamName`. Set e.g. `'query'` to expose
+   * `/search?query=foo` instead of `/search?q=foo`.
+   */
   paramName?: string;
   /** Default search mode: 'any' | 'all' | 'phrase'. Maps to SearchEndpoint.defaultMode. */
   mode?: 'any' | 'all' | 'phrase';
@@ -823,6 +823,7 @@ export function defineEndpoints<M extends MetaInput, E extends Env = Env>(
       extras: {
         ...(cfg.fields !== undefined ? { searchFields: cfg.fields } : {}),
         ...(cfg.mode !== undefined ? { defaultMode: cfg.mode } : {}),
+        ...(cfg.paramName !== undefined ? { searchParamName: cfg.paramName } : {}),
       },
     });
   }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1847,8 +1847,28 @@ export interface SearchOptions {
 export interface SearchResult<T> {
   /** Search result items with scores and highlights */
   items: SearchResultItem<T>[];
-  /** Total number of matching records (before pagination) */
+  /**
+   * Total number of matching records before pagination.
+   *
+   * For adapters whose initial candidate set is a SQL `LIKE` (or similar)
+   * filter and which then apply in-memory tokenization / scoring / minScore
+   * on top, this field is the raw SQL hit count. Set
+   * {@link SearchResult.postFilteredCount} to the post-filter count so that
+   * the public `result_info.total_count` reflects what the client actually
+   * receives. Without `postFilteredCount`, `total_count` falls back to
+   * `totalCount` (back-compatible).
+   */
   totalCount: number;
+  /**
+   * Optional: number of records that survived BOTH the adapter's initial
+   * candidate filter (e.g. SQL LIKE) and any in-memory post-filtering
+   * (tokenization, stopword removal, minScore). Adapters that perform
+   * such post-filtering should populate this so that
+   * `result_info.total_count` matches the user-visible result set and
+   * pagination math is correct. When omitted, the handler falls back to
+   * `totalCount`.
+   */
+  postFilteredCount?: number;
 }
 
 /**

--- a/src/endpoints/search.ts
+++ b/src/endpoints/search.ts
@@ -20,6 +20,30 @@ import {
 } from './search-utils';
 
 /**
+ * Detect a string schema across Zod 3 and Zod 4.
+ *
+ * Zod 3 exposed the schema kind via `_def.typeName === 'ZodString'`. Zod 4
+ * reshaped its internals: `_def.type === 'string'` (and mirrored on `def`).
+ * `instanceof z.ZodString` is also stable across both majors when callers
+ * use the same Zod version as `hono-crud`, but the structural checks make
+ * this robust to dual-Zod installs in monorepos and any future minor
+ * internal drift. Tried in cheapest-first order.
+ */
+function isZodStringSchema(schema: unknown): boolean {
+  if (schema instanceof z.ZodString) return true;
+  const s = schema as {
+    _def?: { type?: string; typeName?: string };
+    def?: { type?: string };
+  } | null | undefined;
+  if (!s) return false;
+  return (
+    s._def?.type === 'string' ||
+    s._def?.typeName === 'ZodString' ||
+    s.def?.type === 'string'
+  );
+}
+
+/**
  * Base endpoint for full-text search with filtering, relevance scoring, and highlighting.
  * Extend this class and implement the `search` method for your ORM.
  *
@@ -100,6 +124,13 @@ export abstract class SearchEndpoint<
    * Results below this score are excluded.
    */
   protected defaultMinScore: number = 0;
+
+  /**
+   * Query parameter name used to read the search string. Defaults to `'q'`.
+   * Override (or configure via `endpoints.search.paramName`) to expose a
+   * different name on the wire, e.g. `'query'` for `/search?query=foo`.
+   */
+  protected searchParamName: string = 'q';
 
   // ============================================================================
   // Filter Configuration (reused from ListEndpoint)
@@ -188,9 +219,7 @@ export abstract class SearchEndpoint<
     const fields: Record<string, SearchFieldConfig> = {};
 
     for (const [key, zodType] of Object.entries(schemaShape)) {
-      // Check if field is a string type
-      const desc = (zodType as { _def?: { typeName?: string } })._def;
-      if (desc?.typeName === 'ZodString') {
+      if (isZodStringSchema(zodType)) {
         fields[key] = { weight: 1.0 };
       }
     }
@@ -206,10 +235,11 @@ export abstract class SearchEndpoint<
    * Returns the query parameter schema for search and filtering.
    */
   protected getQuerySchema(): ZodObject<ZodRawShape> {
+    const queryParam = this.searchParamName || 'q';
     // Use Record for mutable shape building (ZodRawShape is readonly in Zod v4)
     const shape: Record<string, z.ZodTypeAny> = {
-      // Search parameters
-      q: z.string().min(this.minQueryLength).max(this.maxQueryLength).describe('Search query'),
+      // Search parameters — key is `searchParamName` (default `'q'`).
+      [queryParam]: z.string().min(this.minQueryLength).max(this.maxQueryLength).describe('Search query'),
       fields: z.string().optional().describe(
         `Comma-separated fields to search. Available: ${Object.keys(this.getSearchableFields()).join(', ')}`
       ),
@@ -364,7 +394,8 @@ export abstract class SearchEndpoint<
   protected async getSearchOptions(): Promise<SearchOptions> {
     const { query } = await this.getValidatedData();
 
-    const q = query?.q as string;
+    const queryParam = this.searchParamName || 'q';
+    const q = (query as Record<string, unknown> | undefined)?.[queryParam] as string;
     const fieldsParam = query?.fields as string | undefined;
     const mode = parseSearchMode(query?.mode as string | undefined);
     const highlight = query?.highlight === 'true';
@@ -520,15 +551,23 @@ export abstract class SearchEndpoint<
       }));
     }
 
-    // Calculate pagination info
+    // Calculate pagination info.
+    //
+    // Prefer `postFilteredCount` when the adapter populates it — that
+    // reflects the actual user-visible result set after in-memory
+    // tokenization / minScore filtering, so pagination math matches what
+    // the client receives. Adapters that already return a post-filter
+    // count via `totalCount` (e.g. memory) leave `postFilteredCount`
+    // unset and the legacy field is used unchanged — fully back-compat.
+    const effectiveTotal = searchResult.postFilteredCount ?? searchResult.totalCount;
     const page = filters.options.page || 1;
     const perPage = filters.options.per_page || this.defaultPerPage;
-    const totalPages = Math.ceil(searchResult.totalCount / perPage);
+    const totalPages = Math.ceil(effectiveTotal / perPage);
 
     return this.successPaginated(result, {
       page,
       per_page: perPage,
-      total_count: searchResult.totalCount,
+      total_count: effectiveTotal,
       total_pages: totalPages,
       query: searchOptions.query,
       searchedFields: searchOptions.fields || Object.keys(this.getSearchableFields()),

--- a/tests/search-abstract-fixes.test.ts
+++ b/tests/search-abstract-fixes.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Tests for three abstract-layer fixes on SearchEndpoint (v0.12.3 audit):
+ *
+ *   1. Zod-version-agnostic searchable-field auto-detection.
+ *      v0.12.3 only inspected `_def.typeName === 'ZodString'` (Zod 3
+ *      internal shape). Zod 4 reshaped internals to `_def.type === 'string'`,
+ *      so on Zod 4 the default-detect path returned an empty field set —
+ *      `searchedFields: []` and no matches.
+ *
+ *   2. `endpoints.search.paramName` actually wired to the handler.
+ *      v0.12.3 hardcoded `c.req.query('q')` regardless of the config.
+ *
+ *   3. `result_info.total_count` reflects the post-filter result set, not
+ *      the adapter's pre-filter candidate count. Implemented at the abstract
+ *      layer via the optional `SearchResult.postFilteredCount` contract —
+ *      `handle()` prefers it when present.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { z } from 'zod';
+import { Hono } from 'hono';
+import { defineModel } from '../src/index.js';
+import type { ListFilters } from '../src/endpoints/types.js';
+import type { SearchOptions, SearchResult } from '../src/core/types.js';
+import { SearchEndpoint } from '../src/endpoints/search.js';
+import {
+  MemorySearchEndpoint,
+  clearStorage,
+  getStorage,
+} from '../src/adapters/memory/index.js';
+
+// ============================================================================
+// Fix 1: Zod 4 searchable-field auto-detection
+// ============================================================================
+
+describe('Fix 1 — getSearchableFields() works on Zod 4', () => {
+  /**
+   * Endpoint with NO explicit `searchableFields` / `searchFields` — forces
+   * the auto-detect path that v0.12.3 broke under Zod 4.
+   */
+  const AutoDetectSchema = z.object({
+    id: z.string(),
+    title: z.string(),
+    description: z.string(),
+    views: z.number().default(0),
+    published: z.boolean().default(false),
+  });
+
+  const AutoDetectModel = defineModel({
+    tableName: 'autodetect',
+    schema: AutoDetectSchema,
+    primaryKeys: ['id'],
+  });
+
+  class AutoDetectSearch extends MemorySearchEndpoint {
+    _meta = { model: AutoDetectModel };
+    schema = { tags: ['AutoDetect'] };
+    // Intentionally no `searchableFields` / `searchFields` overrides —
+    // the abstract default-detect path is exercised.
+
+    // Expose the protected helper for direct unit assertion.
+    public _getSearchableFieldsPublic() {
+      return this.getSearchableFields();
+    }
+  }
+
+  it('auto-detects string fields on the installed Zod major (Zod 4)', () => {
+    const ep = new AutoDetectSearch();
+    const fields = ep._getSearchableFieldsPublic();
+    expect(Object.keys(fields).sort()).toEqual(['description', 'id', 'title']);
+    // Non-string fields must NOT be picked up.
+    expect(fields).not.toHaveProperty('views');
+    expect(fields).not.toHaveProperty('published');
+  });
+
+  it('returns a non-empty field set so default-search end-to-end matches rows', async () => {
+    clearStorage();
+    const store = getStorage<Record<string, unknown>>('autodetect');
+    store.set('a', { id: 'a', title: 'hello world', description: 'something' });
+    store.set('b', { id: 'b', title: 'unrelated', description: 'something else' });
+
+    const app = new Hono();
+    app.get('/autodetect/search', async (c) => {
+      const ep = new AutoDetectSearch();
+      ep.setContext(c);
+      return ep.handle();
+    });
+
+    const res = await app.request('/autodetect/search?q=hello');
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as {
+      success: boolean;
+      result: Array<{ item: { id: string } }>;
+      result_info: { searchedFields: string[] };
+    };
+    expect(data.success).toBe(true);
+    // The v0.12.3 bug would yield `searchedFields: []` and zero matches.
+    expect(data.result_info.searchedFields.length).toBeGreaterThan(0);
+    expect(data.result.some((r) => r.item.id === 'a')).toBe(true);
+  });
+
+  it('still detects a faux Zod-3-shaped string schema (back-compat)', () => {
+    // Construct a fixture whose `_def` mimics Zod 3's old `typeName` shape.
+    // The detection helper is intentionally dual-shape, so both Zod-3 and
+    // Zod-4 introspection patterns are recognised even in monorepos with
+    // multiple Zod installs.
+    const FakeZod3Schema = {
+      shape: {
+        title: { _def: { typeName: 'ZodString' } },
+        count: { _def: { typeName: 'ZodNumber' } },
+      },
+    };
+
+    class FauxZod3Search extends MemorySearchEndpoint {
+      _meta = { model: AutoDetectModel };
+      schema = { tags: ['Fake'] };
+      // Override the schema accessor to return the Zod-3-shape fixture.
+      protected getModelSchema(): never {
+        return FakeZod3Schema as never;
+      }
+      public _getSearchableFieldsPublic() {
+        return this.getSearchableFields();
+      }
+    }
+
+    const ep = new FauxZod3Search();
+    const fields = ep._getSearchableFieldsPublic();
+    expect(Object.keys(fields)).toEqual(['title']);
+  });
+});
+
+// ============================================================================
+// Fix 2: paramName config actually changes the wire param
+// ============================================================================
+
+describe('Fix 2 — searchParamName changes the on-wire query param', () => {
+  const PostSchema = z.object({
+    id: z.string(),
+    title: z.string(),
+    body: z.string(),
+  });
+
+  const PostModel = defineModel({
+    tableName: 'posts',
+    schema: PostSchema,
+    primaryKeys: ['id'],
+  });
+
+  class PostSearchCustom extends MemorySearchEndpoint {
+    _meta = { model: PostModel };
+    schema = { tags: ['Posts'] };
+    protected searchableFields = { title: { weight: 2.0 }, body: { weight: 1.0 } };
+    // The fix: this should re-route the wire param name through the handler.
+    protected searchParamName = 'query';
+  }
+
+  beforeEach(() => {
+    clearStorage();
+    const store = getStorage<Record<string, unknown>>('posts');
+    store.set('1', { id: '1', title: 'hello world', body: 'a post body' });
+    store.set('2', { id: '2', title: 'goodbye', body: 'another post body' });
+  });
+
+  it('reads the configured param name (?query=...)', async () => {
+    const app = new Hono();
+    app.get('/posts/search', async (c) => {
+      const ep = new PostSearchCustom();
+      ep.setContext(c);
+      return ep.handle();
+    });
+
+    const res = await app.request('/posts/search?query=hello');
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as {
+      success: boolean;
+      result: Array<{ item: { id: string } }>;
+      result_info: { query: string };
+    };
+    expect(data.success).toBe(true);
+    expect(data.result_info.query).toBe('hello');
+    expect(data.result.some((r) => r.item.id === '1')).toBe(true);
+  });
+
+  it('default `q` still works when no paramName override is set', async () => {
+    class PostSearchDefault extends MemorySearchEndpoint {
+      _meta = { model: PostModel };
+      schema = { tags: ['Posts'] };
+      protected searchableFields = { title: { weight: 2.0 }, body: { weight: 1.0 } };
+      // searchParamName intentionally left at default 'q'
+    }
+
+    const app = new Hono();
+    app.get('/posts/search', async (c) => {
+      const ep = new PostSearchDefault();
+      ep.setContext(c);
+      return ep.handle();
+    });
+
+    const res = await app.request('/posts/search?q=hello');
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { success: boolean };
+    expect(data.success).toBe(true);
+  });
+});
+
+// ============================================================================
+// Fix 3: total_count reconciliation via postFilteredCount
+// ============================================================================
+
+describe('Fix 3 — result_info.total_count reflects post-filter result set', () => {
+  /**
+   * Custom SearchEndpoint subclass that simulates an adapter whose initial
+   * SQL `LIKE` hit count is HIGHER than the post-tokenization result set
+   * (e.g. stopword query, or minScore clamp). The pre-fix abstract handler
+   * would surface the SQL-hit count as `total_count` — misleading for
+   * clients computing pagination off it.
+   */
+  const ItemSchema = z.object({
+    id: z.string(),
+    name: z.string(),
+  });
+
+  const ItemModel = defineModel({
+    tableName: 'items',
+    schema: ItemSchema,
+    primaryKeys: ['id'],
+  });
+
+  abstract class FakeAdapterSearchBase extends SearchEndpoint {
+    _meta = { model: ItemModel };
+    schema = { tags: ['Items'] };
+    protected searchableFields = { name: { weight: 1.0 } };
+  }
+
+  it('uses postFilteredCount when the adapter populates it', async () => {
+    class StopwordSimSearch extends FakeAdapterSearchBase {
+      async search(
+        options: SearchOptions,
+        filters: ListFilters,
+      ): Promise<SearchResult<Record<string, unknown>>> {
+        void options;
+        void filters;
+        // Simulate: SQL LIKE matched 3 rows, post-tokenization filter
+        // (stopword removal) dropped them all.
+        return {
+          items: [],
+          totalCount: 3, // legacy: SQL-hit count
+          postFilteredCount: 0, // accurate: nothing survived tokenization
+        };
+      }
+    }
+
+    const app = new Hono();
+    app.get('/items/search', async (c) => {
+      const ep = new StopwordSimSearch();
+      ep.setContext(c);
+      return ep.handle();
+    });
+
+    const res = await app.request('/items/search?q=foo');
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as {
+      result: unknown[];
+      result_info: { total_count: number; total_pages: number };
+    };
+    // Critical: total_count must NOT be 3 — that's the misleading SQL count.
+    expect(data.result_info.total_count).toBe(0);
+    expect(data.result.length).toBe(0);
+    expect(data.result_info.total_pages).toBe(0);
+  });
+
+  it('falls back to totalCount when postFilteredCount is omitted (back-compat)', async () => {
+    class LegacyShapeSearch extends FakeAdapterSearchBase {
+      async search(
+        options: SearchOptions,
+        filters: ListFilters,
+      ): Promise<SearchResult<Record<string, unknown>>> {
+        void options;
+        void filters;
+        // Legacy adapter: only `totalCount` populated. Must keep
+        // working byte-for-byte (no regression on memory / older
+        // adapters that already returned an accurate totalCount).
+        return {
+          items: [
+            { item: { id: '1', name: 'foo' }, score: 1, matchedFields: ['name'] },
+            { item: { id: '2', name: 'foobar' }, score: 0.8, matchedFields: ['name'] },
+          ],
+          totalCount: 2,
+        };
+      }
+    }
+
+    const app = new Hono();
+    app.get('/items/search', async (c) => {
+      const ep = new LegacyShapeSearch();
+      ep.setContext(c);
+      return ep.handle();
+    });
+
+    const res = await app.request('/items/search?q=foo');
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as {
+      result: unknown[];
+      result_info: { total_count: number; total_pages: number; per_page: number };
+    };
+    expect(data.result_info.total_count).toBe(2);
+    expect(data.result.length).toBe(2);
+    expect(data.result_info.total_pages).toBe(1);
+  });
+
+  it('pagination math uses the post-filter count', async () => {
+    class PartialFilterSearch extends FakeAdapterSearchBase {
+      async search(
+        options: SearchOptions,
+        filters: ListFilters,
+      ): Promise<SearchResult<Record<string, unknown>>> {
+        void options;
+        void filters;
+        // SQL matched 100 candidates; minScore clamp left 25.
+        return {
+          items: [
+            { item: { id: '1', name: 'foo' }, score: 1, matchedFields: ['name'] },
+          ],
+          totalCount: 100,
+          postFilteredCount: 25,
+        };
+      }
+    }
+
+    const app = new Hono();
+    app.get('/items/search', async (c) => {
+      const ep = new PartialFilterSearch();
+      ep.setContext(c);
+      return ep.handle();
+    });
+
+    const res = await app.request('/items/search?q=foo&per_page=10');
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as {
+      result_info: { total_count: number; total_pages: number; per_page: number };
+    };
+    expect(data.result_info.total_count).toBe(25);
+    expect(data.result_info.per_page).toBe(10);
+    // 25 / 10 -> 3 pages, not 10 (which the SQL-hit count would have given).
+    expect(data.result_info.total_pages).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

Three abstract-layer defects on `SearchEndpoint`, surfaced by a live audit
of a Zod-4 consumer against 0.12.3. All fixes are in the abstract endpoint
class / public types / config wiring - **no adapter files are touched**.

### 1) Zod-version-agnostic searchable-field auto-detection
When a consumer does not set `endpoints.search.fields` explicitly,
`getSearchableFields()` falls back to "every `z.string()` in the model
schema". The check used `_def.typeName === 'ZodString'`, which is the
Zod 3 internal shape. Zod 4 reshaped introspection to `_def.type === 'string'`
(verified against the bundled `zod@4.3.6`), so the default-detect path
returned an empty field set under Zod 4 - `searchedFields: []`, no rows
matched. Replaced with a dual-shape helper (`instanceof z.ZodString` fast
path + structural `_def.type` / `_def.typeName` / `def.type` fallbacks)
that works on both majors, robust to monorepo dual-Zod installs.

### 2) `endpoints.search.paramName` actually wired
The field was documented on `SearchEndpointConfig` but the previous
JSDoc explicitly called it out as *reserved - currently unused*; the
handler hardcoded `c.req.query('q')`. Setting `paramName: 'query'`
silently did nothing. Added `SearchEndpoint.searchParamName`
(default `'q'`), threaded it through `getQuerySchema()` (so OpenAPI
docs reflect the configured name) and `getSearchOptions()`, and wired
it from `config.search.paramName` via the existing `extras` spread
in `generateEndpointClass`. Default behaviour is unchanged.

### 3) `result_info.total_count` reconciliation
`total_count` previously surfaced the adapter's pre-filter candidate
count (e.g. SQL `LIKE` hit count) rather than the user-visible result
set size after in-memory tokenization, stopword removal, and `minScore`.
Pagination math was therefore wrong - a stopword query (`q=in`) could
return `total_count: 3` with `result: []`.

Implemented at the abstract layer via an optional `SearchResult.postFilteredCount`:
- `handle()` prefers `postFilteredCount` when present, falls back to `totalCount`.
- Fully back-compatible: the memory adapter already returns a
  post-filter count via `totalCount`, so its behaviour is byte-identical.
- Adapters whose `totalCount` is the SQL-hit count can opt in by
  populating `postFilteredCount` - no further abstract-layer changes
  required.

## Files

- `src/endpoints/search.ts` - dual-shape Zod detection helper, `searchParamName` field threaded through `getQuerySchema()` / `getSearchOptions()`, `handle()` prefers `postFilteredCount`.
- `src/core/types.ts` - extends `SearchResult<T>` with optional `postFilteredCount` (documented).
- `src/config/index.ts` - removes the "reserved - unused" note on `paramName`, wires `cfg.paramName` into the generator's `extras` as `searchParamName`.
- `tests/search-abstract-fixes.test.ts` - new test file (8 tests) for all three fixes.

## Compatibility

- No public API removed or renamed.
- Default behaviour for every existing search consumer is unchanged.
- All 36 pre-existing search tests still pass; the new file adds 8 more.

## Test plan

- [x] `pnpm typecheck` - clean
- [x] `pnpm typecheck:examples` - clean
- [x] `pnpm test:unit` - 869 / 869 (861 baseline + 8 new)
- [x] `pnpm test:workers` - 42 / 42
- [x] `pnpm test:package-example` - passes (build + local consumer typecheck + smoke)
- [ ] `pnpm test:examples` - environmental gap on this host (Postgres at `localhost:5432` not reachable). Same gap exists on pristine `origin/main`, not introduced by this PR. Re-runnable in CI.

## Notes

- Does not modify `src/adapters/{drizzle,memory,prisma}/search*.ts` - those are owned by a parallel PR. The new `postFilteredCount` field is the abstract-layer hook those adapter fixes can plug into.
- No `package.version` bump and no `CHANGELOG` edit, per release-Action contract.