### PR TITLE
fix: adapter search — escape LIKE wildcards + correct mode='all' token-AND semantics

### DIFF
--- a/src/adapters/drizzle/advanced.ts
+++ b/src/adapters/drizzle/advanced.ts
@@ -37,6 +37,35 @@ import {
 import { getDrizzleDb } from './connection';
 
 /**
+ * Escape SQL LIKE wildcard characters in user-supplied input.
+ *
+ * The escape character itself (`\\`) must be escaped first to avoid
+ * double-escaping the wildcards that follow. The corresponding LIKE
+ * clause should declare `ESCAPE '\\'` so the database treats `\%`
+ * and `\_` as literal characters.
+ */
+function escapeLikePattern(input: string): string {
+  return input
+    .replace(/\\/g, '\\\\')
+    .replace(/%/g, '\\%')
+    .replace(/_/g, '\\_');
+}
+
+/**
+ * Split a search query into whitespace-delimited tokens for the
+ * SQL pre-filter used by `mode='all'`. Empty tokens are dropped.
+ *
+ * Final relevance scoring still happens in-memory via
+ * `searchInMemory`, which applies stopword filtering and tokenizes
+ * with its own rules — this function only narrows the SQL result
+ * set so the pre-filter is consistent with the abstract layer's
+ * notion of "all tokens must match".
+ */
+function tokenizeForSearch(query: string): string[] {
+  return query.split(/\s+/).filter((t) => t.length > 0);
+}
+
+/**
  * Drizzle Upsert endpoint.
  * Creates a record if it doesn't exist, updates it if it does.
  */
@@ -700,24 +729,54 @@ export abstract class DrizzleSearchEndpoint<
 
       conditions.push(sql`${vectorCol} @@ ${tsQuery}`);
     } else {
-      // Fallback: LIKE-based search
-      const searchConditions = fieldsToSearch.map((field) => {
+      // Fallback: LIKE-based search.
+      //
+      // SECURITY: user input is escaped for LIKE wildcards (`%`, `_`) so that
+      // a client cannot smuggle wildcard semantics through the bound parameter.
+      // The escape character (`\\`) itself is escaped first; the LIKE clause
+      // declares `ESCAPE '\\'` so the database treats the escapes correctly.
+      // Without this, `q=%%` would match every row and `q=foo_bar` would match
+      // `fooXbar`.
+      //
+      // mode='all' uses token-AND across fields: each query token must be
+      // present in at least ONE configured field. The prior implementation
+      // required EVERY field to contain the WHOLE phrase, which made
+      // mode='all' effectively unusable for multi-term queries.
+      const buildFieldLike = (field: string, needle: string): SQL | undefined => {
         try {
           const column = this.getColumn(field);
-          // Use ILIKE for case-insensitive search (works with PostgreSQL)
-          // For SQLite, use LOWER() with LIKE
-          return sql`LOWER(CAST(${column} AS TEXT)) LIKE LOWER(${`%${options.query}%`})`;
+          const pattern = `%${escapeLikePattern(needle)}%`;
+          return sql`LOWER(CAST(${column} AS TEXT)) LIKE LOWER(${pattern}) ESCAPE '\\'`;
         } catch {
           return undefined;
         }
-      }).filter((c): c is SQL => c !== undefined);
+      };
 
-      if (searchConditions.length > 0) {
-        if (options.mode === 'all') {
-          // AND all conditions
-          conditions.push(and(...searchConditions)!);
-        } else {
-          // OR conditions for 'any' mode
+      if (options.mode === 'all') {
+        // Token-AND across fields: for each token, AT LEAST ONE field must
+        // match (OR within token); ALL tokens must match (AND across tokens).
+        const tokens = tokenizeForSearch(options.query);
+        if (tokens.length > 0) {
+          const tokenClauses: SQL[] = [];
+          for (const token of tokens) {
+            const perFieldOr = fieldsToSearch
+              .map((field) => buildFieldLike(field, token))
+              .filter((c): c is SQL => c !== undefined);
+            if (perFieldOr.length > 0) {
+              tokenClauses.push(or(...perFieldOr)!);
+            }
+          }
+          if (tokenClauses.length > 0) {
+            conditions.push(and(...tokenClauses)!);
+          }
+        }
+      } else {
+        // 'any' or 'phrase': phrase OR'd across fields (unchanged semantics).
+        const searchConditions = fieldsToSearch
+          .map((field) => buildFieldLike(field, options.query))
+          .filter((c): c is SQL => c !== undefined);
+
+        if (searchConditions.length > 0) {
           conditions.push(or(...searchConditions)!);
         }
       }
@@ -750,10 +809,18 @@ export abstract class DrizzleSearchEndpoint<
 
     const records = await query;
 
-    // Score results in memory and generate highlights
+    // Score results in memory and generate highlights.
+    //
+    // For mode='all' the SQL above already enforces token-AND across fields,
+    // so we score with mode='any' to avoid `searchInMemory`'s stricter
+    // per-field "all tokens in same field" gate dropping correctly-matched
+    // rows. The score is used for ranking only — matching was decided in SQL.
+    const scoringOptions = options.mode === 'all'
+      ? { ...options, mode: 'any' as const }
+      : options;
     const searchResults = searchInMemory(
       records as ModelObject<M['model']>[],
-      options,
+      scoringOptions,
       searchableFields
     );
 
@@ -832,9 +899,10 @@ export abstract class DrizzleExportEndpoint<
 
     // Apply search
     if (filters.options.search && this.searchFields.length > 0) {
+      const needle = `%${escapeLikePattern(filters.options.search)}%`;
       const searchConditions = this.searchFields.map((field) => {
         const column = this.getColumn(field);
-        return sql`LOWER(${column}) LIKE LOWER(${`%${filters.options.search}%`})`;
+        return sql`LOWER(${column}) LIKE LOWER(${needle}) ESCAPE '\\'`;
       });
       conditions.push(or(...searchConditions)!);
     }

--- a/src/adapters/memory/advanced.ts
+++ b/src/adapters/memory/advanced.ts
@@ -579,11 +579,52 @@ export abstract class MemorySearchEndpoint<
       });
     }
 
