### PR TITLE
chore: release packages

### DIFF
--- a/.changeset/crud-resource-registry.md
+++ b/.changeset/crud-resource-registry.md
@@ -1,5 +1,0 @@
----
-"hono-crud": patch
----
-
-`registerCrud(...)` now records each resource on the app instance (app-scoped, startup-time, edge-safe), and `hono-crud/internal` exports `getRegisteredCrudResources(app)` plus the `RegisteredCrudResource` type. This lets addon packages (e.g. `@hono-crud/mcp`) enumerate registered CRUD resources. `hono-crud/internal` also now exports `extractBearerToken(ctx)` (the default `Authorization: Bearer` extractor) for reuse by first-party addons. No behavior change for existing apps.

--- a/.changeset/hono-crud-mcp.md
+++ b/.changeset/hono-crud-mcp.md
@@ -1,5 +1,0 @@
----
-"@hono-crud/mcp": patch
----
-
-Add `@hono-crud/mcp`: auto-generate Model Context Protocol (MCP) tools from hono-crud resources. Introspects the CRUD endpoints you register and exposes `list`/`read`/`create`/`update`/`delete` as MCP tools over HTTP streaming transport, re-dispatching tool calls through the mounted Hono app so they share the full REST pipeline (auth, validation, hooks, serialization, pagination). Register resources explicitly with `mcp.resource(path, endpoints)`, or set `auto: true` to discover and expose every `registerCrud(...)` resource automatically (with include/exclude, default operations, and per-resource overrides). Configurable tool names, descriptions, operation allow-list, and MCP annotations; pluggable bearer-token auth by default with optional MCP OAuth 2.1.

--- a/packages/cache/CHANGELOG.md
+++ b/packages/cache/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @hono-crud/cache
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies [c95d8dc]
+  - hono-crud@0.13.5
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hono-crud/cache",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Caching mixins and storage backends for hono-crud",
   "author": "Kauan Guesser <contato@kauan.net>",
   "license": "MIT",
@@ -28,9 +28,20 @@
     "clean": "rm -rf dist .tsup",
     "lint": "biome check src/"
   },
-  "keywords": ["hono", "crud", "cache", "caching", "redis", "kv"],
+  "keywords": [
+    "hono",
+    "crud",
+    "cache",
+    "caching",
+    "redis",
+    "kv"
+  ],
   "sideEffects": false,
-  "files": ["dist", "README.md", "LICENSE"],
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "engines": {
     "node": ">=20.19.0"
   },

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.13.5
+
+### Patch Changes
+
+- c95d8dc: `registerCrud(...)` now records each resource on the app instance (app-scoped, startup-time, edge-safe), and `hono-crud/internal` exports `getRegisteredCrudResources(app)` plus the `RegisteredCrudResource` type. This lets addon packages (e.g. `@hono-crud/mcp`) enumerate registered CRUD resources. `hono-crud/internal` also now exports `extractBearerToken(ctx)` (the default `Authorization: Bearer` extractor) for reuse by first-party addons. No behavior change for existing apps.
+
 ## 0.13.4
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hono-crud",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "CRUD generator for Hono with Zod validation and OpenAPI generation",
   "author": "Kauan Guesser <contato@kauan.net>",
   "license": "MIT",
@@ -89,7 +89,12 @@
     "cloudflare-workers"
   ],
   "sideEffects": false,
-  "files": ["dist", "README.md", "LICENSE", "CHANGELOG.md"],
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ],
   "engines": {
     "node": ">=20.19.0"
   },

--- a/packages/drizzle/CHANGELOG.md
+++ b/packages/drizzle/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @hono-crud/drizzle
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies [c95d8dc]
+  - hono-crud@0.13.5
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hono-crud/drizzle",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Drizzle ORM CRUD adapter for hono-crud",
   "author": "Kauan Guesser <contato@kauan.net>",
   "license": "MIT",
@@ -28,9 +28,19 @@
     "clean": "rm -rf dist .tsup",
     "lint": "biome check src/"
   },
-  "keywords": ["hono", "crud", "drizzle", "drizzle-orm", "adapter"],
+  "keywords": [
+    "hono",
+    "crud",
+    "drizzle",
+    "drizzle-orm",
+    "adapter"
+  ],
   "sideEffects": false,
-  "files": ["dist", "README.md", "LICENSE"],
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "engines": {
     "node": ">=20.19.0"
   },

--- a/packages/idempotency/CHANGELOG.md
+++ b/packages/idempotency/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @hono-crud/idempotency
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies [c95d8dc]
+  - hono-crud@0.13.5
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/idempotency/package.json
+++ b/packages/idempotency/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hono-crud/idempotency",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Idempotency middleware and storage backends for hono-crud",
   "author": "Kauan Guesser <contato@kauan.net>",
   "license": "MIT",
@@ -28,9 +28,19 @@
     "clean": "rm -rf dist .tsup",
     "lint": "biome check src/"
   },
-  "keywords": ["hono", "crud", "idempotency", "idempotency-key", "retries"],
+  "keywords": [
+    "hono",
+    "crud",
+    "idempotency",
+    "idempotency-key",
+    "retries"
+  ],
   "sideEffects": false,
