### PR TITLE
refactor(types): phase 1 — unify HonoOpenAPIApp, exhaustiveness guards, fix filter bypass

### DIFF
--- a/.changeset/type-safety-phase-1.md
+++ b/.changeset/type-safety-phase-1.md
@@ -1,0 +1,17 @@
+---
+"hono-crud": patch
+"@hono-crud/memory": patch
+"@hono-crud/drizzle": patch
+"@hono-crud/prisma": patch
+"@hono-crud/scalar": patch
+---
+
+Type-safety hardening (phase 1): eliminate type/schema drift and silent fall-throughs.
+
+- **Unify `HonoOpenAPIApp`.** The publicly re-exported type was a 4-verb subset that disagreed with the 7-verb superset `fromHono` actually returns; both now resolve to one canonical definition, so typing the documented `HonoOpenAPIApp` and calling `.options()`/`.head()`/`.doc()` type-checks.
+- **Closed-union exhaustiveness.** Filter-operator handling now goes through a single shared `matchesFilter` in the in-memory adapter (the four copy-pasted switches had drifted — one was missing `between` and silently matched every row), and the Drizzle/Prisma/aggregate switches gained `assertNever` exhaustiveness guards so a future operator is a compile error rather than a silent gap.
+- **Validate untrusted filter operators.** `parseFilterValue` no longer blindly casts an unrecognized `field[op]=value` token to `FilterOperator` (which downstream adapters silently ignored, disabling the filter); unknown operators now fall back to literal equality. `FilterOperator` is now derived from a single `as const` `FILTER_OPERATORS` source with an `isFilterOperator` guard.
+- **Scalar config.** `@hono-crud/scalar` no longer escapes its own typing via `as Record<string, unknown>`; `ScalarTheme` is derived from the upstream `ApiReferenceConfiguration` and `scalarUI` has an explicit return type.
+- **De-duplicated casts.** Added a localized `readResponseEnvelope(ctx)` accessor and a Drizzle `readCount`/`CountRow` helper, removing repeated inline casts.
+
+New exports: `FILTER_OPERATORS`, `isFilterOperator`, `assertNever`, `readResponseEnvelope` (from `hono-crud`); `readCount`/`CountRow` (from `@hono-crud/drizzle`). All additive; no breaking changes.

--- a/packages/core/src/core/error-handler.ts
+++ b/packages/core/src/core/error-handler.ts
@@ -5,11 +5,7 @@ import { getRequestId } from '../logging/middleware';
 import { ApiException, InputValidationException } from './exceptions';
 import { getLogger } from './logger';
 import { jsonResponse } from './route';
-import {
-  RESPONSE_ENVELOPE_CONTEXT_KEY,
-  type ResponseEnvelope,
-  type StructuredError,
-} from './types';
+import { type ResponseEnvelope, type StructuredError, readResponseEnvelope } from './types';
 
 /**
  * Error mapper: transforms unknown errors to ApiException.
@@ -234,8 +230,5 @@ export function resolveErrorEnvelope<E extends Env = Env>(
   ctx: Context<E>,
   fallback?: ResponseEnvelope,
 ): ResponseEnvelope | undefined {
-  const fromCtx = (ctx as unknown as { var?: Record<string, unknown> })?.var?.[
-    RESPONSE_ENVELOPE_CONTEXT_KEY
-  ] as ResponseEnvelope | undefined;
-  return fromCtx ?? fallback;
+  return readResponseEnvelope(ctx) ?? fallback;
 }

--- a/packages/core/src/core/openapi.ts
+++ b/packages/core/src/core/openapi.ts
@@ -3,11 +3,7 @@ import type { Context, Env, Hono, MiddlewareHandler } from 'hono';
 import { ApiException } from './exceptions';
 import type { OpenAPIRoute } from './route';
 import { isRouteClass, jsonResponse } from './route';
-import {
-  type OpenAPIRouteSchema,
-  RESPONSE_ENVELOPE_CONTEXT_KEY,
-  type ResponseEnvelope,
-} from './types';
+import { type OpenAPIRouteSchema, readResponseEnvelope } from './types';
 
 export interface OpenAPIConfig {
   openapi?: string;
@@ -233,9 +229,7 @@ export class HonoOpenAPIHandler<E extends Env = Env> {
           // override observable even when the endpoint short-circuits
           // before reaching `app.onError`.
           const body = error.toJSON();
-          const envelope = (c as unknown as { var?: Record<string, unknown> })?.var?.[
-            RESPONSE_ENVELOPE_CONTEXT_KEY
-          ] as ResponseEnvelope | undefined;
+          const envelope = readResponseEnvelope(c);
           if (envelope) {
             return jsonResponse(c, envelope.error(body.error), error.status);
           }

--- a/packages/core/src/core/register.ts
+++ b/packages/core/src/core/register.ts
@@ -1,6 +1,7 @@
 import type { OpenAPIHono } from '@hono/zod-openapi';
 import type { Env, MiddlewareHandler } from 'hono';
 import { setContextVar } from '../utils/context';
+import type { HonoOpenAPIApp } from './openapi';
 import { recordCrudResource } from './resource-registry';
 import type { OpenAPIRoute } from './route';
 import { RESPONSE_ENVELOPE_CONTEXT_KEY, type ResponseEnvelope } from './types';
@@ -142,42 +143,19 @@ export interface CrudEndpoints<E extends Env = Env> {
 }
 
 /**
- * Type for the proxied app returned by fromHono.
- * Extends OpenAPIHono to accept both regular handlers and endpoint classes.
+ * Type for the proxied app returned by `fromHono`.
+ *
+ * Re-exported from `./openapi`, which owns the single canonical definition.
+ * That definition is the superset: it covers every HTTP verb
+ * (`get`/`post`/`put`/`patch`/`delete`/`options`/`head`) plus `doc()`.
+ *
+ * This module previously declared a divergent 4-verb subset, so the type
+ * publicly re-exported through `index.ts` disagreed with what `fromHono`
+ * actually returns (a consumer typing the documented `HonoOpenAPIApp` and
+ * calling `.options()`/`.head()`/`.doc()` would hit a phantom type error).
+ * Keeping one source of truth removes that drift.
  */
