### PR TITLE
refactor(openapi): finish describe() to meta() migration (read/export/import)

### DIFF
--- a/.changeset/openapi-meta-registry-complete.md
+++ b/.changeset/openapi-meta-registry-complete.md
@@ -1,0 +1,5 @@
+---
+"hono-crud": patch
+---
+
+Internal: complete the OpenAPI metadata migration to Zod v4's `.meta()` registry — the remaining `.describe()` calls (read/export/import endpoint query parameters) now use `.meta()`, so the entire core no longer uses `.describe()`. The OpenAPI snapshot fixture was expanded to cover the export/import endpoints, and the generated output is unchanged (the snapshot is byte-for-byte identical after the migration). No consumer-facing change.

--- a/packages/core/src/endpoints/export.ts
+++ b/packages/core/src/endpoints/export.ts
@@ -96,8 +96,10 @@ export abstract class ExportEndpoint<
   protected getExportQuerySchema() {
     const baseSchema = this.getQuerySchema();
     return baseSchema.extend({
-      format: z.enum(['json', 'csv']).optional().describe('Export format'),
-      stream: z.enum(['true', 'false']).optional().describe('Enable streaming for large exports'),
+      format: z.enum(['json', 'csv']).optional().meta({ description: 'Export format' }),
+      stream: z.enum(['true', 'false']).optional().meta({
+        description: 'Enable streaming for large exports',
+      }),
     });
   }
 

--- a/packages/core/src/endpoints/import.ts
+++ b/packages/core/src/endpoints/import.ts
@@ -222,9 +222,14 @@ export abstract class ImportEndpoint<
       ...this.schema,
       request: {
         query: z.object({
-          mode: z.enum(['create', 'upsert']).optional().describe('Import mode'),
-          skipInvalid: z.enum(['true', 'false']).optional().describe('Skip invalid rows'),
-          stopOnError: z.enum(['true', 'false']).optional().describe('Stop on first error'),
+          mode: z.enum(['create', 'upsert']).optional().meta({ description: 'Import mode' }),
+          skipInvalid: z
+            .enum(['true', 'false'])
+            .optional()
+            .meta({ description: 'Skip invalid rows' }),
+          stopOnError: z.enum(['true', 'false']).optional().meta({
+            description: 'Stop on first error',
+          }),
         }),
         // Body validation is done manually to support multiple content types
       },

--- a/packages/core/src/endpoints/read.ts
+++ b/packages/core/src/endpoints/read.ts
@@ -100,9 +100,9 @@ export abstract class ReadEndpoint<
       shape.include = z
         .string()
         .optional()
-        .describe(
-          `Comma-separated list of relations to include. Allowed: ${this.allowedIncludes.join(', ')}`,
-        );
+        .meta({
+          description: `Comma-separated list of relations to include. Allowed: ${this.allowedIncludes.join(', ')}`,
+        });
     }
 
     // Add fields parameter for field selection
@@ -111,9 +111,9 @@ export abstract class ReadEndpoint<
       shape.fields = z
         .string()
         .optional()
