### PR TITLE
refactor(types): phase 2 — single-source unions via as-const & Zod

### DIFF
--- a/.changeset/type-safety-phase-2.md
+++ b/.changeset/type-safety-phase-2.md
@@ -1,0 +1,13 @@
+---
+"hono-crud": patch
+"@hono-crud/drizzle": patch
+---
+
+Type-safety hardening (phase 2): derive types from single `as const` / Zod sources so the compile-time union and its runtime validators can no longer drift.
+
+- **Union single-sources.** `SortDirection`, `SearchMode`, `AggregateOperation`, `JWTAlgorithm` (core) and `DrizzleDialect` (drizzle) are now derived from exported `as const` arrays (`SORT_DIRECTIONS`, `SEARCH_MODES`, `AGGREGATE_OPERATIONS`, `JWT_ALGORITHMS`, `DRIZZLE_DIALECTS`). The three `z.enum(['asc','desc'])` schemas and the `z.enum(['any','all','phrase'])` schema now reference these arrays, and the aggregate query parser derives its runtime operation lists from `AGGREGATE_OPERATIONS` instead of hand-maintained copies.
+- **Removed a redundant type.** The JWT middleware's `HonoAlgorithm` type and its hand-maintained `supported` allow-list were exact duplicates of `JWTAlgorithm`; both are gone (and with them two casts) — `validateAlgorithm` checks against `JWT_ALGORITHMS` directly.
+- **`SortSpec`.** The repeated inline `{ field: string; order: 'asc' | 'desc' }` shape across list/search/builder/functional/config is now the named `SortSpec` type.
+- **Schema-derived shapes.** `EncryptedValue` is inferred from a new `encryptedValueSchema` and `isEncryptedValue` validates with `.safeParse` (one shape, not a hand-written twin). `CrudEventType` is single-sourced from `CRUD_EVENT_TYPES`, and the webhook event-filter template-literal type derives from it, so a new event type can't silently become unfilterable.
+
+New additive exports: `SORT_DIRECTIONS`, `SEARCH_MODES`, `AGGREGATE_OPERATIONS`, `SortDirection`, `SortSpec`, `JWT_ALGORITHMS`, `CRUD_EVENT_TYPES`, `encryptedValueSchema` (from `hono-crud`); `DRIZZLE_DIALECTS`, `readCount`, `CountRow` (from `@hono-crud/drizzle`). All derived types are structurally identical to what they replaced — no breaking changes.

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -32,6 +32,8 @@ export {
   JWTClaimsSchema,
   parseJWTClaims,
   safeParseJWTClaims,
+  // Supported signing algorithms (single source for the JWTAlgorithm union)
+  JWT_ALGORITHMS,
 } from './types';
 
 // ============================================================================

--- a/packages/core/src/auth/middleware/jwt.ts
+++ b/packages/core/src/auth/middleware/jwt.ts
@@ -4,6 +4,7 @@ import type { JWTPayload } from 'hono/utils/jwt/types';
 import { CONTEXT_KEYS } from '../../core/context-keys';
 import { UnauthorizedException } from '../../core/exceptions';
 import type { AuthEnv, AuthUser, JWTAlgorithm, JWTClaims, JWTConfig } from '../types';
+import { JWT_ALGORITHMS } from '../types';
 import { validateJWTClaims } from '../validators/jwt-claims';
 
 // ============================================================================
@@ -11,39 +12,19 @@ import { validateJWTClaims } from '../validators/jwt-claims';
 // ============================================================================
 
 /**
- * Map custom JWTAlgorithm to Hono's supported algorithm types.
- * Hono's JWT supports: HS256, HS384, HS512, RS256, RS384, RS512, PS256, PS384, PS512, ES256, ES384, ES512
+ * Validate that the configured algorithm is one this middleware supports.
+ *
+ * `JWTAlgorithm` already enumerates exactly the algorithms Hono's `verify`
+ * accepts, so the previous separate `HonoAlgorithm` type and hand-maintained
+ * `supported` allow-list were redundant copies of the same set (and forced two
+ * casts). The runtime check still guards against an invalid value arriving
+ * through a non-type-checked path (e.g. a config object cast from `unknown`).
  */
