### PR TITLE
fix(multi-tenant): fail fast on source:'custom' without an extractor

### DIFF
--- a/.changeset/multi-tenant-config-validation.md
+++ b/.changeset/multi-tenant-config-validation.md
@@ -1,0 +1,5 @@
+---
+"hono-crud": patch
+---
+
+`multiTenant()` now fails fast on an inconsistent configuration. Previously, `source: 'custom'` without an `extractor` silently extracted `undefined` on every request and surfaced as a misleading `400 "Tenant ID is required"` (a misconfiguration masquerading as a client error). It now throws a clear setup-time error pointing at the missing `extractor`.

--- a/packages/core/src/multi-tenant/index.ts
+++ b/packages/core/src/multi-tenant/index.ts
@@ -142,6 +142,16 @@ export function multiTenant<E extends Env = Env>(
     invalidMessage = 'Invalid tenant ID',
   } = options;
 
+  // Fail fast on an inconsistent configuration at setup time. `source: 'custom'`
+  // without an `extractor` would otherwise extract `undefined` on every request
+  // and surface as a misleading "Tenant ID is required" 400 — a misconfiguration
+  // masquerading as a client error. Surface it as a clear setup error instead.
+  if (source === 'custom' && !extractor) {
+    throw new Error(
+      "multiTenant: source 'custom' requires an `extractor` function. Provide `extractor`, or choose a different `source`.",
+    );
+  }
+
   /**
    * Tenant ID extraction functions by source type.
    * O(1) lookup instead of switch statement.

--- a/tests/multi-tenant.test.ts
+++ b/tests/multi-tenant.test.ts
@@ -290,3 +290,22 @@ describe('Multi-Tenancy', () => {
     });
   });
 });
+
+describe('multiTenant config validation', () => {
+  it("throws a clear setup error when source is 'custom' without an extractor", () => {
+    // Previously this mis-configuration silently extracted `undefined` and
+    // surfaced as a misleading "Tenant ID is required" 400 on every request.
+    expect(() => multiTenant({ source: 'custom' })).toThrow(/requires an `extractor`/);
+  });
+
+  it("accepts source 'custom' when an extractor is provided", () => {
+    expect(() => multiTenant({ source: 'custom', extractor: () => 'tenant-a' })).not.toThrow();
+  });
+
+  it('accepts the built-in sources without extra configuration', () => {
+    expect(() => multiTenant({ source: 'header' })).not.toThrow();
+    expect(() => multiTenant({ source: 'path' })).not.toThrow();
+    expect(() => multiTenant({ source: 'query' })).not.toThrow();
+    expect(() => multiTenant({ source: 'jwt' })).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Context

While scoping Phase 3 (structural type upgrades), I found a real config footgun in `multiTenant()`: `source: 'custom'` without an `extractor` silently extracted `undefined` on every request, surfacing as a misleading `400 "Tenant ID is required"` — a setup mistake masquerading as a client error.

This PR delivers the **safety intent** of the planned Phase-3 *"variant configs as discriminated unions"* initiative — illegal config states are now caught — **without** the breaking public-type change a compile-time discriminated union would require. `multiTenant()` throws a clear configuration error at construction time.

## Why not the full discriminated-union conversion?

The remaining Phase 3 items (branded identity types, compile-time discriminated-union configs, the DB-generic refactor, the OpenAPI-registry migration) all **reshape public/consumer-facing types** — they're API-design decisions for a pre-1.0 library, not internal hardening. I've deliberately not rammed those through autonomously; they warrant the maintainer's explicit design call. (The sibling configs were checked: `VersionStrategy` is already exhaustively covered by its typed lookup map, and `RelationConfig.foreignKey` is universally required — no equivalent silent-misconfig bugs there.)

## Verification

- ✅ typecheck
- ✅ 10 multi-tenant tests (3 new config-validation cases)

Patch changeset for `hono-crud`.