### PR TITLE
test: restore full CI coverage (workers, examples, local-consumer)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,5 +51,17 @@ jobs:
       - name: Type check
         run: pnpm -r typecheck
 
+      - name: Type check examples
+        run: pnpm run typecheck:examples
+
       - name: Unit tests
         run: pnpm run test:unit
+
+      - name: Example tests (Postgres)
+        run: pnpm run test:examples
+
+      - name: Workers tests (miniflare)
+        run: pnpm run test:workers
+
+      - name: Local consumer smoke
+        run: pnpm run example:local

--- a/package.json
+++ b/package.json
@@ -27,11 +27,12 @@
     "prisma:studio": "prisma studio --schema=examples/prisma/schema.prisma --config=examples/prisma/prisma.config.ts",
     "db:up": "cd examples && docker compose up -d",
     "db:down": "cd examples && docker compose down",
-    "test": "pnpm run typecheck && pnpm run typecheck:examples && pnpm run test:unit && pnpm run test:examples && pnpm run test:workers",
+    "test": "pnpm -r build && pnpm -r typecheck && pnpm run typecheck:examples && pnpm run test:unit && pnpm run test:examples && pnpm run test:workers && pnpm run example:local",
     "test:unit": "vitest run --exclude 'tests/examples/**'",
     "test:examples": "pnpm run prisma:generate && pnpm run prisma:push && vitest run tests/examples",
     "test:workers": "vitest run --config vitest.config.workers.ts",
     "typecheck:examples": "pnpm run prisma:generate && tsc -p tsconfig.examples.json",
+    "example:local": "pnpm --filter hono-crud-local-consumer-example run typecheck && pnpm --filter hono-crud-local-consumer-example run test",
     "changeset": "changeset",
     "version": "changeset version",
     "release": "pnpm -r build && changeset publish"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,49 @@ importers:
         specifier: ^4.3.5
         version: 4.3.6
 
+  examples/local-consumer:
+    dependencies:
+      '@hono-crud/cache':
+        specifier: workspace:*
+        version: link:../../packages/cache
+      '@hono-crud/health':
+        specifier: workspace:*
+        version: link:../../packages/health
+      '@hono-crud/idempotency':
+        specifier: workspace:*
+        version: link:../../packages/idempotency
+      '@hono-crud/memory':
+        specifier: workspace:*
+        version: link:../../packages/memory
+      '@hono-crud/rate-limit':
+        specifier: workspace:*
+        version: link:../../packages/rate-limit
+      '@hono-crud/swagger':
+        specifier: workspace:*
+        version: link:../../packages/swagger
+      '@hono/node-server':
+        specifier: ^1.19.9
+        version: 1.19.9(hono@4.11.7)
+      hono:
+        specifier: ^4.11.4
+        version: 4.11.7
+      hono-crud:
+        specifier: workspace:*
+        version: link:../../packages/core
+      zod:
+        specifier: ^4.3.5
+        version: 4.3.6
+    devDependencies:
+      '@types/node':
+        specifier: ^22.14.1
+        version: 22.19.7
+      tsx:
+        specifier: ^4.19.3
+        version: 4.21.0
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+
   packages/cache:
     dependencies:
       hono-crud:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - 'packages/*'
+  - 'examples/local-consumer'

--- a/tests/workers/edge-compat.test.ts
+++ b/tests/workers/edge-compat.test.ts
@@ -98,8 +98,10 @@ describe('Edge Runtime Compatibility (Workers)', () => {
     it('should import the root package entry in a Workers isolate', async () => {
       const mod = await import('hono-crud');
       expect(mod.createCrudMiddleware).toBeTypeOf('function');
-      expect(mod.KVCacheStorage).toBeTypeOf('function');
-      expect(mod.KVRateLimitStorage).toBeTypeOf('function');
+      const { KVCacheStorage } = await import('@hono-crud/cache');
+      const { KVRateLimitStorage } = await import('@hono-crud/rate-limit');
+      expect(KVCacheStorage).toBeTypeOf('function');
+      expect(KVRateLimitStorage).toBeTypeOf('function');
     });
 
     it('should handle requests correctly', async () => {
@@ -130,20 +132,22 @@ describe('Edge Runtime Compatibility (Workers)', () => {
 
   describe('createCrudMiddleware in Workers', () => {
     it('should inject storage into Hono context', async () => {
-      const { createCrudMiddleware } = await import('hono-crud/middleware');
-      const { MemoryCacheStorage } = await import('@hono-crud/cache/storage/memory');
+      // createCrudMiddleware injects the core-owned storages (audit/versioning/
+      // logging/events). Cache/rate-limit/idempotency moved to their own
+      // packages and compose their own middleware.
+      const { createCrudMiddleware, MemoryAuditLogStorage } = await import('hono-crud');
 
-      const cache = new MemoryCacheStorage();
+      const audit = new MemoryAuditLogStorage();
       const app = new Hono<StorageEnv>();
 
-      app.use('*', createCrudMiddleware({ cache }));
+      app.use('*', createCrudMiddleware({ audit }));
       app.get('/test', (c) => {
-        return c.json({ hasCache: c.var.cacheStorage === cache });
+        return c.json({ hasAudit: c.var.auditStorage === audit });
       });
 
       const res = await app.request('/test');
       const body = await res.json();
-      expect(body).toEqual({ hasCache: true });
+      expect(body).toEqual({ hasAudit: true });
     });
   });
 });

--- a/tests/workers/resolve-schema-edge.test.ts
+++ b/tests/workers/resolve-schema-edge.test.ts
@@ -61,9 +61,9 @@ describe('Per-tenant schema resolution (Workers)', () => {
       defineModel,
       defineMeta,
       buildPerTenantOpenApi,
-      KVCacheStorage,
       wrapCacheStorageForOpenApi,
     } = await import('hono-crud');
+    const { KVCacheStorage } = await import('@hono-crud/cache');
     const { MemoryCreateEndpoint } = await import('@hono-crud/memory');
 
     const Base = z.object({ id: z.string().uuid(), title: z.string() });


### PR DESCRIPTION
Closes the post-migration coverage gap — the monorepo PR had narrowed CI to `test:unit` only. Now CI runs the complete gate again.

## What changed
- **Fixed 3 Workers (miniflare) tests** that asserted pre-split behavior:
  - `KVCacheStorage` / `KVRateLimitStorage` are imported from `@hono-crud/cache` and `@hono-crud/rate-limit` (no longer on the `hono-crud` barrel).
  - `createCrudMiddleware` now injects only core-owned storages, so the injection test uses `MemoryAuditLogStorage` instead of cache.
- **`examples/local-consumer`** is now a workspace member, so it imports the locally **built** packages by name — validating real `exports`/dist resolution from a consumer's perspective. Restored an `example:local` smoke script.
- **`ci.yml`**: re-added `typecheck:examples`, `test:examples` (Postgres service already present), `test:workers` (miniflare), and a `example:local` smoke step. Root `test` is now build-first and runs the full gate.

## Verified locally (Postgres via docker)
`pnpm test` → exit 0:
- build + typecheck (10 packages) ✅
- typecheck:examples ✅
- unit **902** ✅
- examples (Postgres) **37** ✅
- workers (miniflare) **42** ✅
- local-consumer smoke ✅