-    // Perform search and scoring
+    // Perform search and scoring.
+    //
+    // For mode='all' we apply a token-AND across fields ourselves before
+    // delegating to `searchInMemory`: each token must be present in AT LEAST
+    // ONE configured field. This matches the documented "all terms match"
+    // intent (rather than "every field contains the whole phrase").
+    //
+    // After pre-filtering we score with mode='any' so the scorer doesn't
+    // re-apply its stricter per-field "all tokens in same field" gate.
+    //
+    // SECURITY: matching uses native String#includes — `%` and `_` from the
+    // user query are treated as literal characters (no LIKE semantics on the
+    // in-memory adapter). This mirrors the SQL adapters' explicit wildcard
+    // escaping.
     const searchableFields = this.getSearchableFields();
+    let recordsForScoring = records as ModelObject<M['model']>[];
+    let scoringOptions = options;
+
+    if (options.mode === 'all') {
+      const tokens = options.query
+        .toLowerCase()
+        .split(/\s+/)
+        .filter((t) => t.length > 0);
+      const fieldsToSearch = options.fields || Object.keys(searchableFields);
+
+      if (tokens.length > 0) {
+        recordsForScoring = recordsForScoring.filter((record) => {
+          const rec = record as Record<string, unknown>;
+          return tokens.every((token) =>
+            fieldsToSearch.some((field) => {
+              const value = rec[field];
+              if (value === undefined || value === null) return false;
+              const content = Array.isArray(value) ? value.join(' ') : String(value);
+              return content.toLowerCase().includes(token);
+            })
+          );
+        });
+      }
+
+      // Score with 'any' to avoid the scorer's stricter per-field gate.
+      scoringOptions = { ...options, mode: 'any' };
+    }
+
     const searchResults = searchInMemory(
-      records as ModelObject<M['model']>[],
-      options,
+      recordsForScoring,
+      scoringOptions,
       searchableFields
     );
 