-type HonoAlgorithm =
-  | 'HS256'
-  | 'HS384'
-  | 'HS512'
-  | 'RS256'
-  | 'RS384'
-  | 'RS512'
-  | 'ES256'
-  | 'ES384'
-  | 'ES512';
-
-/**
- * Validates that the algorithm is supported by Hono's JWT.
- */
-function validateAlgorithm(algorithm: JWTAlgorithm): HonoAlgorithm {
-  const supported: HonoAlgorithm[] = [
-    'HS256',
-    'HS384',
-    'HS512',
-    'RS256',
-    'RS384',
-    'RS512',
-    'ES256',
-    'ES384',
-    'ES512',
-  ];
-  if (!supported.includes(algorithm as HonoAlgorithm)) {
+function validateAlgorithm(algorithm: JWTAlgorithm): JWTAlgorithm {
+  if (!JWT_ALGORITHMS.includes(algorithm)) {
     throw new Error(`Unsupported algorithm: ${algorithm}`);
   }
-  return algorithm as HonoAlgorithm;
+  return algorithm;
 }
 
 // ============================================================================

--- a/packages/core/src/auth/types.ts
+++ b/packages/core/src/auth/types.ts
@@ -65,16 +65,19 @@ export interface AuthEnv extends Env {
 /**
  * Supported JWT signing algorithms.
  */
-export type JWTAlgorithm =
-  | 'HS256'
-  | 'HS384'
-  | 'HS512'
-  | 'RS256'
-  | 'RS384'
-  | 'RS512'
-  | 'ES256'
-  | 'ES384'
-  | 'ES512';
+export const JWT_ALGORITHMS = [
+  'HS256',
+  'HS384',
+  'HS512',
+  'RS256',
+  'RS384',
+  'RS512',
+  'ES256',
+  'ES384',
+  'ES512',
+] as const;
+
+export type JWTAlgorithm = (typeof JWT_ALGORITHMS)[number];
 
 /**
  * Standard JWT claims.

--- a/packages/core/src/builder/index.ts
+++ b/packages/core/src/builder/index.ts
@@ -31,7 +31,7 @@
 
 import type { Env, MiddlewareHandler } from 'hono';
 import { generateEndpointClass } from '../core/generate-endpoint-class';
-import type { FilterConfig, HookMode, MetaInput } from '../core/types';
+import type { FilterConfig, HookMode, MetaInput, SortDirection, SortSpec } from '../core/types';
 import type { ModelObject } from '../endpoints/types';
 
 type GeneratedClass<B extends abstract new () => unknown> = B & (new () => InstanceType<B>);
@@ -158,7 +158,7 @@ export class ListBuilder<M extends MetaInput, E extends Env = Env> {
   private _searchFields: string[] = [];
   private _searchFieldName = 'search';
   private _sortFields: string[] = [];
-  private _defaultSort?: { field: string; order: 'asc' | 'desc' };
+  private _defaultSort?: SortSpec;
   private _defaultPerPage = 20;
   private _maxPerPage = 100;
   private _allowedIncludes: string[] = [];
@@ -235,13 +235,13 @@ export class ListBuilder<M extends MetaInput, E extends Env = Env> {
   }
 
   /** Set default sort */
-  defaultSort(field: string, order: 'asc' | 'desc' = 'asc'): this {
+  defaultSort(field: string, order: SortDirection = 'asc'): this {
     this._defaultSort = { field, order };
     return this;
   }
 
   /** Backward-compatible alias for default sort. */
-  defaultOrder(field: string, order: 'asc' | 'desc' = 'asc'): this {
+  defaultOrder(field: string, order: SortDirection = 'asc'): this {
     return this.defaultSort(field, order);
   }
 

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -37,7 +37,7 @@ import type { ZodObject, ZodRawShape } from 'zod';
 import { generateEndpointClass } from '../core/generate-endpoint-class';
 import type { EndpointClass } from '../core/register';
 import type { OpenAPIRoute } from '../core/route';
-import type { HookMode, MetaInput } from '../core/types';
+import type { HookMode, MetaInput, SortDirection } from '../core/types';
 import type { FilterConfig } from '../core/types';
 import type {
   AggregateExtras,
@@ -134,9 +134,9 @@ interface SortingConfig {
   /** Default sort field */
   default?: string;
   /** Default sort direction */
-  defaultOrder?: 'asc' | 'desc';
+  defaultOrder?: SortDirection;
   /** Backward-compatible alias for defaultOrder */
-  defaultDirection?: 'asc' | 'desc';
+  defaultDirection?: SortDirection;
 }
 
 /**

--- a/packages/core/src/core/aggregate.ts
+++ b/packages/core/src/core/aggregate.ts
@@ -2,7 +2,12 @@
  * Parse aggregation query parameters into structured `AggregateOptions`.
  */
 
-import type { AggregateField, AggregateOperation, AggregateOptions } from './types';
+import {
+  AGGREGATE_OPERATIONS,
+  type AggregateField,
+  type AggregateOperation,
+  type AggregateOptions,
+} from './types';
 
 /**
  * Parse aggregation field from query string.
@@ -13,7 +18,9 @@ export function parseAggregateField(value: string): AggregateField | null {
   if (parts.length < 2) return null;
 
   const rawOp = parts[0].toLowerCase();
-  const validOps = ['count', 'sum', 'avg', 'min', 'max', 'countdistinct'];
+  // Case-insensitive match against the canonical operations (derived, so a new
+  // operation added to AGGREGATE_OPERATIONS is recognized here automatically).
+  const validOps: readonly string[] = AGGREGATE_OPERATIONS.map((op) => op.toLowerCase());
 
   if (!validOps.includes(rawOp)) {
     return null;
@@ -38,16 +45,14 @@ export function parseAggregateQuery(query: Record<string, unknown>): AggregateOp
   const filters: Record<string, unknown> = {};
 
   // Parse individual aggregation params
-  const aggParams = ['count', 'sum', 'avg', 'min', 'max', 'countDistinct'];
-
-  for (const op of aggParams) {
+  for (const op of AGGREGATE_OPERATIONS) {
     const value = query[op];
     if (value) {
       const fields = Array.isArray(value) ? value : [value];
       for (const field of fields) {
         if (typeof field === 'string') {
           aggregations.push({
-            operation: op as AggregateOperation,
+            operation: op,
             field: field === 'true' || field === '' ? '*' : field,
           });
         }
@@ -87,7 +92,14 @@ export function parseAggregateQuery(query: Record<string, unknown>): AggregateOp
   const offset = typeof query.offset === 'string' ? Number.parseInt(query.offset, 10) : undefined;
 
   // Collect remaining params as filters
-  const reservedParams = [...aggParams, 'groupBy', 'orderBy', 'orderDirection', 'limit', 'offset'];
+  const reservedParams = [
+    ...AGGREGATE_OPERATIONS,
+    'groupBy',
+    'orderBy',
+    'orderDirection',
+    'limit',
+    'offset',
+  ];
   for (const [key, value] of Object.entries(query)) {
     if (!reservedParams.includes(key) && !key.startsWith('having[')) {
       filters[key] = value;

--- a/packages/core/src/core/generate-endpoint-class.ts
+++ b/packages/core/src/core/generate-endpoint-class.ts
@@ -11,7 +11,7 @@
 
 import type { MiddlewareHandler } from 'hono';
 import type { ZodObject, ZodRawShape } from 'zod';
-import type { HookMode, MetaInput, OpenAPIRouteSchema } from './types';
+import type { HookMode, MetaInput, OpenAPIRouteSchema, SortSpec } from './types';
 
 type AnyHook = (...args: unknown[]) => unknown;
 
@@ -57,7 +57,7 @@ export interface NormalizedEndpointConfig {
   searchFields?: string[];
   searchFieldName?: string;
   sortFields?: string[];
-  defaultSort?: { field: string; order: 'asc' | 'desc' };
+  defaultSort?: SortSpec;
   defaultPerPage?: number;
   maxPerPage?: number;
   allowedIncludes?: string[];

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -78,6 +78,37 @@ export function assertNever(value: never): never {
   throw new Error(`Unhandled discriminated union member: ${String(value)}`);
 }
 
+/**
+ * Canonical sort directions. Single source for the {@link SortDirection} type
+ * and every `z.enum(SORT_DIRECTIONS)` validator, so the compile-time union and
+ * the runtime schemas cannot drift from one another.
+ */
+export const SORT_DIRECTIONS = ['asc', 'desc'] as const;
+export type SortDirection = (typeof SORT_DIRECTIONS)[number];
+
+/**
+ * A field + direction sort specification. Names the `{ field, order }` shape
+ * that list/search/builder configuration objects share.
+ */
+export interface SortSpec {
+  field: string;
+  order: SortDirection;
+}
+
+/**
+ * Canonical search modes: `any` (OR), `all` (AND), `phrase` (exact). Single
+ * source for the {@link SearchMode} type and the `z.enum(SEARCH_MODES)` query
+ * validator.
+ */
+export const SEARCH_MODES = ['any', 'all', 'phrase'] as const;
+
+/**
+ * Canonical aggregate operations. Single source for the
+ * {@link AggregateOperation} type and the runtime operation lists in
+ * `core/aggregate.ts`.
+ */
+export const AGGREGATE_OPERATIONS = ['count', 'sum', 'avg', 'min', 'max', 'countDistinct'] as const;
+
 // Filter configuration per field
 export type FilterConfig = {
   [field: string]: FilterOperatorList;
@@ -95,7 +126,7 @@ export interface ListOptions {
   page?: number;
   per_page?: number;
   order_by?: string;
-  order_by_direction?: 'asc' | 'desc';
+  order_by_direction?: SortDirection;
   search?: string;
   /** Include soft-deleted records in results */
   withDeleted?: boolean;
@@ -520,7 +551,7 @@ export interface NormalizedVersioningConfig {
 /**
  * Supported aggregation operations.
  */
-export type AggregateOperation = 'count' | 'sum' | 'avg' | 'min' | 'max' | 'countDistinct';
+export type AggregateOperation = (typeof AGGREGATE_OPERATIONS)[number];
 
 /**
  * A single aggregation definition.
@@ -549,7 +580,7 @@ export interface AggregateOptions {
   /** Order by aggregated values */
   orderBy?: string;
   /** Order direction */
-  orderDirection?: 'asc' | 'desc';
+  orderDirection?: SortDirection;
   /** Limit number of groups */
   limit?: number;
   /** Offset for pagination */
@@ -1464,9 +1495,9 @@ export interface SearchConfig {
 }
 
 /**
- * Search mode for query matching.
+ * Search mode for query matching. Derived from {@link SEARCH_MODES}.
  */
-export type SearchMode = 'any' | 'all' | 'phrase';
+export type SearchMode = (typeof SEARCH_MODES)[number];
 
 /**
  * A single search result item with scoring and highlighting.

--- a/packages/core/src/encryption/crypto.ts
+++ b/packages/core/src/encryption/crypto.ts
@@ -1,4 +1,5 @@
 import type { EncryptedValue, EncryptionKeyProvider } from './types';
+import { encryptedValueSchema } from './types';
 
 /**
  * Convert ArrayBuffer to base64 string.
@@ -96,9 +97,7 @@ export async function decryptValue(
  * Check if a value looks like an encrypted value object.
  */
 export function isEncryptedValue(value: unknown): value is EncryptedValue {
-  if (typeof value !== 'object' || value === null) return false;
-  const obj = value as Record<string, unknown>;
-  return typeof obj.ct === 'string' && typeof obj.iv === 'string' && obj.v === 1;
+  return encryptedValueSchema.safeParse(value).success;
 }
 
 /**

--- a/packages/core/src/encryption/index.ts
+++ b/packages/core/src/encryption/index.ts
@@ -6,6 +6,7 @@ export {
   decryptFields,
   StaticKeyProvider,
 } from './crypto';
+export { encryptedValueSchema } from './types';
 export type {
   EncryptionKeyProvider,
   FieldEncryptionConfig,

--- a/packages/core/src/encryption/types.ts
+++ b/packages/core/src/encryption/types.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 /**
  * Interface for encryption key providers.
  * Implement this to integrate with your key management system.
@@ -26,15 +28,23 @@ export interface FieldEncryptionConfig {
 }
 
 /**
+ * Schema for an encrypted field value with metadata for decryption. Single
+ * source of truth: {@link EncryptedValue} is inferred from it and the runtime
+ * guard `isEncryptedValue` validates against it, so the type and the check
+ * cannot drift.
+ */
+export const encryptedValueSchema = z.object({
+  /** Encrypted data (base64) */
+  ct: z.string(),
+  /** Initialization vector (base64) */
+  iv: z.string(),
+  /** Key ID used for encryption */
+  kid: z.string().optional(),
+  /** Encryption version marker */
+  v: z.literal(1),
+});
+
+/**
  * Encrypted field value with metadata for decryption.
  */
-export interface EncryptedValue {
-  /** Encrypted data (base64) */
-  ct: string;
-  /** Initialization vector (base64) */
-  iv: string;
-  /** Key ID used for encryption */
-  kid?: string;
-  /** Encryption version marker */
-  v: 1;
-}
+export type EncryptedValue = z.infer<typeof encryptedValueSchema>;

--- a/packages/core/src/endpoints/aggregate.ts
+++ b/packages/core/src/endpoints/aggregate.ts
@@ -11,7 +11,7 @@ import type {
   MetaInput,
   OpenAPIRouteSchema,
 } from '../core/types';
-import { assertNever } from '../core/types';
+import { SORT_DIRECTIONS, assertNever } from '../core/types';
 import { CrudEndpoint } from './base';
 import { errorResponseSchema } from './responses';
 
@@ -99,7 +99,7 @@ export abstract class AggregateEndpoint<
         groupBy: z.string().optional(),
         // Ordering
         orderBy: z.string().optional(),
-        orderDirection: z.enum(['asc', 'desc']).optional(),
+        orderDirection: z.enum(SORT_DIRECTIONS).optional(),
         // Pagination
         limit: z.coerce.number().optional(),
         offset: z.coerce.number().optional(),

--- a/packages/core/src/endpoints/list.ts
+++ b/packages/core/src/endpoints/list.ts
@@ -1,6 +1,13 @@
 import type { Env } from 'hono';
 import { type ZodObject, type ZodRawShape, z } from 'zod';
-import type { FilterConfig, MetaInput, OpenAPIRouteSchema, PaginatedResult } from '../core/types';
+import type {
+  FilterConfig,
+  MetaInput,
+  OpenAPIRouteSchema,
+  PaginatedResult,
+  SortSpec,
+} from '../core/types';
+import { SORT_DIRECTIONS } from '../core/types';
 import { CrudEndpoint } from './base';
 import {
   type ListFilterParseOptions,
@@ -35,7 +42,7 @@ export abstract class ListEndpoint<
   /** Fields that can be used for sorting. Use with ?sort=fieldName */
   protected sortFields: string[] = [];
   /** Default sort configuration */
-  protected defaultSort?: { field: string; order: 'asc' | 'desc' };
+  protected defaultSort?: SortSpec;
 
   // Pagination configuration
   protected defaultPerPage = 20;
@@ -114,7 +121,7 @@ export abstract class ListEndpoint<
         .enum(this.sortFields as [string, ...string[]])
         .optional()
         .describe('Field to sort by');
-      shape.order = z.enum(['asc', 'desc']).optional().describe('Sort direction (asc or desc)');
+      shape.order = z.enum(SORT_DIRECTIONS).optional().describe('Sort direction (asc or desc)');
     }
 
     if (this.searchFields.length > 0) {

--- a/packages/core/src/endpoints/search.ts
+++ b/packages/core/src/endpoints/search.ts
@@ -9,7 +9,9 @@ import type {
   SearchOptions,
   SearchResult,
   SearchResultItem,
+  SortSpec,
 } from '../core/types';
+import { SEARCH_MODES, SORT_DIRECTIONS } from '../core/types';
 import { CrudEndpoint } from './base';
 import { errorResponseSchema } from './responses';
 import {
@@ -152,7 +154,7 @@ export abstract class SearchEndpoint<
   protected sortFields: string[] = [];
 
   /** Default sort configuration */
-  protected defaultSort?: { field: string; order: 'asc' | 'desc' };
+  protected defaultSort?: SortSpec;
 
   // ============================================================================
   // Pagination Configuration
@@ -257,7 +259,7 @@ export abstract class SearchEndpoint<
           `Comma-separated fields to search. Available: ${Object.keys(this.getSearchableFields()).join(', ')}`,
         ),
       mode: z
-        .enum(['any', 'all', 'phrase'])
+        .enum(SEARCH_MODES)
         .optional()
         .describe('Search mode: any (OR), all (AND), phrase (exact)'),
       highlight: z.enum(['true', 'false']).optional().describe('Include highlighted snippets'),
@@ -274,7 +276,7 @@ export abstract class SearchEndpoint<
         .enum(this.sortFields as [string, ...string[]])
         .optional()
         .describe('Field to sort by');
-      shape.order = z.enum(['asc', 'desc']).optional().describe('Sort direction (asc or desc)');
+      shape.order = z.enum(SORT_DIRECTIONS).optional().describe('Sort direction (asc or desc)');
     }
 
     // Filter fields

--- a/packages/core/src/endpoints/types.ts
+++ b/packages/core/src/endpoints/types.ts
@@ -11,6 +11,7 @@ import type {
   MetaInput,
   Model,
   SchemaKeys,
+  SortSpec,
   defineMeta,
   defineModel,
 } from '../core/types';
@@ -45,7 +46,7 @@ export interface ListFilterParseOptions {
 
   // Sorting configuration
   sortFields?: string[];
-  defaultSort?: { field: string; order: 'asc' | 'desc' };
+  defaultSort?: SortSpec;
 
   // Pagination configuration
   defaultPerPage?: number;

--- a/packages/core/src/events/index.ts
+++ b/packages/core/src/events/index.ts
@@ -1,5 +1,6 @@
 export { CrudEventEmitter, getEventEmitter, setEventEmitter, resolveEventEmitter } from './emitter';
 export { registerWebhooks } from './webhook';
+export { CRUD_EVENT_TYPES } from './types';
 export type {
   CrudEventType,
   CrudEventPayload,

--- a/packages/core/src/events/types.ts
+++ b/packages/core/src/events/types.ts
@@ -1,7 +1,12 @@
 /**
  * CRUD event types.
+ *
+ * Single source for the {@link CrudEventType} union and any derived shape (e.g.
+ * the webhook event-filter template-literal type), so adding an event type here
+ * propagates everywhere instead of silently leaving a new type unfilterable.
  */
-export type CrudEventType = 'created' | 'updated' | 'deleted' | 'restored';
+export const CRUD_EVENT_TYPES = ['created', 'updated', 'deleted', 'restored'] as const;
+export type CrudEventType = (typeof CRUD_EVENT_TYPES)[number];
 
 /**
  * Payload for a CRUD event.

--- a/packages/core/src/events/webhook.ts
+++ b/packages/core/src/events/webhook.ts
@@ -1,5 +1,5 @@
 import { type CrudEventEmitter, resolveEventEmitter } from './emitter';
-import type { CrudEventListener, CrudEventPayload } from './types';
+import type { CrudEventListener, CrudEventPayload, CrudEventType } from './types';
 
 /**
  * Webhook endpoint configuration.
@@ -10,7 +10,7 @@ export interface WebhookEndpoint {
   /** Optional secret for HMAC signing */
   secret?: string;
   /** Events to subscribe to. If empty, receives all events. */
-  events?: Array<`${string}:${'created' | 'updated' | 'deleted' | 'restored'}` | '*'>;
+  events?: Array<`${string}:${CrudEventType}` | '*'>;
   /** Custom headers to include with each request */
   headers?: Record<string, string>;
   /** Timeout in milliseconds. @default 10000 */

--- a/packages/core/src/functional/index.ts
+++ b/packages/core/src/functional/index.ts
@@ -24,7 +24,14 @@
 
 import type { Env, MiddlewareHandler } from 'hono';
 import { generateEndpointClass } from '../core/generate-endpoint-class';
-import type { FilterConfig, HookMode, MetaInput, OpenAPIRouteSchema } from '../core/types';
+import type {
+  FilterConfig,
+  HookMode,
+  MetaInput,
+  OpenAPIRouteSchema,
+  SortDirection,
+  SortSpec,
+} from '../core/types';
 import type { ModelObject } from '../endpoints/types';
 
 // ============================================================================
@@ -65,9 +72,9 @@ export interface ListConfig<M extends MetaInput, E extends Env = Env> {
   searchFieldName?: string;
   sortFields?: string[];
   orderByFields?: string[];
-  defaultSort?: { field: string; order: 'asc' | 'desc' };
+  defaultSort?: SortSpec;
   defaultOrderBy?: string;
-  defaultOrderDirection?: 'asc' | 'desc';
+  defaultOrderDirection?: SortDirection;
   defaultPerPage?: number;
   maxPerPage?: number;
   allowedIncludes?: string[];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -77,6 +77,9 @@ export {
   FILTER_OPERATORS,
   isFilterOperator,
   assertNever,
+  SORT_DIRECTIONS,
+  SEARCH_MODES,
+  AGGREGATE_OPERATIONS,
 } from './core/types';
 export { encodeCursor, decodeCursor } from './core/cursor';
 export { applyComputedFields, applyComputedFieldsToArray } from './core/computed-fields';
@@ -96,6 +99,8 @@ export type {
   FilterOperator,
   FilterConfig,
   FilterCondition,
+  SortDirection,
+  SortSpec,
   ListOptions,
   ListFilters,
   PaginatedResult,
@@ -368,6 +373,7 @@ export {
   JWTClaimsSchema,
   parseJWTClaims,
   safeParseJWTClaims,
+  JWT_ALGORITHMS,
 } from './auth/index';
 export type {
   AuthUser,
@@ -470,6 +476,7 @@ export {
   setEventEmitter,
   resolveEventEmitter,
   registerWebhooks,
+  CRUD_EVENT_TYPES,
 } from './events/index';
 export type {
   CrudEventType,
@@ -502,6 +509,7 @@ export {
   encryptFields,
   decryptFields,
   StaticKeyProvider,
+  encryptedValueSchema,
 } from './encryption/index';
 export type {
   EncryptionKeyProvider,

--- a/packages/drizzle/src/helpers.ts
+++ b/packages/drizzle/src/helpers.ts
@@ -112,7 +112,8 @@ export type DrizzleDB = DrizzleDatabaseConstraint;
  * pre-existing portable behavior). Set explicitly when targeting PostgreSQL
  * or MySQL to enable the appropriate code paths.
  */
-export type DrizzleDialect = 'sqlite' | 'pg' | 'mysql';
+export const DRIZZLE_DIALECTS = ['sqlite', 'pg', 'mysql'] as const;
+export type DrizzleDialect = (typeof DRIZZLE_DIALECTS)[number];
 
 /**
  * Type helper for defining Hono Env with database in Variables.

--- a/packages/drizzle/src/index.ts
+++ b/packages/drizzle/src/index.ts
@@ -6,6 +6,8 @@ export {
   type DrizzleDB,
   type DrizzleDialect,
   type DrizzleEnv,
+  type CountRow,
+  DRIZZLE_DIALECTS,
   cast,
   getTable,
   getColumn,
@@ -13,6 +15,7 @@ export {
   loadDrizzleRelations,
   batchLoadDrizzleRelations,
   buildWhereCondition,
+  readCount,
 } from './helpers';
 export * from './crud';
 export * from './batch';

--- a/tests/single-source-enums.test.ts
+++ b/tests/single-source-enums.test.ts
@@ -1,0 +1,73 @@
+import { DRIZZLE_DIALECTS } from '@hono-crud/drizzle';
+import {
+  AGGREGATE_OPERATIONS,
+  CRUD_EVENT_TYPES,
+  encryptedValueSchema,
+  isEncryptedValue,
+  JWT_ALGORITHMS,
+  SEARCH_MODES,
+  SORT_DIRECTIONS,
+} from 'hono-crud';
+import { describe, expect, it } from 'vitest';
+
+// These lock the `as const` single-source arrays from which the corresponding
+// TS unions and Zod/runtime validators are derived. If a value is added or
+// reordered, update the source array — the union, the schemas and these
+// expectations all move together, which is the whole point of single-sourcing.
+describe('single-source enum arrays', () => {
+  it('SORT_DIRECTIONS', () => {
+    expect([...SORT_DIRECTIONS]).toEqual(['asc', 'desc']);
+  });
+
+  it('SEARCH_MODES', () => {
+    expect([...SEARCH_MODES]).toEqual(['any', 'all', 'phrase']);
+  });
+
+  it('AGGREGATE_OPERATIONS', () => {
+    expect([...AGGREGATE_OPERATIONS]).toEqual([
+      'count',
+      'sum',
+      'avg',
+      'min',
+      'max',
+      'countDistinct',
+    ]);
+  });
+
+  it('JWT_ALGORITHMS', () => {
+    expect([...JWT_ALGORITHMS]).toEqual([
+      'HS256',
+      'HS384',
+      'HS512',
+      'RS256',
+      'RS384',
+      'RS512',
+      'ES256',
+      'ES384',
+      'ES512',
+    ]);
+  });
+
+  it('CRUD_EVENT_TYPES', () => {
+    expect([...CRUD_EVENT_TYPES]).toEqual(['created', 'updated', 'deleted', 'restored']);
+  });
+
+  it('DRIZZLE_DIALECTS', () => {
+    expect([...DRIZZLE_DIALECTS]).toEqual(['sqlite', 'pg', 'mysql']);
+  });
+});
+
+describe('encryptedValueSchema drives isEncryptedValue', () => {
+  it('accepts a well-formed encrypted value', () => {
+    const value = { ct: 'abc', iv: 'def', v: 1 as const };
+    expect(encryptedValueSchema.safeParse(value).success).toBe(true);
+    expect(isEncryptedValue(value)).toBe(true);
+  });
+
+  it('rejects wrong version, missing fields, and non-objects', () => {
+    expect(isEncryptedValue({ ct: 'a', iv: 'b', v: 2 })).toBe(false);
+    expect(isEncryptedValue({ ct: 'a' })).toBe(false);
+    expect(isEncryptedValue(null)).toBe(false);
+    expect(isEncryptedValue('nope')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Context

Phase 2 of the type-safety hardening pass. **Stacked on #43 (phase 1)** — base is `type-safety/phase-1`; retarget to `main` once #43 merges. The theme of this phase: make each closed union derive from **one** `as const` / Zod source so the compile-time union and its runtime validators (Zod enums, allow-lists) can never drift apart.

## What's in this PR (Initiatives 5 + 8)

1. **Union single-sources.** `SortDirection`, `SearchMode`, `AggregateOperation`, `JWTAlgorithm` (core) and `DrizzleDialect` (drizzle) now derive from exported `as const` arrays. The three `z.enum(['asc','desc'])` and the `z.enum(['any','all','phrase'])` schemas reference those arrays, and the aggregate query parser derives its runtime operation lists from `AGGREGATE_OPERATIONS` (previously two hand-maintained copies, one lowercased).
2. **Removed a redundant duplicate.** The JWT middleware's `HonoAlgorithm` type and its hand-maintained `supported` allow-list were exact duplicates of `JWTAlgorithm` — both deleted (and the two casts they forced); `validateAlgorithm` now checks `JWT_ALGORITHMS` directly.
3. **`SortSpec`.** The inline `{ field: string; order: 'asc' | 'desc' }` shape repeated across list/search/builder/functional/config is now one named type.
4. **Schema-derived shapes.** `EncryptedValue` is inferred from a new `encryptedValueSchema`; `isEncryptedValue` validates via `.safeParse` (one shape, not a hand-written twin). `CrudEventType` is single-sourced from `CRUD_EVENT_TYPES`, and the webhook event-filter template-literal type derives from it — so a newly-added event type can't silently become unfilterable.

New additive exports: `SORT_DIRECTIONS`, `SEARCH_MODES`, `AGGREGATE_OPERATIONS`, `SortDirection`, `SortSpec`, `JWT_ALGORITHMS`, `CRUD_EVENT_TYPES`, `encryptedValueSchema` (`hono-crud`); `DRIZZLE_DIALECTS`, `readCount`, `CountRow` (`@hono-crud/drizzle`). All derived types are structurally identical to what they replaced — no breaking changes.

## Deliberately deferred (to dedicated follow-up)

- **Initiative 6** — routing the JWT request path (`payload as unknown as JWTClaims`) and the Redis rate-limit/cache `JSON.parse` paths through `safeParse`. This changes runtime validation behavior (rejects malformed payloads that previously passed through) and warrants its own focused review + auth tests.
- **Initiative 7** — single-sourcing the error/success response envelope (restated in register.ts, core/types.ts, openapi/utils.ts, idempotency/middleware.ts). A larger contract refactor best done on its own.

## Verification

- ✅ `pnpm -r build`, `pnpm -r typecheck`, `pnpm run typecheck:examples`
- ✅ `pnpm run lint` (biome)
- ✅ `pnpm run test:unit` — **934 passed** (incl. new `single-source-enums.test.ts`)
- ✅ `pnpm run test:workers` — **42 passed**
- ✅ `pnpm run example:local`
- ⏳ `pnpm run test:examples` (Postgres) — deferred to CI

Patch changeset included for `hono-crud` + `@hono-crud/drizzle`.