-  "files": ["dist", "README.md", "LICENSE"],
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "engines": {
     "node": ">=20.19.0"
   },

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @hono-crud/mcp
+
+## 0.1.1
+
+### Patch Changes
+
+- c95d8dc: Add `@hono-crud/mcp`: auto-generate Model Context Protocol (MCP) tools from hono-crud resources. Introspects the CRUD endpoints you register and exposes `list`/`read`/`create`/`update`/`delete` as MCP tools over HTTP streaming transport, re-dispatching tool calls through the mounted Hono app so they share the full REST pipeline (auth, validation, hooks, serialization, pagination). Register resources explicitly with `mcp.resource(path, endpoints)`, or set `auto: true` to discover and expose every `registerCrud(...)` resource automatically (with include/exclude, default operations, and per-resource overrides). Configurable tool names, descriptions, operation allow-list, and MCP annotations; pluggable bearer-token auth by default with optional MCP OAuth 2.1.
+- Updated dependencies [c95d8dc]
+  - hono-crud@0.13.5

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hono-crud/mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Auto-generate Model Context Protocol (MCP) tools from hono-crud resources",
   "author": "Kauan Guesser <contato@kauan.net>",
   "license": "MIT",
@@ -28,9 +28,21 @@
     "clean": "rm -rf dist .tsup",
     "lint": "biome check src/"
   },
-  "keywords": ["hono", "crud", "mcp", "model-context-protocol", "ai", "llm", "tools"],
+  "keywords": [
+    "hono",
+    "crud",
+    "mcp",
+    "model-context-protocol",
+    "ai",
+    "llm",
+    "tools"
+  ],
   "sideEffects": false,
-  "files": ["dist", "README.md", "LICENSE"],
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "engines": {
     "node": ">=20.19.0"
   },

--- a/packages/memory/CHANGELOG.md
+++ b/packages/memory/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @hono-crud/memory
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies [c95d8dc]
+  - hono-crud@0.13.5
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hono-crud/memory",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "In-memory CRUD adapter for hono-crud",
   "author": "Kauan Guesser <contato@kauan.net>",
   "license": "MIT",
@@ -28,9 +28,18 @@
     "clean": "rm -rf dist .tsup",
     "lint": "biome check src/"
   },
-  "keywords": ["hono", "crud", "in-memory", "adapter"],
+  "keywords": [
+    "hono",
+    "crud",
+    "in-memory",
+    "adapter"
+  ],
   "sideEffects": false,
-  "files": ["dist", "README.md", "LICENSE"],
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "engines": {
     "node": ">=20.19.0"
   },

--- a/packages/prisma/CHANGELOG.md
+++ b/packages/prisma/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @hono-crud/prisma
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies [c95d8dc]
+  - hono-crud@0.13.5
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hono-crud/prisma",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Prisma CRUD adapter for hono-crud",
   "author": "Kauan Guesser <contato@kauan.net>",
   "license": "MIT",
@@ -28,9 +28,18 @@
     "clean": "rm -rf dist .tsup",
     "lint": "biome check src/"
   },
-  "keywords": ["hono", "crud", "prisma", "adapter"],
+  "keywords": [
+    "hono",
+    "crud",
+    "prisma",
+    "adapter"
+  ],
   "sideEffects": false,
-  "files": ["dist", "README.md", "LICENSE"],
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "engines": {
     "node": ">=20.19.0"
   },

--- a/packages/rate-limit/CHANGELOG.md
+++ b/packages/rate-limit/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @hono-crud/rate-limit
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies [c95d8dc]
+  - hono-crud@0.13.5
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/rate-limit/package.json
+++ b/packages/rate-limit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hono-crud/rate-limit",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Rate limiting middleware and storage backends for hono-crud",
   "author": "Kauan Guesser <contato@kauan.net>",
   "license": "MIT",
@@ -28,9 +28,21 @@
     "clean": "rm -rf dist .tsup",
     "lint": "biome check src/"
   },
-  "keywords": ["hono", "crud", "rate-limit", "ratelimit", "throttle", "redis", "kv"],
+  "keywords": [
+    "hono",
+    "crud",
+    "rate-limit",
+    "ratelimit",
+    "throttle",
+    "redis",
+    "kv"
+  ],
   "sideEffects": false,
-  "files": ["dist", "README.md", "LICENSE"],
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "engines": {
     "node": ">=20.19.0"
   },


### PR DESCRIPTION
This PR was opened manually to complete the automated release flow. The `Release` workflow's Changesets step pushed the `changeset-release/main` branch with all version bumps and CHANGELOG updates, but could not open this PR because **"Allow GitHub Actions to create and approve pull requests"** is disabled for the repo/org.

When you're ready to release, merging this PR triggers the publish to npm.

### Releases
- `hono-crud` → 0.13.5
- `@hono-crud/mcp` → 0.1.1 (first publish)
- `@hono-crud/{cache,drizzle,idempotency,memory,prisma,rate-limit}` → 0.1.2 (dependency bump)

> To restore the fully automated flow, enable *Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"* (repo, and org if enforced).