-export type HonoOpenAPIApp<E extends Env = Env> = OpenAPIHono<E> & {
-  /**
-   * Register a GET endpoint with an OpenAPIRoute class
-   */
-  get(path: string, handler: EndpointClass<E>): HonoOpenAPIApp<E>;
-  get(path: string, ...handlers: [...MiddlewareHandler<E>[], EndpointClass<E>]): HonoOpenAPIApp<E>;
-  /**
-   * Register a POST endpoint with an OpenAPIRoute class
-   */
-  post(path: string, handler: EndpointClass<E>): HonoOpenAPIApp<E>;
-  post(path: string, ...handlers: [...MiddlewareHandler<E>[], EndpointClass<E>]): HonoOpenAPIApp<E>;
-  /**
-   * Register a PUT endpoint with an OpenAPIRoute class
-   */
-  put(path: string, handler: EndpointClass<E>): HonoOpenAPIApp<E>;
-  put(path: string, ...handlers: [...MiddlewareHandler<E>[], EndpointClass<E>]): HonoOpenAPIApp<E>;
-  /**
-   * Register a PATCH endpoint with an OpenAPIRoute class
-   */
-  patch(path: string, handler: EndpointClass<E>): HonoOpenAPIApp<E>;
-  patch(
-    path: string,
-    ...handlers: [...MiddlewareHandler<E>[], EndpointClass<E>]
-  ): HonoOpenAPIApp<E>;
-  /**
-   * Register a DELETE endpoint with an OpenAPIRoute class
-   */
-  delete(path: string, handler: EndpointClass<E>): HonoOpenAPIApp<E>;
-  delete(
-    path: string,
-    ...handlers: [...MiddlewareHandler<E>[], EndpointClass<E>]
-  ): HonoOpenAPIApp<E>;
-};
+export type { HonoOpenAPIApp };
 
 type RouteRegistrar<E extends Env> = {
   (path: string, handler: EndpointClass<E>): HonoOpenAPIApp<E>;
@@ -263,7 +241,12 @@ export function registerCrud<E extends Env = Env>(
     endpoint: EndpointClass<E>,
   ): void => {
     const mw = getMiddleware(name);
-    const register = typedApp[method] as RouteRegistrar<E>;
+    // Re-type Hono's broadly-overloaded handler method down to the narrow
+    // CRUD registrar shape we actually invoke. The `fromHono` Proxy guarantees
+    // the runtime contract; the two overload sets don't structurally overlap
+    // (Hono's `HandlerInterface` also accepts sub-apps/handler chains), so this
+    // crosses through `unknown` deliberately — an internal boundary, not a hole.
+    const register = typedApp[method] as unknown as RouteRegistrar<E>;
     if (mw.length > 0) {
       register(path, ...mw, endpoint);
     } else {

--- a/packages/core/src/core/route.ts
+++ b/packages/core/src/core/route.ts
@@ -4,11 +4,11 @@ import type { ZodObject, ZodRawShape } from 'zod';
 import { getLogger } from './logger';
 import {
   type OpenAPIRouteSchema,
-  RESPONSE_ENVELOPE_CONTEXT_KEY,
   type ResponseEnvelope,
   type ResponseEnvelopeInfo,
   type RouteOptions,
   type ValidatedData,
+  readResponseEnvelope,
 } from './types';
 
 type ValidationTarget = 'json' | 'query' | 'param';
@@ -166,10 +166,7 @@ export abstract class OpenAPIRoute<
    * see `undefined` and fall through to the default shape.
    */
   protected getResponseEnvelope(): ResponseEnvelope | undefined {
-    if (!this.context) return undefined;
-    const ctx = this.context as unknown as { var?: Record<string, unknown> };
-    const envelope = ctx?.var?.[RESPONSE_ENVELOPE_CONTEXT_KEY];
-    return (envelope as ResponseEnvelope | undefined) ?? undefined;
+    return readResponseEnvelope(this.context);
   }
 
   /**

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -21,21 +21,62 @@ export type SchemaKeys<T extends ZodObject<ZodRawShape>> = keyof z.infer<T>;
 // ============================================================================
 
 // Filter operators for list queries
-export type FilterOperator =
-  | 'eq' // equals
-  | 'ne' // not equals
-  | 'gt' // greater than
-  | 'gte' // greater than or equal
-  | 'lt' // less than
-  | 'lte' // less than or equal
-  | 'in' // in array
-  | 'nin' // not in array
-  | 'like' // SQL LIKE
-  | 'ilike' // case-insensitive LIKE
-  | 'null' // is null
-  | 'between'; // between two values
+/**
+ * Canonical list of supported filter operators.
+ *
+ * Single source of truth: both the {@link FilterOperator} union and the runtime
+ * guard {@link isFilterOperator} are derived from this `as const` array, so the
+ * compile-time type and the runtime membership check can never drift apart.
+ */
+export const FILTER_OPERATORS = [
+  'eq', // equals
+  'ne', // not equals
+  'gt', // greater than
+  'gte', // greater than or equal
+  'lt', // less than
+  'lte', // less than or equal
+  'in', // in array
+  'nin', // not in array
+  'like', // SQL LIKE
+  'ilike', // case-insensitive LIKE
+  'null', // is null
+  'between', // between two values
+] as const;
+
+export type FilterOperator = (typeof FILTER_OPERATORS)[number];
 
 export type FilterOperatorList = readonly FilterOperator[];
+
+/**
+ * Runtime type guard for {@link FilterOperator}.
+ *
+ * Used to validate operators parsed from untrusted query strings
+ * (`field[op]=value`) before they reach an adapter, so an unrecognized operator
+ * cannot silently disable a filter and return every row.
+ */
+export function isFilterOperator(value: string): value is FilterOperator {
+  return (FILTER_OPERATORS as readonly string[]).includes(value);
+}
+
+/**
+ * Compile-time exhaustiveness guard for discriminated unions.
+ *
+ * Call it from the `default` branch of a `switch` over a closed union: the
+ * parameter is typed `never`, so adding a new union member makes every such
+ * call fail to compile until the new case is handled — converting a silent
+ * fall-through into a build error. If somehow reached at runtime (an invariant
+ * was violated), it throws rather than continuing with bad state.
+ *
+ * @example
+ * switch (op) {
+ *   case 'a': return 1;
+ *   case 'b': return 2;
+ *   default: return assertNever(op);
+ * }
+ */
+export function assertNever(value: never): never {
+  throw new Error(`Unhandled discriminated union member: ${String(value)}`);
+}
 
 // Filter configuration per field
 export type FilterConfig = {
@@ -1376,6 +1417,22 @@ export interface ResponseEnvelope {
  * to read the same envelope from custom endpoints.
  */
 export const RESPONSE_ENVELOPE_CONTEXT_KEY = '__honoCrudResponseEnvelope__' as const;
+
+/**
+ * Read the per-request {@link ResponseEnvelope} stashed on the Hono context by
+ * `registerCrud(...)`'s envelope middleware.
+ *
+ * The context `var` bag is untyped at this boundary (it carries arbitrary
+ * per-request values), so the single unavoidable cast is localized here instead
+ * of being repeated — previously as `(ctx as unknown as { var?: … })?.var?.[…]
+ * as ResponseEnvelope` — at every read site (`OpenAPIRoute.getResponseEnvelope`,
+ * the OpenAPI error path, and `resolveErrorEnvelope`). Accepts an `unknown`
+ * context (including `undefined`) and returns `undefined` when no envelope is set.
+ */
+export function readResponseEnvelope(ctx: unknown): ResponseEnvelope | undefined {
+  const vars = (ctx as { var?: Record<string, unknown> } | null | undefined)?.var;
+  return vars?.[RESPONSE_ENVELOPE_CONTEXT_KEY] as ResponseEnvelope | undefined;
+}
 
 // Route handler arguments
 export type HandleArgs<E extends Env = Env> = [Context<E>];

--- a/packages/core/src/endpoints/aggregate.ts
+++ b/packages/core/src/endpoints/aggregate.ts
@@ -11,6 +11,7 @@ import type {
   MetaInput,
   OpenAPIRouteSchema,
 } from '../core/types';
+import { assertNever } from '../core/types';
 import { CrudEndpoint } from './base';
 import { errorResponseSchema } from './responses';
 
@@ -163,8 +164,14 @@ export abstract class AggregateEndpoint<
         continue;
       }
 
-      // Check field restrictions based on operation
+      // Check field restrictions based on operation.
+      // Exhaustive over AggregateOperation so a newly-added operation cannot
+      // silently skip field-restriction validation (a security gap): the
+      // `assertNever` default forces every operation to be handled here.
       switch (agg.operation) {
+        case 'count':
+          // COUNT on a specific field is unrestricted (COUNT(*) handled above).
+          break;
         case 'sum':
           if (config.sumFields.length > 0 && !config.sumFields.includes(agg.field)) {
             throw new Error(`Field '${agg.field}' is not allowed for SUM aggregation`);
@@ -189,6 +196,8 @@ export abstract class AggregateEndpoint<
             throw new Error(`Field '${agg.field}' is not allowed for COUNT DISTINCT aggregation`);
           }
           break;
+        default:
+          assertNever(agg.operation);
       }
     }
 

--- a/packages/core/src/endpoints/types.ts
+++ b/packages/core/src/endpoints/types.ts
@@ -14,6 +14,7 @@ import type {
   defineMeta,
   defineModel,
 } from '../core/types';
+import { isFilterOperator } from '../core/types';
 
 // Re-export core types
 export type {
@@ -99,8 +100,13 @@ function coerceFilterValue(operator: FilterOperator, raw: string): unknown {
 export function parseFilterValue(value: string): { operator: FilterOperator; value: unknown } {
   // Check for operator syntax: field[operator]=value
   const operatorMatch = value.match(/^\[([a-z]+)\](.*)$/);
-  if (operatorMatch) {
-    const operator = operatorMatch[1] as FilterOperator;
+  // Only treat the bracketed token as an operator when it is a real
+  // `FilterOperator`. An unrecognized token (e.g. `[foo]bar`) must NOT be cast
+  // blindly — doing so produced an invalid operator that downstream adapters
+  // silently ignored, disabling the filter and returning every record. Fall
+  // through to literal equality so an unknown operator simply fails to match.
+  if (operatorMatch && isFilterOperator(operatorMatch[1])) {
+    const operator = operatorMatch[1];
     return { operator, value: coerceFilterValue(operator, operatorMatch[2]) };
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -70,7 +70,14 @@ export type {
   AdapterKind,
   NormalizedTimestampsConfig,
 } from './core/managed-fields';
-export { defineModel, defineMeta, RESPONSE_ENVELOPE_CONTEXT_KEY } from './core/types';
+export {
+  defineModel,
+  defineMeta,
+  RESPONSE_ENVELOPE_CONTEXT_KEY,
+  FILTER_OPERATORS,
+  isFilterOperator,
+  assertNever,
+} from './core/types';
 export { encodeCursor, decodeCursor } from './core/cursor';
 export { applyComputedFields, applyComputedFieldsToArray } from './core/computed-fields';
 export { extractNestedData, isDirectNestedData } from './core/nested-writes';

--- a/packages/drizzle/src/advanced.ts
+++ b/packages/drizzle/src/advanced.ts
@@ -35,6 +35,7 @@ import {
   cast,
   getColumn,
   getTable,
+  readCount,
 } from './helpers';
 
 /**
@@ -477,7 +478,7 @@ export abstract class DrizzleVersionHistoryEndpoint<
       .from(table)
       .where(eq(this.getColumn('id'), lookupValue));
 
-    return Number((result as { count: number }[])[0]?.count) > 0;
+    return readCount(result) > 0;
   }
 }
 
@@ -800,7 +801,7 @@ export abstract class DrizzleSearchEndpoint<
       .from(table)
       .where(whereClause);
 
-    const totalCount = Number((countResult as { count: number }[])[0]?.count) || 0;
+    const totalCount = readCount(countResult);
 
     // Build main query
     let query = cast(this.getDb()).select().from(table).where(whereClause);
@@ -930,7 +931,7 @@ export abstract class DrizzleExportEndpoint<
       .from(table)
       .where(whereClause);
 
-    const totalCount = Number((countResult as { count: number }[])[0]?.count) || 0;
+    const totalCount = readCount(countResult);
 
     // Build main query
     let query = cast(this.getDb()).select().from(table).where(whereClause);

--- a/packages/drizzle/src/crud.ts
+++ b/packages/drizzle/src/crud.ts
@@ -29,6 +29,7 @@ import {
   getColumn,
   getTable,
   loadDrizzleRelations,
+  readCount,
 } from './helpers';
 
 /**
@@ -667,7 +668,7 @@ export abstract class DrizzleDeleteEndpoint<
       .from(relatedTable)
       .where(eq(fkColumn, parentId));
 
-    return Number((result as { count: number }[])[0]?.count) || 0;
+    return readCount(result);
   }
 
   /**
@@ -831,7 +832,7 @@ export abstract class DrizzleListEndpoint<
       .from(table)
       .where(whereClause);
 
-    const totalCount = Number((countResult as { count: number }[])[0]?.count) || 0;
+    const totalCount = readCount(countResult);
 
     // Build main query
     let query = cast(db).select().from(table).where(whereClause);

--- a/packages/drizzle/src/helpers.ts
+++ b/packages/drizzle/src/helpers.ts
@@ -21,6 +21,7 @@ import type {
   MetaInput,
   RelationConfig,
 } from 'hono-crud/internal';
+import { assertNever } from 'hono-crud/internal';
 
 // ============================================================================
 // Drizzle Database Types
@@ -424,6 +425,28 @@ export function buildWhereCondition(table: Table, filter: FilterCondition): SQL 
       return between(column, min, max);
     }
     default:
-      return undefined;
+      // Exhaustive over FilterOperator: a new operator must be handled here.
+      // Unreachable at runtime — operators are validated upstream
+      // (`parseFilterValue` / allow-listed query parsing) before reaching an adapter.
+      return assertNever(filter.operator);
   }
+}
+
+/**
+ * Shape of a `SELECT count(*) AS count` row produced by the Drizzle query
+ * builder. The builder returns rows as `unknown`, so this names the one row
+ * shape the count queries rely on.
+ */
+export interface CountRow {
+  count: number;
+}
+
+/**
+ * Read the scalar total from a `SELECT count(*) AS count` result, coercing the
+ * driver's value to a number and defaulting to `0` when the result is empty.
+ * Centralizes the `as CountRow[]` cast that the count/exists/pagination paths
+ * would otherwise repeat at every call site.
+ */
+export function readCount(result: unknown): number {
+  return Number((result as CountRow[])[0]?.count) || 0;
 }

--- a/packages/memory/src/advanced.ts
+++ b/packages/memory/src/advanced.ts
@@ -26,6 +26,7 @@ import type {
   SearchResult,
 } from 'hono-crud/internal';
 import type { ModelObject } from 'hono-crud/internal';
+import { matchesFilter } from './filter';
 import { getStore, loadRelations } from './helpers';
 import { isVisible } from './visibility';
 
@@ -535,39 +536,7 @@ export abstract class MemorySearchEndpoint<
     for (const filter of filters.filters) {
       records = records.filter((record) => {
         const value = record[filter.field];
-
-        switch (filter.operator) {
-          case 'eq':
-            return String(value) === String(filter.value);
-          case 'ne':
-            return String(value) !== String(filter.value);
-          case 'gt':
-            return Number(value) > Number(filter.value);
-          case 'gte':
-            return Number(value) >= Number(filter.value);
-          case 'lt':
-            return Number(value) < Number(filter.value);
-          case 'lte':
-            return Number(value) <= Number(filter.value);
-          case 'in':
-            return (filter.value as unknown[]).map(String).includes(String(value));
-          case 'nin':
-            return !(filter.value as unknown[]).map(String).includes(String(value));
-          case 'like':
-            return String(value).includes(String(filter.value).replace(/%/g, ''));
-          case 'ilike':
-            return String(value)
-              .toLowerCase()
-              .includes(String(filter.value).replace(/%/g, '').toLowerCase());
-          case 'null':
-            return filter.value ? value === null : value !== null;
-          case 'between': {
-            const [min, max] = filter.value as [unknown, unknown];
-            return Number(value) >= Number(min) && Number(value) <= Number(max);
-          }
-          default:
-            return true;
-        }
+        return matchesFilter(value, filter);
       });
     }
 
@@ -690,39 +659,7 @@ export abstract class MemoryExportEndpoint<
     for (const filter of filters.filters) {
       items = items.filter((item) => {
         const value = (item as Record<string, unknown>)[filter.field];
-
-        switch (filter.operator) {
-          case 'eq':
-            return String(value) === String(filter.value);
-          case 'ne':
-            return String(value) !== String(filter.value);
-          case 'gt':
-            return Number(value) > Number(filter.value);
-          case 'gte':
-            return Number(value) >= Number(filter.value);
-          case 'lt':
-            return Number(value) < Number(filter.value);
-          case 'lte':
-            return Number(value) <= Number(filter.value);
-          case 'in':
-            return (filter.value as unknown[]).map(String).includes(String(value));
-          case 'nin':
-            return !(filter.value as unknown[]).map(String).includes(String(value));
-          case 'like':
-            return String(value).includes(String(filter.value).replace(/%/g, ''));
-          case 'ilike':
-            return String(value)
-              .toLowerCase()
-              .includes(String(filter.value).replace(/%/g, '').toLowerCase());
-          case 'null':
-            return filter.value ? value === null : value !== null;
-          case 'between': {
-            const [min, max] = filter.value as [unknown, unknown];
-            return Number(value) >= Number(min) && Number(value) <= Number(max);
-          }
-          default:
-            return true;
-        }
+        return matchesFilter(value, filter);
       });
     }
 
@@ -918,34 +855,7 @@ export abstract class MemoryBulkPatchEndpoint<
     for (const filter of filters.filters) {
       items = items.filter((item) => {
         const value = (item as Record<string, unknown>)[filter.field];
-        switch (filter.operator) {
-          case 'eq':
-            return String(value) === String(filter.value);
-          case 'ne':
-            return String(value) !== String(filter.value);
-          case 'gt':
-            return Number(value) > Number(filter.value);
-          case 'gte':
-            return Number(value) >= Number(filter.value);
-          case 'lt':
-            return Number(value) < Number(filter.value);
-          case 'lte':
-            return Number(value) <= Number(filter.value);
-          case 'in':
-            return (filter.value as unknown[]).map(String).includes(String(value));
-          case 'nin':
-            return !(filter.value as unknown[]).map(String).includes(String(value));
-          case 'like':
-            return String(value).includes(String(filter.value).replace(/%/g, ''));
-          case 'ilike':
-            return String(value)
-              .toLowerCase()
-              .includes(String(filter.value).replace(/%/g, '').toLowerCase());
-          case 'null':
-            return filter.value ? value === null : value !== null;
-          default:
-            return true;
-        }
+        return matchesFilter(value, filter);
       });
     }
 

--- a/packages/memory/src/crud.ts
+++ b/packages/memory/src/crud.ts
@@ -16,6 +16,7 @@ import type {
   RelationConfig,
 } from 'hono-crud/internal';
 import type { ModelObject } from 'hono-crud/internal';
+import { matchesFilter } from './filter';
 import { getStore, loadRelations } from './helpers';
 import { isVisible } from './visibility';
 
@@ -481,39 +482,7 @@ export abstract class MemoryListEndpoint<
     for (const filter of filters.filters) {
       items = items.filter((item) => {
         const value = (item as Record<string, unknown>)[filter.field];
-
-        switch (filter.operator) {
-          case 'eq':
-            return String(value) === String(filter.value);
-          case 'ne':
-            return String(value) !== String(filter.value);
-          case 'gt':
-            return Number(value) > Number(filter.value);
-          case 'gte':
-            return Number(value) >= Number(filter.value);
-          case 'lt':
-            return Number(value) < Number(filter.value);
-          case 'lte':
-            return Number(value) <= Number(filter.value);
-          case 'in':
-            return (filter.value as unknown[]).map(String).includes(String(value));
-          case 'nin':
-            return !(filter.value as unknown[]).map(String).includes(String(value));
-          case 'like':
-            return String(value).includes(String(filter.value).replace(/%/g, ''));
-          case 'ilike':
-            return String(value)
-              .toLowerCase()
-              .includes(String(filter.value).replace(/%/g, '').toLowerCase());
-          case 'null':
-            return filter.value ? value === null : value !== null;
-          case 'between': {
-            const [min, max] = filter.value as [unknown, unknown];
-            return Number(value) >= Number(min) && Number(value) <= Number(max);
-          }
-          default:
-            return true;
-        }
+        return matchesFilter(value, filter);
       });
     }
 

--- a/packages/memory/src/filter.ts
+++ b/packages/memory/src/filter.ts
@@ -1,0 +1,65 @@
+import type { FilterCondition } from 'hono-crud/internal';
+
+/**
+ * Compile-time exhaustiveness guard for `FilterOperator`.
+ *
+ * The parameter is typed `never`, so if a new member is ever added to
+ * `FilterOperator` in core, every `default` branch that calls this stops
+ * type-checking until the new operator is handled — turning what used to be a
+ * silent runtime gap into a build error.
+ *
+ * At runtime the only way an unrecognized operator reaches here is from
+ * untrusted query input: `parseFilterValue` matches `field[op]=value` with a
+ * permissive regex and casts the captured `op` to `FilterOperator` without
+ * validating it. We therefore fail **closed** (match nothing) instead of the
+ * previous `default: return true`, which silently disabled the filter and
+ * returned every record — a filter-bypass / data-exposure footgun.
+ */
+function unknownOperator(_operator: never): false {
+  return false;
+}
+
+/**
+ * Evaluate a single {@link FilterCondition} against an already-extracted field
+ * value, using the in-memory adapter's filter semantics.
+ *
+ * This is the single source of truth for operator handling across the in-memory
+ * adapter (list / search / export / bulk-patch). Previously the same 12-case
+ * switch was copy-pasted at four call sites, and they had already drifted — one
+ * copy was missing the `between` case, so `between` filters there silently
+ * matched every record.
+ */
+export function matchesFilter(value: unknown, filter: FilterCondition): boolean {
+  switch (filter.operator) {
+    case 'eq':
+      return String(value) === String(filter.value);
+    case 'ne':
+      return String(value) !== String(filter.value);
+    case 'gt':
+      return Number(value) > Number(filter.value);
+    case 'gte':
+      return Number(value) >= Number(filter.value);
+    case 'lt':
+      return Number(value) < Number(filter.value);
+    case 'lte':
+      return Number(value) <= Number(filter.value);
+    case 'in':
+      return (filter.value as unknown[]).map(String).includes(String(value));
+    case 'nin':
+      return !(filter.value as unknown[]).map(String).includes(String(value));
+    case 'like':
+      return String(value).includes(String(filter.value).replace(/%/g, ''));
+    case 'ilike':
+      return String(value)
+        .toLowerCase()
+        .includes(String(filter.value).replace(/%/g, '').toLowerCase());
+    case 'null':
+      return filter.value ? value === null : value !== null;
+    case 'between': {
+      const [min, max] = filter.value as [unknown, unknown];
+      return Number(value) >= Number(min) && Number(value) <= Number(max);
+    }
+    default:
+      return unknownOperator(filter.operator);
+  }
+}

--- a/packages/prisma/src/helpers.ts
+++ b/packages/prisma/src/helpers.ts
@@ -14,6 +14,7 @@ import type {
   PaginatedResult,
   RelationConfig,
 } from 'hono-crud/internal';
+import { assertNever } from 'hono-crud/internal';
 import { inlineSingular, levenshteinDistance } from './pluralize';
 
 // Type for Prisma model operations
@@ -148,6 +149,11 @@ export function buildPrismaWhere(filters: FilterCondition[]): Record<string, unk
         where[filter.field] = { gte: coerceValue(min), lte: coerceValue(max) };
         break;
       }
+      default:
+        // Exhaustive over FilterOperator: a new operator must be handled here.
+        // Unreachable at runtime — operators are validated upstream
+        // (`parseFilterValue` / allow-listed query parsing) before reaching an adapter.
+        assertNever(filter.operator);
     }
   }
 

--- a/packages/scalar/src/index.ts
+++ b/packages/scalar/src/index.ts
@@ -1,25 +1,15 @@
 import { apiReference } from '@scalar/hono-api-reference';
 import type { ApiReferenceConfiguration } from '@scalar/hono-api-reference';
-import type { Env, Hono } from 'hono';
+import type { Env, Hono, MiddlewareHandler } from 'hono';
 
 /**
  * Available Scalar themes.
+ *
+ * Derived from the upstream `ApiReferenceConfiguration['theme']` enum so the
+ * set stays in lockstep with `@scalar/hono-api-reference` instead of drifting
+ * from a hand-maintained copy on every Scalar version bump.
  */
-export type ScalarTheme =
-  | 'default'
-  | 'alternate'
-  | 'moon'
-  | 'purple'
-  | 'solarized'
-  | 'bluePlanet'
-  | 'saturn'
-  | 'kepler'
-  | 'mars'
-  | 'deepSpace'
-  | 'laserwave'
-  | 'elysiajs'
-  | 'fastify'
-  | 'none';
+export type ScalarTheme = NonNullable<ApiReferenceConfiguration['theme']>;
 
 /**
  * Configuration options for Scalar API Reference.
@@ -102,7 +92,7 @@ export interface ScalarConfig {
  * }));
  * ```
  */
-export function scalarUI(config: ScalarConfig = {}) {
+export function scalarUI(config: ScalarConfig = {}): MiddlewareHandler {
   const {
     specUrl = '/openapi.json',
     content,
@@ -115,8 +105,19 @@ export function scalarUI(config: ScalarConfig = {}) {
     cdn,
   } = config;
 
-  // Build configuration matching Scalar's expected format
-  const scalarConfig: Partial<ApiReferenceConfiguration> = {
+  // Build configuration matching Scalar's expected format.
+  //
+  // `apiReference()` types its parameter as `Partial<ApiReferenceConfiguration>`,
+  // but Scalar's HTML renderer additionally reads `pageTitle` and `cdn` (declared
+  // on `HtmlRenderingConfiguration`, which `@scalar/hono-api-reference` does not
+  // re-export). Model those two render-only options locally so every assignment
+  // below stays type-checked instead of escaping through `as Record<string, unknown>`.
+  type ScalarRenderConfig = Partial<ApiReferenceConfiguration> & {
+    pageTitle?: string;
+    cdn?: string;
+  };
+
+  const scalarConfig: ScalarRenderConfig = {
     theme,
     showSidebar,
     layout,
@@ -125,23 +126,23 @@ export function scalarUI(config: ScalarConfig = {}) {
 
   // Add URL or content for the spec
   if (content) {
-    (scalarConfig as Record<string, unknown>).content = content;
+    scalarConfig.content = content;
   } else {
-    (scalarConfig as Record<string, unknown>).url = specUrl;
+    scalarConfig.url = specUrl;
   }
 
   // Add optional properties
   if (pageTitle) {
-    (scalarConfig as Record<string, unknown>).pageTitle = pageTitle;
+    scalarConfig.pageTitle = pageTitle;
   }
   if (baseServerURL) {
     scalarConfig.baseServerURL = baseServerURL;
   }
   if (cdn) {
-    (scalarConfig as Record<string, unknown>).cdn = cdn;
+    scalarConfig.cdn = cdn;
   }
 
-  return apiReference(scalarConfig as ApiReferenceConfiguration);
+  return apiReference(scalarConfig);
 }
 
 /**

--- a/tests/filter-operators.test.ts
+++ b/tests/filter-operators.test.ts
@@ -1,0 +1,69 @@
+import {
+  assertNever,
+  FILTER_OPERATORS,
+  isFilterOperator,
+  parseFilterValue,
+} from 'hono-crud';
+import { describe, expect, it } from 'vitest';
+
+describe('FilterOperator single source of truth', () => {
+  it('FILTER_OPERATORS lists every supported operator', () => {
+    expect([...FILTER_OPERATORS]).toEqual([
+      'eq',
+      'ne',
+      'gt',
+      'gte',
+      'lt',
+      'lte',
+      'in',
+      'nin',
+      'like',
+      'ilike',
+      'null',
+      'between',
+    ]);
+  });
+
+  it('isFilterOperator accepts known operators and rejects unknown tokens', () => {
+    for (const op of FILTER_OPERATORS) {
+      expect(isFilterOperator(op)).toBe(true);
+    }
+    expect(isFilterOperator('foo')).toBe(false);
+    expect(isFilterOperator('')).toBe(false);
+    expect(isFilterOperator('EQ')).toBe(false);
+  });
+});
+
+describe('parseFilterValue', () => {
+  it('parses a recognized operator from the bracket syntax', () => {
+    expect(parseFilterValue('[gte]30')).toEqual({ operator: 'gte', value: '30' });
+  });
+
+  it('splits array operators into trimmed parts', () => {
+    expect(parseFilterValue('[in]1, 2 ,3')).toEqual({ operator: 'in', value: ['1', '2', '3'] });
+  });
+
+  it('coerces the null operator to a boolean', () => {
+    expect(parseFilterValue('[null]true')).toEqual({ operator: 'null', value: true });
+  });
+
+  it('neutralizes an unknown operator instead of forging an invalid one', () => {
+    // Regression: `[foo]30` was previously cast to `{ operator: 'foo' }`, an
+    // invalid operator that downstream adapters silently ignored — disabling
+    // the filter and returning every row. It must now fall back to literal
+    // equality on the raw value so it cannot act as an operator.
+    expect(parseFilterValue('[foo]30')).toEqual({ operator: 'eq', value: '[foo]30' });
+  });
+
+  it('treats a plain value as equality', () => {
+    expect(parseFilterValue('hello')).toEqual({ operator: 'eq', value: 'hello' });
+  });
+});
+
+describe('assertNever', () => {
+  it('throws when reached at runtime (invariant violation)', () => {
+    // `assertNever` is a compile-time exhaustiveness guard; if a closed union
+    // ever reaches it at runtime, it fails loud rather than continuing.
+    expect(() => assertNever('unexpected' as never)).toThrow(/Unhandled discriminated union member/);
+  });
+});

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -256,6 +256,19 @@ describe('Memory Adapter', () => {
       expect(data.result.every((item: TestItem) => (item.age || 0) >= 30)).toBe(true);
     });
 
+    it('should filter with the between operator (regression: shared matchesFilter)', async () => {
+      // Guards the de-duplicated in-memory `matchesFilter`: one of the former
+      // copy-pasted filter switches was missing the `between` case and silently
+      // matched every record. ages: Alice 30, Bob 25, Charlie 35, Diana 28.
+      const res = await app.request('/items?age[between]=28,32');
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.result.length).toBe(2);
+      expect(data.result.every((item: TestItem) => (item.age ?? 0) >= 28 && (item.age ?? 0) <= 32)).toBe(
+        true,
+      );
+    });
+
     it('should paginate results', async () => {
       const res = await app.request('/items?page=1&per_page=2');
       expect(res.status).toBe(200);


### PR DESCRIPTION
## Context

Phase 1 of a 3-phase type-safety hardening pass (one PR per phase). The codebase is already disciplined (zero `any`, strict mode, dedicated `types.ts` modules) — this is *sharpening, not rescuing*. Phase 1 covers the quick, high-confidence wins that remove proven drift hazards and silent-failure gaps. No breaking changes.

## What's in this PR

1. **Unify the dual `HonoOpenAPIApp`.** It was defined twice and had diverged: `core/openapi.ts` is the superset `fromHono` returns; `core/register.ts` declared a 4-verb subset that was the one re-exported publicly. A consumer typing the documented type and calling `.options()`/`.head()`/`.doc()` hit a phantom error. Now one canonical definition.
2. **Exhaustiveness guards on closed-union switches.** The in-memory adapter's 12-operator filter switch was copy-pasted at 4 sites and had **drifted — one copy was missing the `between` case and silently matched every record**. All 4 now delegate to one shared `matchesFilter` with a fail-closed `never` guard. Drizzle/Prisma/aggregate switches gained `assertNever` guards so a future `FilterOperator`/`AggregateOperation` member is a compile error, not a silent no-op (the aggregate case was a field-restriction bypass risk).
3. **Validate untrusted filter operators.** `parseFilterValue` (a public util) blindly cast an unrecognized `field[op]=value` token to `FilterOperator`; downstream adapters then silently ignored it, **disabling the filter and returning every row**. Unknown operators now fall back to literal equality. `FilterOperator` is derived from a single `FILTER_OPERATORS` `as const` source + `isFilterOperator` guard.
4. **Scalar package.** Stopped escaping its own typing via four `as Record<string, unknown>` casts; `ScalarTheme` is now derived from upstream `ApiReferenceConfiguration['theme']`; `scalarUI` has an explicit `MiddlewareHandler` return type.
5. **De-duplicated casts.** One localized `readResponseEnvelope(ctx)` accessor (was a 2-cast read at 3 sites) and a Drizzle `readCount`/`CountRow` helper (was `as { count: number }[]` at 5 sites).

New additive exports: `FILTER_OPERATORS`, `isFilterOperator`, `assertNever`, `readResponseEnvelope` (from `hono-crud`); `readCount`, `CountRow` (from `@hono-crud/drizzle`).

## Verification

- ✅ `pnpm -r build`, `pnpm -r typecheck`, `pnpm run typecheck:examples`
- ✅ `pnpm run lint` (biome)
- ✅ `pnpm run test:unit` — **926 passed** (incl. new `filter-operators.test.ts` + a `between` regression test)
- ✅ `pnpm run test:workers` — **42 passed** (edge-runtime safety, incl. D1/Drizzle path)
- ✅ `pnpm run example:local`
- ⏳ `pnpm run test:examples` (Postgres) — deferred to CI; no local Docker

Patch changeset included for the 5 affected packages.