### PR TITLE
fix: drizzle postgres examples — override dialect on remaining non-list endpoints

### DIFF
--- a/examples/drizzle/comprehensive.ts
+++ b/examples/drizzle/comprehensive.ts
@@ -346,6 +346,7 @@ class CategoryList extends DrizzleListEndpoint {
 class CategoryUpsert extends DrizzleUpsertEndpoint {
   _meta = categoryMeta;
   db = typedDb;
+  protected override dialect = 'pg' as const;
 
   schema = {
     tags: ['Categories'],

--- a/examples/drizzle/upsert.ts
+++ b/examples/drizzle/upsert.ts
@@ -133,6 +133,7 @@ const inventoryMeta = defineMeta({ model: InventoryModel });
 class ProductUpsert extends DrizzleUpsertEndpoint {
   _meta = productMeta;
   db = typedDb;
+  protected override dialect = 'pg' as const;
 
   schema = {
     tags: ['Products'],
@@ -176,6 +177,7 @@ class ProductList extends DrizzleListEndpoint {
 class InventoryBatchUpsert extends DrizzleBatchUpsertEndpoint {
   _meta = inventoryMeta;
   db = typedDb;
+  protected override dialect = 'pg' as const;
 
   schema = {
     tags: ['Inventory'],


### PR DESCRIPTION
## Summary

PR-J (#30, `fix: drizzle list — literal-substring …`) added
`protected override dialect = 'pg' as const` to every `DrizzleListEndpoint`
subclass in postgres-backed `examples/drizzle/*.ts` files. The same class
of latent issue exists for any subclass of the other dialect-aware endpoint
classes (`DrizzleUpsertEndpoint`, `DrizzleBatchUpsertEndpoint`,
`DrizzleSearchEndpoint`, `DrizzleExportEndpoint`) — they all default to
`'sqlite'` at the engine level. Without an explicit override, a postgres-
backed example wires a sqlite SQL dialect into its endpoints.

This PR closes that gap comprehensively across all five dialect-aware
endpoint classes in `examples/drizzle/`.

## Audit table

For each `examples/drizzle/*.ts` file: inferred dialect (from
`drizzle-orm/{node-postgres,libsql,d1,...}` import in the file or its
imported `./db`), every subclass of the five dialect-aware endpoint
classes, and override status.

| File | Dialect | Subclass | Endpoint base | Override status |
| --- | --- | --- | --- | --- |
| `basic-crud.ts` | pg | `UserList` | `DrizzleListEndpoint` | already set (PR-J) |
| `batch-operations.ts` | pg | `UserList` | `DrizzleListEndpoint` | already set (PR-J) |
| `clone.ts` | sqlite (libsql) | `ArticleList` | `DrizzleListEndpoint` | default `'sqlite'` correct — unchanged |
| `comprehensive.ts` | pg | `UserList` | `DrizzleListEndpoint` | already set (PR-J) |
| `comprehensive.ts` | pg | `PostList` | `DrizzleListEndpoint` | already set (PR-J) |
| `comprehensive.ts` | pg | `CommentList` | `DrizzleListEndpoint` | already set (PR-J) |
| `comprehensive.ts` | pg | `CategoryList` | `DrizzleListEndpoint` | already set (PR-J) |
| `comprehensive.ts` | pg | `CategoryUpsert` | `DrizzleUpsertEndpoint` | **this PR** |
| `d1-crud.ts` | sqlite (D1) | _no subclass_ | — | n/a |
| `filtering.ts` | pg | `UserList` | `DrizzleListEndpoint` | already set (PR-J) |
| `filtering.ts` | pg | `CategoryList` | `DrizzleListEndpoint` | already set (PR-J) |
| `relations.ts` | pg | `UserList` | `DrizzleListEndpoint` | already set (PR-J) |
| `relations.ts` | pg | `PostList` | `DrizzleListEndpoint` | already set (PR-J) |
| `relations.ts` | pg | `CommentList` | `DrizzleListEndpoint` | already set (PR-J) |
| `soft-delete.ts` | pg | `UserList` | `DrizzleListEndpoint` | already set (PR-J) |
| `upsert.ts` | pg | `ProductUpsert` | `DrizzleUpsertEndpoint` | **this PR** |
| `upsert.ts` | pg | `ProductList` | `DrizzleListEndpoint` | already set (PR-J) |
| `upsert.ts` | pg | `InventoryBatchUpsert` | `DrizzleBatchUpsertEndpoint` | **this PR** |
| `upsert.ts` | pg | `InventoryList` | `DrizzleListEndpoint` | already set (PR-J) |
| `with-drizzle-zod.ts` | sqlite (libsql) | `ProductList` | `DrizzleListEndpoint` | default `'sqlite'` correct — unchanged |

Findings:

- `DrizzleSearchEndpoint` and `DrizzleExportEndpoint` are **not subclassed
  anywhere in `examples/drizzle/`**. They are mounted directly via
  `createDrizzleCrud(...)`, which already plumbs `dialect` through.
- No mysql-backed drizzle example exists.
- Three non-list subclasses in postgres-backed files needed the override
  and now have it.

## Why this is a `fix:`

Same root cause as PR-J: `DrizzleUpsertEndpoint` / `DrizzleBatchUpsertEndpoint`
each declare `protected dialect: DrizzleDialect = 'sqlite'` as the base
default. A postgres-backed example that extends those classes directly
inherits the sqlite default unless it overrides. PR-J caught the list
case; this PR closes the same class of latent issue for upsert /
batch-upsert subclasses.

## Test plan

- [x] `pnpm run typecheck` — pass
- [x] `pnpm run typecheck:examples` — pass
- [x] `pnpm run test:unit` — 48 files / 902 tests pass (no delta vs baseline on `main`)
- [x] `pnpm run test:workers` — 5 files / 42 tests pass (no delta)
- [x] `pnpm run test:package-example` — pass
- [x] `tests/examples/db-comprehensive.test.ts` already exercises
  `CategoryUpsert` against the drizzle-postgres example via the
  `/categories` PUT path in `tests/examples/harness.ts` — the existing
  matrix covers the regression surface for that subclass.
- [ ] `pnpm run test:examples` — local env gap (Prisma `prisma db push`
  cannot reach `localhost:5432` on this workstation); CI matrix will run
  it.

Scope: only the three example files / subclass call sites listed above.
No `src/` changes, no schema changes, no test changes, no version bump,
no CHANGELOG edit.