--- a/src/adapters/prisma/advanced.ts
+++ b/src/adapters/prisma/advanced.ts
@@ -70,25 +70,43 @@ export abstract class PrismaSearchEndpoint<
       }
     }
 
-    // Build search conditions
+    // Build search conditions.
+    //
+    // SECURITY: Prisma's `contains` is a literal substring match — it does
+    // NOT interpret SQL LIKE wildcards (`%`, `_`) from user input, so no
+    // additional escaping is required at this layer.
+    //
+    // mode='all' uses token-AND across fields: each query token must appear
+    // in AT LEAST ONE configured field. The prior implementation required
+    // EVERY field to contain the WHOLE phrase, which made mode='all'
+    // effectively unusable for multi-term queries.
     const searchableFields = this.getSearchableFields();
     const fieldsToSearch = options.fields || Object.keys(searchableFields);
 
-    const searchConditions = fieldsToSearch.map((field) => ({
+    const fieldContains = (field: string, needle: string) => ({
       [field]: {
-        contains: options.query,
+        contains: needle,
         mode: 'insensitive',
       },
-    }));
+    });
 
-    // Combine with filters based on search mode
-    if (searchConditions.length > 0) {
+    if (fieldsToSearch.length > 0) {
       if (options.mode === 'all') {
-        // AND all search conditions
-        where = { ...where, AND: searchConditions };
+        const tokens = options.query.split(/\s+/).filter((t) => t.length > 0);
+        if (tokens.length > 0) {
+          where = {
+            ...where,
+            AND: tokens.map((token) => ({
+              OR: fieldsToSearch.map((field) => fieldContains(field, token)),
+            })),
+          };
+        }
       } else {
-        // OR search conditions (for 'any' and 'phrase' modes)
-        where = { ...where, OR: searchConditions };
+        // 'any' or 'phrase': phrase OR'd across fields (unchanged semantics).
+        where = {
+          ...where,
+          OR: fieldsToSearch.map((field) => fieldContains(field, options.query)),
+        };
       }
     }
 
@@ -127,10 +145,19 @@ export abstract class PrismaSearchEndpoint<
       take: perPage,
     });
 
-    // Score results in memory and generate highlights
+    // Score results in memory and generate highlights.
+    //
+    // For mode='all' the WHERE above already enforces token-AND across
+    // fields, so we score with mode='any' to avoid `searchInMemory`'s
+    // stricter per-field "all tokens in same field" gate dropping
+    // correctly-matched rows. The score is used for ranking only — matching
+    // was decided in the database query.
+    const scoringOptions = options.mode === 'all'
+      ? { ...options, mode: 'any' as const }
+      : options;
     const searchResults = searchInMemory(
       records as ModelObject<M['model']>[],
-      options,
+      scoringOptions,
       this.getSearchableFields()
     );
 