-        .describe(
-          `Comma-separated list of fields to return. Available: ${availableFields.join(', ')}`,
-        );
+        .meta({
+          description: `Comma-separated list of fields to return. Available: ${availableFields.join(', ')}`,
+        });
     }
 
     if (Object.keys(shape).length === 0) {

--- a/tests/__snapshots__/openapi-snapshot.test.ts.snap
+++ b/tests/__snapshots__/openapi-snapshot.test.ts.snap
@@ -627,6 +627,476 @@ exports[`OpenAPI output snapshot > toOpenApiPaths output is stable (byte-for-byt
       ],
     },
   },
+  "/export": {
+    "get": {
+      "parameters": [
+        {
+          "in": "query",
+          "name": "page",
+          "required": false,
+          "schema": {
+            "type": "string",
+          },
+        },
+        {
+          "in": "query",
+          "name": "per_page",
+          "required": false,
+          "schema": {
+            "type": "string",
+          },
+        },
+        {
+          "description": "Export format",
+          "in": "query",
+          "name": "format",
+          "required": false,
+          "schema": {
+            "description": "Export format",
+            "enum": [
+              "json",
+              "csv",
+            ],
+            "type": "string",
+          },
+        },
+        {
+          "description": "Enable streaming for large exports",
+          "in": "query",
+          "name": "stream",
+          "required": false,
+          "schema": {
+            "description": "Enable streaming for large exports",
+            "enum": [
+              "true",
+              "false",
+            ],
+            "type": "string",
+          },
+        },
+      ],
+      "responses": {
+        "200": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "result": {
+                    "properties": {
+                      "count": {
+                        "type": "number",
+                      },
+                      "data": {
+                        "items": {
+                          "properties": {
+                            "authorEmail": {
+                              "description": "Author contact email",
+                              "format": "email",
+                              "type": "string",
+                            },
+                            "body": {
+                              "description": "Article body in Markdown",
+                              "type": "string",
+                            },
+                            "id": {
+                              "description": "Unique article identifier",
+                              "format": "uuid",
+                              "type": "string",
+                            },
+                            "published": {
+                              "default": false,
+                              "description": "Whether the article is live",
+                              "type": "boolean",
+                            },
+                            "slug": {
+                              "description": "URL-friendly identifier",
+                              "type": "string",
+                            },
+                            "status": {
+                              "description": "Publication status",
+                              "enum": [
+                                "draft",
+                                "published",
+                                "archived",
+                              ],
+                              "type": "string",
+                            },
+                            "title": {
+                              "description": "Article title",
+                              "maxLength": 200,
+                              "minLength": 1,
+                              "type": "string",
+                            },
+                            "views": {
+                              "default": 0,
+                              "description": "View counter",
+                              "minimum": 0,
+                              "type": "integer",
+                            },
+                          },
+                          "required": [
+                            "id",
+                            "title",
+                            "slug",
+                            "status",
+                            "authorEmail",
+                          ],
+                          "type": "object",
+                        },
+                        "type": "array",
+                      },
+                      "exportedAt": {
+                        "type": "string",
+                      },
+                      "format": {
+                        "enum": [
+                          "json",
+                          "csv",
+                        ],
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "data",
+                      "count",
+                      "format",
+                      "exportedAt",
+                    ],
+                    "type": "object",
+                  },
+                  "success": {
+                    "enum": [
+                      true,
+                    ],
+                    "type": "boolean",
+                  },
+                },
+                "required": [
+                  "success",
+                  "result",
+                ],
+                "type": "object",
+              },
+            },
+            "text/csv": {
+              "schema": {
+                "type": "string",
+              },
+            },
+          },
+          "description": "Export successful",
+        },
+      },
+      "tags": [
+        "articles",
+      ],
+    },
+  },
+  "/import": {
+    "post": {
+      "parameters": [
+        {
+          "description": "Import mode",
+          "in": "query",
+          "name": "mode",
+          "required": false,
+          "schema": {
+            "description": "Import mode",
+            "enum": [
+              "create",
+              "upsert",
+            ],
+            "type": "string",
+          },
+        },
+        {
+          "description": "Skip invalid rows",
+          "in": "query",
+          "name": "skipInvalid",
+          "required": false,
+          "schema": {
+            "description": "Skip invalid rows",
+            "enum": [
+              "true",
+              "false",
+            ],
+            "type": "string",
+          },
+        },
+        {
+          "description": "Stop on first error",
+          "in": "query",
+          "name": "stopOnError",
+          "required": false,
+          "schema": {
+            "description": "Stop on first error",
+            "enum": [
+              "true",
+              "false",
+            ],
+            "type": "string",
+          },
+        },
+      ],
+      "responses": {
+        "200": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "result": {
+                    "properties": {
+                      "results": {
+                        "items": {
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                            },
+                            "data": {},
+                            "error": {
+                              "type": "string",
+                            },
+                            "rowNumber": {
+                              "type": "number",
+                            },
+                            "status": {
+                              "enum": [
+                                "created",
+                                "updated",
+                                "skipped",
+                                "failed",
+                              ],
+                              "type": "string",
+                            },
+                            "validationErrors": {
+                              "items": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string",
+                                  },
+                                  "path": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "path",
+                                  "message",
+                                ],
+                                "type": "object",
+                              },
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "rowNumber",
+                            "status",
+                          ],
+                          "type": "object",
+                        },
+                        "type": "array",
+                      },
+                      "summary": {
+                        "properties": {
+                          "created": {
+                            "type": "number",
+                          },
+                          "failed": {
+                            "type": "number",
+                          },
+                          "skipped": {
+                            "type": "number",
+                          },
+                          "total": {
+                            "type": "number",
+                          },
+                          "updated": {
+                            "type": "number",
+                          },
+                        },
+                        "required": [
+                          "total",
+                          "created",
+                          "updated",
+                          "skipped",
+                          "failed",
+                        ],
+                        "type": "object",
+                      },
+                    },
+                    "required": [
+                      "summary",
+                      "results",
+                    ],
+                    "type": "object",
+                  },
+                  "success": {
+                    "enum": [
+                      true,
+                    ],
+                    "type": "boolean",
+                  },
+                },
+                "required": [
+                  "success",
+                  "result",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "Import completed successfully",
+        },
+        "207": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "result": {
+                    "properties": {
+                      "results": {
+                        "items": {
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                            },
+                            "data": {},
+                            "error": {
+                              "type": "string",
+                            },
+                            "rowNumber": {
+                              "type": "number",
+                            },
+                            "status": {
+                              "enum": [
+                                "created",
+                                "updated",
+                                "skipped",
+                                "failed",
+                              ],
+                              "type": "string",
+                            },
+                            "validationErrors": {
+                              "items": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string",
+                                  },
+                                  "path": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "path",
+                                  "message",
+                                ],
+                                "type": "object",
+                              },
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "rowNumber",
+                            "status",
+                          ],
+                          "type": "object",
+                        },
+                        "type": "array",
+                      },
+                      "summary": {
+                        "properties": {
+                          "created": {
+                            "type": "number",
+                          },
+                          "failed": {
+                            "type": "number",
+                          },
+                          "skipped": {
+                            "type": "number",
+                          },
+                          "total": {
+                            "type": "number",
+                          },
+                          "updated": {
+                            "type": "number",
+                          },
+                        },
+                        "required": [
+                          "total",
+                          "created",
+                          "updated",
+                          "skipped",
+                          "failed",
+                        ],
+                        "type": "object",
+                      },
+                    },
+                    "required": [
+                      "summary",
+                      "results",
+                    ],
+                    "type": "object",
+                  },
+                  "success": {
+                    "enum": [
+                      true,
+                    ],
+                    "type": "boolean",
+                  },
+                },
+                "required": [
+                  "success",
+                  "result",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "Import completed with partial failures",
+        },
+        "400": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "error": {
+                    "properties": {
+                      "code": {
+                        "type": "string",
+                      },
+                      "details": {},
+                      "message": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "code",
+                      "message",
+                    ],
+                    "type": "object",
+                  },
+                  "success": {
+                    "enum": [
+                      false,
+                    ],
+                    "type": "boolean",
+                  },
+                },
+                "required": [
+                  "success",
+                  "error",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "Validation error",
+        },
+      },
+      "tags": [
+        "articles",
+      ],
+    },
+  },
   "/search": {
     "get": {
       "parameters": [

--- a/tests/openapi-snapshot.test.ts
+++ b/tests/openapi-snapshot.test.ts
@@ -54,6 +54,8 @@ function articleEndpoints() {
       search: { fields: ['title', 'body'] },
       aggregate: {},
       upsert: { conflictTarget: 'slug' },
+      export: {},
+      import: {},
     },
     MemoryAdapters,
   );


### PR DESCRIPTION
## Context

Completes **Initiative 12** (started in #49). Migrates the last `.describe()` call sites — the read/export/import endpoint query parameters — to Zod v4's `.meta()` registry. **Core source now contains zero `.describe()` calls**; all OpenAPI metadata flows through the metadata registry.

## Method (snapshot-guarded, non-breaking)

1. Expanded the OpenAPI snapshot fixture to cover the `export` and `import` endpoints (so their metadata is captured).
2. Migrated the remaining 7 `.describe()` calls (read ×2, export ×2, import ×3) to `.meta()`.
3. The snapshot is **byte-for-byte identical** after the migration — confirming, again, that `.meta()` and `.describe()` emit the same OpenAPI output here.

No consumer-facing change.

## Verification

- ✅ `pnpm -r build`, `pnpm -r typecheck`, `pnpm run typecheck:examples`
- ✅ `pnpm run lint`
- ✅ `pnpm run test:unit` — **945 passed**
- ✅ `pnpm run test:workers` — **42 passed**
- ✅ OpenAPI snapshot unchanged by the migration
- ✅ `grep -rn '\.describe(' packages/core/src` → **0**

Patch changeset for `hono-crud` (internal; no output change).