### PR TITLE
refactor(types): phase 2 deferred — validate JWT boundary + single-source error envelope

### DIFF
--- a/.changeset/type-safety-phase-2-deferred.md
+++ b/.changeset/type-safety-phase-2-deferred.md
@@ -1,0 +1,14 @@
+---
+"hono-crud": patch
+"@hono-crud/idempotency": patch
+---
+
+Type-safety hardening (phase 2, deferred items): validate the JWT trust boundary and single-source the error envelope.
+
+- **Validate JWT claims (security).** The JWT middleware previously coerced the verified payload to `JWTClaims` with a blind `payload as unknown as JWTClaims` cast — Hono's `verify` checks the signature and `exp`/`nbf` timing but not claim *shapes*, so a structurally malformed payload was trusted. The verified payload now runs through `safeParseJWTClaims`; a payload that fails the schema is rejected with `401 Invalid token claims`. `JWTClaimsSchema` was extended with the identity claims the default extractor reads (`email`, `role`, `roles`, `permissions`, `metadata`), and `JWTClaims` is now derived from it (single source). The wrong `secret as string` cast (which mistyped a `CryptoKey` secret) was removed.
+- **Fix role normalization.** `defaultExtractUser` previously assigned a singular `role` claim straight to `AuthUser.roles`, producing a value mistyped as `string[]`. `role` / single-string `roles` claims are now normalized to a string array.
+- **Single-source the error envelope.** The `{ success: false, error: { code, message, details? } }` contract was hand-restated as TS types in `core/types.ts`, as the return type of `ApiException.toJSON()`, and inline in the idempotency middleware. There is now one `structuredErrorSchema` / `errorEnvelopeSchema` (plus a `successEnvelopeSchema(result)` factory); `StructuredError` and `ErrorResponse` are derived from them via `z.infer`, `ApiException.toJSON()` returns the shared `ErrorResponse`, and the idempotency bodies use a typed helper bound to it.
+
+New additive exports: `structuredErrorSchema`, `errorEnvelopeSchema`, `successEnvelopeSchema` (from `hono-crud`).
+
+**Behavior change:** JWT tokens whose payloads do not match `JWTClaimsSchema` (e.g. a non-numeric `exp`, a non-string `sub`) are now rejected rather than accepted. This is the intended security tightening; the identity claims are typed leniently (`roles`/`permissions` accept a string or array) to avoid rejecting common real-world token shapes.

--- a/packages/core/src/auth/middleware/jwt.ts
+++ b/packages/core/src/auth/middleware/jwt.ts
@@ -4,7 +4,7 @@ import type { JWTPayload } from 'hono/utils/jwt/types';
 import { CONTEXT_KEYS } from '../../core/context-keys';
 import { UnauthorizedException } from '../../core/exceptions';
 import type { AuthEnv, AuthUser, JWTAlgorithm, JWTClaims, JWTConfig } from '../types';
-import { JWT_ALGORITHMS } from '../types';
+import { JWT_ALGORITHMS, safeParseJWTClaims } from '../types';
 import { validateJWTClaims } from '../validators/jwt-claims';
 
 // ============================================================================