--- a/tests/search-adapter-sql.test.ts
+++ b/tests/search-adapter-sql.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Tests for adapter-layer search fixes:
+ *
+ *   1. LIKE wildcard escape — user `%` and `_` must be treated as literals
+ *      (security/hardening: prevents abuse-vector probing/exfiltration).
+ *   2. mode='all' token-AND semantics — each token must appear in AT LEAST
+ *      ONE configured field, not the whole phrase in EVERY field.
+ *
+ * Covers drizzle (real libsql/SQLite table) and the in-memory adapter.
+ */
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { z } from 'zod';
+import { Hono } from 'hono';
+import { sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { drizzle } from 'drizzle-orm/libsql';
+import { createClient } from '@libsql/client';
+import { sql } from 'drizzle-orm';
+import { defineModel } from '../src/index.js';
+import {
+  DrizzleSearchEndpoint,
+  type DrizzleDatabase,
+} from '../src/adapters/drizzle/index.js';
+import {
+  MemorySearchEndpoint,
+  clearStorage,
+  getStorage,
+} from '../src/adapters/memory/index.js';
+
+// ============================================================================
+// Shared fixture model
+// ============================================================================
+
+const ProductSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  deletedAt: z.string().nullable().optional(),
+});
+
+// ============================================================================
+// Drizzle setup (libsql / in-memory SQLite)
+// ============================================================================
+
+const productsTable = sqliteTable('products', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull(),
+  description: text('description').notNull(),
+  deletedAt: text('deletedAt'),
+});
+
+const drizzleClient = createClient({ url: ':memory:' });
+const drizzleDb = drizzle(drizzleClient);
+
+const DrizzleProductModel = defineModel({
+  tableName: 'products',
+  schema: ProductSchema,
+  primaryKeys: ['id'],
+  table: productsTable,
+  softDelete: { field: 'deletedAt' },
+});
+
+class DrizzleProductSearch extends DrizzleSearchEndpoint {
+  _meta = { model: DrizzleProductModel };
+  db = drizzleDb as unknown as DrizzleDatabase;
+  schema = { tags: ['Products'], summary: 'Search products' };
+
+  protected searchFields = ['name', 'description'];
+  protected minQueryLength = 2;
+}
+
+// ============================================================================
+// Memory setup (separate model so it doesn't collide with drizzle storage)
+// ============================================================================
+
+const MemoryProductModel = defineModel({
+  tableName: 'memory_products',
+  schema: ProductSchema,
+  primaryKeys: ['id'],
+  softDelete: { field: 'deletedAt' },
+});
+
+class MemoryProductSearch extends MemorySearchEndpoint {
+  _meta = { model: MemoryProductModel };
+  schema = { tags: ['Products'], summary: 'Search products' };
+
+  protected searchFields = ['name', 'description'];
+  protected minQueryLength = 2;
+}
+
+// ============================================================================
+// Fixture rows
+// ============================================================================
+
+/**
+ * Rows chosen to exercise BOTH fixes simultaneously:
+ *  - "orbit"      : multi-field token-AND target — name has "Orbit Desk Light",
+ *                   description has "warm/cool" and "USB-C charger".
+ *  - "wildcard_%" : literal `_` and `%` in the user-visible name/description
+ *                   to verify they are not treated as LIKE wildcards.
+ *  - "percent"    : control row to confirm `q=%%` does NOT match every row.
+ *  - "foo_bar"    : control row with literal `foo_bar` to verify `_` escape.
+ *  - "fooXbar"    : control row that WOULD match `foo_bar` if `_` leaked as
+ *                   a single-char wildcard. Must NOT match post-fix.
+ */
+const ROWS = [
+  {
+    id: 'r1',
+    name: 'Orbit Desk Light',
+    description: 'Adjustable warm/cool LED with USB-C charger.',
+  },
+  {
+    id: 'r2',
+    name: 'Literal foo_bar widget',
+    description: 'Contains the exact characters foo_bar in the name.',
+  },
+  {
+    id: 'r3',
+    name: 'fooXbar device',
+    description: 'No underscore in name; would match if _ leaked as wildcard.',
+  },
+  {
+    id: 'r4',
+    name: '50% off sticker',
+    description: 'Promotional sticker with a literal percent sign.',
+  },
+  {
+    id: 'r5',
+    name: 'Plain item',
+    description: 'No special characters or matching tokens at all.',
+  },
+  {
+    id: 'r6',
+    name: 'Warm cushion',
+    description: 'Cozy fabric cushion in warm earth tones.',
+  },
+];
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+interface SearchResponse {
+  success: boolean;
+  result: Array<{ item: { id: string; name: string; description: string } }>;
+  result_info: { total_count: number; query: string };
+}
+
+async function parseSearch(
+  response: Response
+): Promise<{ ids: string[]; totalCount: number }> {
+  expect(response.status).toBe(200);
+  const data = (await response.json()) as SearchResponse;
+  expect(data.success).toBe(true);
+  return {
+    ids: data.result.map((r) => r.item.id).sort(),
+    totalCount: data.result_info.total_count,
+  };
+}
+
+async function ids(response: Response): Promise<string[]> {
+  return (await parseSearch(response)).ids;
+}
+
+// ============================================================================
+// Drizzle suite
+// ============================================================================
+
+describe('Drizzle search adapter — LIKE wildcard escape', () => {
+  let app: Hono;
+
+  beforeAll(async () => {
+    await drizzleDb.run(sql`
+      CREATE TABLE IF NOT EXISTS products (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        description TEXT NOT NULL,
+        deletedAt TEXT
+      )
+    `);
+  });
+
+  beforeEach(async () => {
+    await drizzleDb.delete(productsTable);
+    for (const row of ROWS) {
+      await drizzleDb.insert(productsTable).values(row);
+    }
+
+    app = new Hono();
+    app.onError((err, c) =>
+      c.json({ success: false, error: { message: err.message } }, 400)
+    );
+    app.get('/products/search', async (c) => {
+      const endpoint = new DrizzleProductSearch();
+      endpoint.setContext(c);
+      return endpoint.handle();
+    });
+  });
+
+  it('treats user `_` as literal — q=foo_bar matches only literal "foo_bar"', async () => {
+    const response = await app.request('/products/search?q=foo_bar');
+    const { ids: matched, totalCount } = await parseSearch(response);
+
+    // Must include r2 (literal foo_bar in name + description).
+    expect(matched).toContain('r2');
+    // Must NOT include r3 (would only match if `_` leaked as a wildcard).
+    expect(matched).not.toContain('r3');
+    // SQL-level leak guard: total_count comes from `count(*)` BEFORE the
+    // in-memory rescorer drops false positives. Pre-fix the SQL matched
+    // both r2 and r3 (because `_` was a wildcard), so total_count was 2.
+    // Post-fix the SQL matches exactly r2 → total_count is 1.
+    expect(totalCount).toBe(1);
+  });
+
+  it('treats user `%%` as literal — q=%% matches zero rows', async () => {
+    const response = await app.request('/products/search?q=%25%25');
+    const { ids: matched, totalCount } = await parseSearch(response);
+
+    expect(matched).toEqual([]);
+    // SQL-level leak guard: pre-fix `q=%%` returns every row from the SQL
+    // count (total_count === 6). Post-fix it returns 0.
+    expect(totalCount).toBe(0);
+  });
+
+  it('treats user `%` as literal — q=50% matches only the literal "50%" row', async () => {
+    const response = await app.request('/products/search?q=50%25');
+    const { ids: matched, totalCount } = await parseSearch(response);
+
+    expect(matched).toContain('r4');
+    // Must NOT include r5 (the plain item — no `%` and no '50' in it).
+    expect(matched).not.toContain('r5');
+    // SQL-level leak guard.
+    expect(totalCount).toBe(1);
+  });
+});
+
+describe("Drizzle search adapter — mode='all' token-AND semantics", () => {
+  let app: Hono;
+
+  beforeAll(async () => {
+    await drizzleDb.run(sql`
+      CREATE TABLE IF NOT EXISTS products (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        description TEXT NOT NULL,
+        deletedAt TEXT
+      )
+    `);
+  });
+
+  beforeEach(async () => {
+    await drizzleDb.delete(productsTable);
+    for (const row of ROWS) {
+      await drizzleDb.insert(productsTable).values(row);
+    }
+
+    app = new Hono();
+    app.onError((err, c) =>
+      c.json({ success: false, error: { message: err.message } }, 400)
+    );
+    app.get('/products/search', async (c) => {
+      const endpoint = new DrizzleProductSearch();
+      endpoint.setContext(c);
+      return endpoint.handle();
+    });
+  });
+
+  it("q='warm cool' mode='all' matches the Orbit row (token-AND across fields)", async () => {
+    const response = await app.request(
+      '/products/search?q=warm%20cool&mode=all'
+    );
+    const matched = await ids(response);
+
+    // r1 description contains both "warm" and "cool" (in "warm/cool").
+    // The pre-fix per-field-AND would never match this since no single field
+    // contains the literal phrase "warm cool".
+    expect(matched).toContain('r1');
+    // r6 has "warm" but not "cool" — must be excluded.
+    expect(matched).not.toContain('r6');
+  });
+
+  it("q='warm zzzz' mode='all' returns 0 (negative case)", async () => {
+    const response = await app.request(
+      '/products/search?q=warm%20zzzz&mode=all'
+    );
+    const matched = await ids(response);
+
+    expect(matched).toEqual([]);
+  });
+
+  it("mode='any' (default) preserves phrase OR'd across fields", async () => {
+    const response = await app.request(
+      '/products/search?q=warm%20cool&mode=any'
+    );
+    const matched = await ids(response);
+
+    // 'any' mode keeps the legacy semantics: full phrase OR'd across fields.
+    // No row has the LITERAL string "warm cool" anywhere, so the SQL
+    // pre-filter returns 0 rows. This documents the pre-existing behavior.
+    expect(matched).toEqual([]);
+  });
+
+  it("mode='phrase' matches the literal phrase 'warm/cool'", async () => {
+    const response = await app.request(
+      '/products/search?q=warm%2Fcool&mode=phrase'
+    );
+    const matched = await ids(response);
+
+    expect(matched).toContain('r1');
+  });
+
+  it("mode='phrase' does NOT match the non-existent phrase 'warm cool'", async () => {
+    const response = await app.request(
+      '/products/search?q=warm%20cool&mode=phrase'
+    );
+    const matched = await ids(response);
+
+    expect(matched).not.toContain('r1');
+  });
+});
+
+// ============================================================================
+// Memory suite
+// ============================================================================
+
+describe('Memory search adapter — LIKE wildcard semantics (literal chars)', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    clearStorage();
+    const store = getStorage<Record<string, unknown>>('memory_products');
+    for (const row of ROWS) {
+      store.set(row.id, row);
+    }
+
+    app = new Hono();
+    app.onError((err, c) =>
+      c.json({ success: false, error: { message: err.message } }, 400)
+    );
+    app.get('/products/search', async (c) => {
+      const endpoint = new MemoryProductSearch();
+      endpoint.setContext(c);
+      return endpoint.handle();
+    });
+  });
+
+  it('treats `_` as literal — q=foo_bar matches only the literal row', async () => {
+    const response = await app.request('/products/search?q=foo_bar');
+    const matched = await ids(response);
+
+    expect(matched).toContain('r2');
+    expect(matched).not.toContain('r3');
+  });
+
+  it('treats `%%` as literal — q=%% matches zero rows', async () => {
+    const response = await app.request('/products/search?q=%25%25');
+    const matched = await ids(response);
+
+    expect(matched).toEqual([]);
+  });
+});
+
+describe("Memory search adapter — mode='all' token-AND semantics", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    clearStorage();
+    const store = getStorage<Record<string, unknown>>('memory_products');
+    for (const row of ROWS) {
+      store.set(row.id, row);
+    }
+
+    app = new Hono();
+    app.onError((err, c) =>
+      c.json({ success: false, error: { message: err.message } }, 400)
+    );
+    app.get('/products/search', async (c) => {
+      const endpoint = new MemoryProductSearch();
+      endpoint.setContext(c);
+      return endpoint.handle();
+    });
+  });
+
+  it("q='warm cool' mode='all' matches the Orbit row (token-AND across fields)", async () => {
+    const response = await app.request(
+      '/products/search?q=warm%20cool&mode=all'
+    );
+    const matched = await ids(response);
+
+    expect(matched).toContain('r1');
+    expect(matched).not.toContain('r6');
+  });
+
+  it("q='warm zzzz' mode='all' returns 0 (negative case)", async () => {
+    const response = await app.request(
+      '/products/search?q=warm%20zzzz&mode=all'
+    );
+    const matched = await ids(response);
+
+    expect(matched).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Two correctness / hardening fixes in the per-adapter `search` implementations (drizzle / memory / prisma). The abstract `SearchEndpoint` (`src/endpoints/search.ts`) is **not** touched.

### 1. LIKE wildcard escape (security / hardening)

Before, the drizzle adapter built `LOWER(col) LIKE LOWER('%' || ? || '%')` and bound the raw user query. The bind is parameterised so this is **not** SQL injection, but `%` and `_` inside the user input were still interpreted as LIKE wildcards. A client could probe / exfiltrate more rows than the maintainer intends:

- `q=%%` matched **every row**.
- `q=auro_a` matched "Aurora" via `_` as single-char wildcard.
- `q=_oo_` matched any 4-char field containing "oo".

Drizzle now escapes `\\`, `%`, `_` in the user query (backslash first) and declares `ESCAPE '\\'` on every LIKE clause — both in `DrizzleSearchEndpoint` and in the `DrizzleExportEndpoint` list path that reuses LIKE for the `search` query filter.

Prisma's `contains` operator is a literal substring match — it does NOT interpret SQL LIKE wildcards from user input, so no escaping is required there. This is now documented in the adapter.

The memory adapter already used `String#includes` for matching, which treats `%`/`_` literally; a regression test pins this behaviour.

### 2. mode='all' token-AND semantics (correctness — behaviour change)

> **Behaviour change — please review.** `mode='all'` was effectively unusable for multi-term queries and now works as documented. `mode='any'` (default) and `mode='phrase'` are unchanged.

Before, `mode='all'` built `(col1 LIKE '%full query%') AND (col2 LIKE '%full query%') AND …` — every configured field had to contain the **whole** phrase. For example, against a row with `description="Adjustable warm/cool LED…"`, the query `q=warm cool&mode=all` returned 0 hits because no field contains the literal string "warm cool".

All three adapters now implement **token-AND across fields**: for each whitespace-delimited token of the query, AT LEAST ONE configured field must contain that token. This matches the documented "all terms match" intent.

- drizzle / prisma: SQL pre-filter enforces token-AND; the in-memory `searchInMemory` is then called with `mode='any'` so it does scoring only and does not re-apply its stricter per-field gate.
- memory: the same token-AND pre-filter runs in JS before delegating to `searchInMemory` for scoring / highlights.

`mode='any'` (default) and `mode='phrase'` retain their existing "phrase OR'd across fields" semantics.

## Files

- `src/adapters/drizzle/advanced.ts` — wildcard escape + token-AND, plus the `escapeLikePattern` / `tokenizeForSearch` helpers (file-local).
- `src/adapters/memory/advanced.ts` — token-AND pre-filter; `searchInMemory` then scores with `mode='any'`.
- `src/adapters/prisma/advanced.ts` — token-AND `WHERE` shape; documents that `contains` does not interpret LIKE wildcards.
- `tests/search-adapter-sql.test.ts` — **new** (12 cases).

`src/index.ts` is intentionally not modified — no new exports are required.

## Test plan

- [x] `pnpm typecheck` clean.
- [x] `pnpm test:unit` — 873 pass (was 861 on `main`; +12 new).
- [x] `pnpm test:workers` — 42 pass.
- [x] `pnpm test:package-example` — passes (server boots, local-consumer test green).
- [x] New tests verified to **fail on pristine `main`** (stash adapters, re-run): the wildcard `total_count` leak guards and the `mode='all'` token-AND case fail without the fix, confirming the tests catch the regressions.
- [x] `pnpm test:examples` — skipped (requires local Postgres `localhost:5432`; same env gap as prior PRs).
- [x] Existing `tests/search.test.ts` "should support all mode (AND)" continues to pass (the test row contains both tokens in multiple fields, so it matches under both old and new semantics).