@@ -53,13 +53,22 @@ export function defaultExtractToken(ctx: Context): string | null {
 /**
  * Default function to extract user info from JWT claims.
  */
+/** Normalize a `string | string[]` claim to a string array (or undefined). */
+function normalizeStringList(value: string | string[] | undefined): string[] | undefined {
+  if (value === undefined) return undefined;
+  return Array.isArray(value) ? value : [value];
+}
+
 function defaultExtractUser(claims: JWTClaims): AuthUser {
   return {
     id: String(claims.sub || claims.id || ''),
-    email: claims.email as string | undefined,
-    roles: (claims.roles || claims.role) as string[] | undefined,
-    permissions: claims.permissions as string[] | undefined,
-    metadata: claims.metadata as Record<string, unknown> | undefined,
+    email: claims.email,
+    // `roles` (array or single) falls back to the singular `role` claim; both
+    // are normalized to a string[] so a single-role token no longer yields a
+    // bare string mistyped as string[].
+    roles: normalizeStringList(claims.roles ?? claims.role),
+    permissions: normalizeStringList(claims.permissions),
+    metadata: claims.metadata,
   };
 }
 
@@ -113,7 +122,7 @@ export function createJWTMiddleware<E extends AuthEnv = AuthEnv>(
     // Verify signature using Hono's verify function
     let payload: JWTPayload;
     try {
-      payload = await verify(token, config.secret as string, algorithm);
+      payload = await verify(token, config.secret, algorithm);
     } catch (error) {
       // Handle specific JWT errors
       if (error instanceof Error) {
@@ -130,8 +139,15 @@ export function createJWTMiddleware<E extends AuthEnv = AuthEnv>(
       throw new UnauthorizedException('Invalid token');
     }
 
-    // Convert payload to JWTClaims
-    const claims: JWTClaims = payload as unknown as JWTClaims;
+    // Validate the verified payload against the claims schema. Hono's `verify`
+    // checks the signature and exp/nbf timing, but not the *shape* of the
+    // claims — so a structurally malformed payload would otherwise be trusted
+    // via a blind cast. Reject it instead.
+    const parsed = safeParseJWTClaims(payload);
+    if (!parsed.success) {
+      throw new UnauthorizedException('Invalid token claims');
+    }
+    const claims = parsed.data;
 
     // Validate additional claims (issuer, audience) using shared validator
     // Note: Hono's verify already validates exp, nbf, iat

--- a/packages/core/src/auth/types.ts
+++ b/packages/core/src/auth/types.ts
@@ -80,30 +80,15 @@ export const JWT_ALGORITHMS = [
 export type JWTAlgorithm = (typeof JWT_ALGORITHMS)[number];
 
 /**
- * Standard JWT claims.
- */
-export interface JWTClaims {
-  /** Subject (typically user ID) */
-  sub?: string;
-  /** Issuer */
-  iss?: string;
-  /** Audience */
-  aud?: string | string[];
-  /** Expiration time (Unix timestamp) */
-  exp?: number;
-  /** Not before time (Unix timestamp) */
-  nbf?: number;
-  /** Issued at time (Unix timestamp) */
-  iat?: number;
-  /** JWT ID */
-  jti?: string;
-  /** Custom claims */
-  [key: string]: unknown;
-}
-
-/**
- * Zod schema for validating JWT claims at runtime.
- * Uses passthrough() to allow custom claims while validating standard ones.
+ * Zod schema for validating JWT claims at runtime — the single source of truth
+ * for {@link JWTClaims} / {@link ValidatedJWTClaims}.
+ *
+ * Standard registered claims are validated against their RFC 7519 types. The
+ * common identity claims read by the default user extractor (`email`, `role`,
+ * `roles`, `permissions`, `metadata`) are typed but lenient — `roles` /
+ * `permissions` accept either a single string or an array so real-world tokens
+ * that use either shape are not rejected. `.passthrough()` keeps any additional
+ * custom claims, accessible via the `JWTClaims` index signature.
  *
  * @example
  * ```ts
@@ -133,14 +118,32 @@ export const JWTClaimsSchema = z
     iat: z.number().int().optional(),
     /** JWT ID */
     jti: z.string().optional(),
+    /** Email claim (read by the default user extractor) */
+    email: z.string().optional(),
+    /** Single-role claim */
+    role: z.string().optional(),
+    /** Multi-role claim — a single string or an array of strings */
+    roles: z.union([z.array(z.string()), z.string()]).optional(),
+    /** Permission claim — a single string or an array of strings */
+    permissions: z.union([z.array(z.string()), z.string()]).optional(),
+    /** Arbitrary user metadata claim */
+    metadata: z.record(z.string(), z.unknown()).optional(),
   })
   .passthrough();
 
 /**
- * Type inferred from JWTClaimsSchema.
- * Equivalent to JWTClaims but derived from Zod schema.
+ * JWT claims validated against {@link JWTClaimsSchema}.
  */
 export type ValidatedJWTClaims = z.infer<typeof JWTClaimsSchema>;
+
+/**
+ * Standard + common JWT claims.
+ *
+ * Derived from {@link JWTClaimsSchema} (so the type and the runtime validator
+ * cannot drift), intersected with an index signature that preserves access to
+ * arbitrary custom claims kept by the schema's `.passthrough()`.
+ */
+export type JWTClaims = ValidatedJWTClaims & { [key: string]: unknown };
 
 /**
  * Validates JWT claims using the Zod schema.

--- a/packages/core/src/core/exceptions.ts
+++ b/packages/core/src/core/exceptions.ts
@@ -1,6 +1,7 @@
 import { HTTPException } from 'hono/http-exception';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import type { ZodError } from 'zod';
+import type { ErrorResponse, StructuredError } from './types';
 
 /**
  * Valid HTTP status codes for API exceptions.
@@ -38,23 +39,8 @@ export class ApiException extends HTTPException {
    * Converts the exception to a JSON response object.
    * Maintains backwards compatibility with existing error handling.
    */
-  toJSON(): {
-    success: false;
-    error: {
-      code: string;
-      message: string;
-      details?: unknown;
-      requestId?: string;
-      stack?: string;
-    };
-  } {
-    const errorObj: {
-      code: string;
-      message: string;
-      details?: unknown;
-      requestId?: string;
-      stack?: string;
-    } = {
+  toJSON(): ErrorResponse {
+    const errorObj: StructuredError = {
       code: this.code,
       message: this.message,
     };

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -1,6 +1,6 @@
 import type { RouteConfig } from '@hono/zod-openapi';
 import type { Context, Env } from 'hono';
-import type { ZodObject, ZodRawShape, ZodType, z } from 'zod';
+import { type ZodObject, type ZodRawShape, type ZodType, z } from 'zod';
 
 // ============================================================================
 // Schema Type Utilities
@@ -1352,37 +1352,67 @@ export interface SuccessResponse<T> {
   result: T;
 }
 
-export interface ErrorResponse {
-  success: false;
-  error: {
-    code: string;
-    message: string;
-    details?: unknown;
-  };
+/**
+ * Canonical schema for the structured error object passed to
+ * `ResponseEnvelope.error` — the single source of truth for the
+ * `{ code, message, details?, … }` shape produced by `ApiException.toJSON()`,
+ * emitted in OpenAPI 4xx/5xx responses, and reused by middleware that returns
+ * the standard error envelope (e.g. idempotency). `.passthrough()` keeps the
+ * shape open for forward-compatible enrichment.
+ */
+export const structuredErrorSchema = z
+  .object({
+    /** Stable error code (`'NOT_FOUND'`, `'VALIDATION_ERROR'`, …). */
+    code: z.string(),
+    /** Human-readable error message. */
+    message: z.string(),
+    /** Optional structured details (validation issues, conflict info, etc.). */
+    details: z.unknown().optional(),
+    /** Request id, if logging middleware is active and surfacing it. */
+    requestId: z.string().optional(),
+    /** Stack trace, if `includeStackTrace` is enabled (development only!). */
+    stack: z.string().optional(),
+  })
+  .passthrough();
+
+/**
+ * Canonical schema for the standard error response envelope
+ * (`{ success: false, error: <structuredError> }`).
+ */
+export const errorEnvelopeSchema = z.object({
+  success: z.literal(false),
+  error: structuredErrorSchema,
+});
+
+/**
+ * Build the matching success envelope schema (`{ success: true, result }`) for
+ * a given result schema. Pairs with {@link errorEnvelopeSchema} so both halves
+ * of the response contract come from one place.
+ */
+export function successEnvelopeSchema<T extends ZodType>(
+  result: T,
+): ZodObject<{ success: ZodType; result: T }> {
+  return z.object({ success: z.literal(true), result }) as unknown as ZodObject<{
+    success: ZodType;
+    result: T;
+  }>;
 }
 
 /**
  * Standardised structured error object passed to `ResponseEnvelope.error`.
  *
- * This is the output of the error-handler pipeline (`ApiException.toJSON`
- * + any `ErrorMapper`s + optional `requestId` / `stack` enrichment), prior
- * to being wrapped in the response envelope. Custom envelopes can format
- * this shape into RFC 7807, JSON:API, a house standard, etc.
+ * Derived from {@link structuredErrorSchema}; the `[key: string]: unknown`
+ * intersection preserves the open shape (`.passthrough()`) for custom envelopes
+ * that format it into RFC 7807, JSON:API, a house standard, etc.
  */
-export interface StructuredError {
-  /** Stable error code (`'NOT_FOUND'`, `'VALIDATION_ERROR'`, …). */
-  code: string;
-  /** Human-readable error message. */
-  message: string;
-  /** Optional structured details (validation issues, conflict info, etc.). */
-  details?: unknown;
-  /** Request id, if logging middleware is active and surfacing it. */
-  requestId?: string;
-  /** Stack trace, if `includeStackTrace` is enabled (development only!). */
-  stack?: string;
-  /** Open-ended for forward compatibility. */
+export type StructuredError = z.infer<typeof structuredErrorSchema> & {
   [key: string]: unknown;
-}
+};
+
+/**
+ * Standard error response envelope. Derived from {@link errorEnvelopeSchema}.
+ */
+export type ErrorResponse = z.infer<typeof errorEnvelopeSchema>;
 
 /**
  * Pagination metadata shape passed to `ResponseEnvelope.success` for list

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -80,6 +80,9 @@ export {
   SORT_DIRECTIONS,
   SEARCH_MODES,
   AGGREGATE_OPERATIONS,
+  structuredErrorSchema,
+  errorEnvelopeSchema,
+  successEnvelopeSchema,
 } from './core/types';
 export { encodeCursor, decodeCursor } from './core/cursor';
 export { applyComputedFields, applyComputedFieldsToArray } from './core/computed-fields';

--- a/packages/idempotency/src/middleware.ts
+++ b/packages/idempotency/src/middleware.ts
@@ -1,6 +1,17 @@
 import type { Context, Env, MiddlewareHandler } from 'hono';
 import { createNullableRegistry, getContextVar } from 'hono-crud/internal';
+import type { ErrorResponse } from 'hono-crud/internal';
 import type { IdempotencyConfig, IdempotencyEntry, IdempotencyStorage } from './types';
+
+/**
+ * Build a standard error envelope. Typed as the shared {@link ErrorResponse} so
+ * these bodies stay in lockstep with the framework's canonical error contract
+ * (`{ success: false, error: { code, message } }`) instead of being re-declared
+ * inline at each return site.
+ */
+function idempotencyError(code: string, message: string): ErrorResponse {
+  return { success: false, error: { code, message } };
+}
 
 // ============================================================================
 // Global Storage
@@ -97,13 +108,10 @@ export function idempotency(config?: IdempotencyConfig): MiddlewareHandler {
     if (!idempotencyKey) {
       if (required) {
         return ctx.json(
-          {
-            success: false,
-            error: {
-              code: 'IDEMPOTENCY_KEY_REQUIRED',
-              message: `${headerName} header is required for ${method} requests`,
-            },
-          },
+          idempotencyError(
+            'IDEMPOTENCY_KEY_REQUIRED',
+            `${headerName} header is required for ${method} requests`,
+          ),
           400,
         );
       }
@@ -140,13 +148,10 @@ export function idempotency(config?: IdempotencyConfig): MiddlewareHandler {
     const locked = await storage.isLocked(scopedKey);
     if (locked) {
       return ctx.json(
-        {
-          success: false,
-          error: {
-            code: 'IDEMPOTENCY_CONFLICT',
-            message: 'A request with this idempotency key is already being processed',
-          },
-        },
+        idempotencyError(
+          'IDEMPOTENCY_CONFLICT',
+          'A request with this idempotency key is already being processed',
+        ),
         409,
       );
     }
@@ -155,13 +160,10 @@ export function idempotency(config?: IdempotencyConfig): MiddlewareHandler {
     const acquired = await storage.lock(scopedKey, lockTimeoutMs);
     if (!acquired) {
       return ctx.json(
-        {
-          success: false,
-          error: {
-            code: 'IDEMPOTENCY_CONFLICT',
-            message: 'A request with this idempotency key is already being processed',
-          },
-        },
+        idempotencyError(
+          'IDEMPOTENCY_CONFLICT',
+          'A request with this idempotency key is already being processed',
+        ),
         409,
       );
     }

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -124,6 +124,42 @@ describe('JWT Middleware', () => {
     expect(data.user.roles).toEqual(['admin']);
   });
 
+  it('normalizes a singular `role` claim to a roles array', async () => {
+    const app = createTestApp<AuthEnv>();
+    app.use('*', createJWTMiddleware({ secret }));
+    app.get('/me', (c) => c.json({ roles: c.var.roles, user: c.var.user }));
+
+    const token = await createTestJWT(
+      { sub: 'user-1', role: 'admin', exp: Math.floor(Date.now() / 1000) + 3600 },
+      secret,
+    );
+    const res = await app.request('/me', { headers: { Authorization: `Bearer ${token}` } });
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    // Previously a single `role` string was assigned straight to AuthUser.roles,
+    // producing a value mistyped as string[]. It is now normalized to ['admin'].
+    expect(data.user.roles).toEqual(['admin']);
+    expect(data.roles).toEqual(['admin']);
+  });
+
+  it('normalizes a single-string `roles` claim to an array', async () => {
+    const app = createTestApp<AuthEnv>();
+    app.use('*', createJWTMiddleware({ secret }));
+    app.get('/me', (c) => c.json({ user: c.var.user }));
+
+    const token = await createTestJWT(
+      // roles provided as a bare string rather than an array
+      { sub: 'user-2', roles: 'editor', exp: Math.floor(Date.now() / 1000) + 3600 } as never,
+      secret,
+    );
+    const res = await app.request('/me', { headers: { Authorization: `Bearer ${token}` } });
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.user.roles).toEqual(['editor']);
+  });
+
   it('should reject missing token', async () => {
     const app = createTestApp<AuthEnv>();
 

--- a/tests/error-envelope-schema.test.ts
+++ b/tests/error-envelope-schema.test.ts
@@ -1,0 +1,48 @@
+import {
+  ApiException,
+  errorEnvelopeSchema,
+  NotFoundException,
+  structuredErrorSchema,
+  successEnvelopeSchema,
+} from 'hono-crud';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+// Locks the single-source error/success envelope contract: the same Zod schema
+// that documents OpenAPI 4xx/5xx responses and types `ErrorResponse` also
+// validates what `ApiException.toJSON()` actually emits. If the shape drifts,
+// this fails.
+describe('error envelope single source', () => {
+  it('ApiException.toJSON() satisfies errorEnvelopeSchema', () => {
+    const body = new ApiException('User not found', 404, 'NOT_FOUND').toJSON();
+    expect(errorEnvelopeSchema.safeParse(body).success).toBe(true);
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe('NOT_FOUND');
+    expect(body.error.message).toBe('User not found');
+  });
+
+  it('a built-in exception subclass also satisfies the envelope schema', () => {
+    const body = new NotFoundException('User').toJSON();
+    expect(errorEnvelopeSchema.safeParse(body).success).toBe(true);
+    expect(body.error.code).toBe('NOT_FOUND');
+  });
+
+  it('carries structured details when provided', () => {
+    const body = new ApiException('Boom', 422, 'VALIDATION_ERROR', { field: 'email' }).toJSON();
+    const parsed = errorEnvelopeSchema.safeParse(body);
+    expect(parsed.success).toBe(true);
+    expect(body.error.details).toEqual({ field: 'email' });
+  });
+
+  it('structuredErrorSchema requires code + message and rejects malformed errors', () => {
+    expect(structuredErrorSchema.safeParse({ code: 'X', message: 'y' }).success).toBe(true);
+    expect(structuredErrorSchema.safeParse({ code: 'X' }).success).toBe(false);
+    expect(structuredErrorSchema.safeParse({ message: 'y' }).success).toBe(false);
+  });
+
+  it('successEnvelopeSchema builds a matching { success: true, result } schema', () => {
+    const schema = successEnvelopeSchema(z.object({ id: z.string() }));
+    expect(schema.safeParse({ success: true, result: { id: 'a' } }).success).toBe(true);
+    expect(schema.safeParse({ success: false, result: { id: 'a' } }).success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Context

The two items intentionally deferred from #44 (Initiatives 6 + 7). **Stacked on #44** — base is `type-safety/phase-2`; retarget down the stack as the earlier PRs merge. These were held back because they change runtime/contract behavior and deserved a focused review.

## What's in this PR

### Initiative 6 — Validate the JWT trust boundary (security)
- The JWT middleware coerced the verified payload with a blind `payload as unknown as JWTClaims`. Hono's `verify` checks the **signature** and `exp`/`nbf` timing but **not the claim shapes**, so a structurally malformed payload was trusted. The payload now runs through `safeParseJWTClaims`; a payload that fails the schema is rejected with **`401 Invalid token claims`**.
- `JWTClaimsSchema` is extended with the identity claims the default extractor reads (`email`, `role`, `roles`, `permissions`, `metadata`), and `JWTClaims` is now **derived from it** (one source). The identity claims are typed **leniently** (`roles`/`permissions` accept a string *or* array) to avoid rejecting common real-world tokens.
- **Bug fix:** `defaultExtractUser` assigned a singular `role` claim straight to `AuthUser.roles`, yielding a value mistyped as `string[]`. It now normalizes `role` / single-string `roles` to a string array.
- Removed the wrong `secret as string` cast (`SignatureKey` already accepts `string | CryptoKey`, so it was mistyping CryptoKey secrets).

### Initiative 7 — Single-source the error envelope
The `{ success: false, error: { code, message, details? } }` contract was hand-restated as TS types in `core/types.ts`, as `ApiException.toJSON()`'s return type, and inline in the idempotency middleware. Now: one `structuredErrorSchema` / `errorEnvelopeSchema` (+ a `successEnvelopeSchema(result)` factory); `StructuredError` and `ErrorResponse` derive via `z.infer`; `ApiException.toJSON()` returns the shared `ErrorResponse`; idempotency bodies use a typed helper bound to it.

New additive exports: `structuredErrorSchema`, `errorEnvelopeSchema`, `successEnvelopeSchema`.

## Deliberately scoped out

**Redis storage validation** (the other half of Init 6). The `@hono-crud/rate-limit` and `@hono-crud/cache` packages don't depend on zod, the Redis data is **app-written** (corruption/migration risk, not user input), and the `JSON.parse` paths already fall back to `null` on malformed JSON. Adding a zod dependency to those packages for that case wasn't worth it; flagged for a future call.

## ⚠️ Behavior change

JWT tokens whose payloads fail `JWTClaimsSchema` (e.g. a non-numeric `exp`, a non-string `sub`) are now **rejected** rather than accepted. This is the intended security tightening. The lenient identity-claim typing keeps normal tokens working.

## Verification

- ✅ `pnpm -r build`, `pnpm -r typecheck`, `pnpm run typecheck:examples`
- ✅ `pnpm run lint`
- ✅ `pnpm run test:unit` — **941 passed** (new JWT role-normalization tests in `auth.test.ts`; new `error-envelope-schema.test.ts`)
- ✅ `pnpm run test:workers` — **42 passed**
- ✅ `pnpm run example:local`
- ⏳ `pnpm run test:examples` (Postgres) — deferred to CI

Patch changeset for `hono-crud` + `@hono-crud/idempotency`.