### PR TITLE
fix: bug batch from the drift audit (9 fixes)

### DIFF
--- a/.changeset/aggregate-fail-closed.md
+++ b/.changeset/aggregate-fail-closed.md
@@ -1,0 +1,7 @@
+---
+"@hono-crud/memory": patch
+"@hono-crud/prisma": patch
+"@hono-crud/drizzle": patch
+---
+
+Aggregate filters now fail closed on unknown operators across all adapters. Memory's `MemoryAggregateEndpoint` delegated to its own inline 6-operator switch with a fail-open default (unknown operators matched every record); it now delegates to `matchesFilter()`, the fail-closed single source of truth, and supports all 12 operators. Prisma's aggregate where-builder forwarded unrecognized operator strings verbatim into the Prisma where clause and 500'd on documented operators like `between`/`ilike`; it now validates with `isFilterOperator()` and delegates to `buildPrismaWhere`. Drizzle's aggregate path cast untrusted operator strings and crashed via `assertNever` on unknown operators; it now validates first and pushes a never-true condition instead. In every adapter an unknown operator now matches nothing (count 0) instead of leaking data or crashing.

--- a/.changeset/cache-respects-envelope.md
+++ b/.changeset/cache-respects-envelope.md
@@ -1,0 +1,5 @@
+---
+"@hono-crud/cache": patch
+---
+
+Cache HITs now honor the configured `ResponseEnvelope`. The cache mixin previously hardcoded the default `{success, result}` envelope when serving from cache, so endpoints with a custom envelope returned different body shapes on HIT vs MISS. Raw result data is now cached and the envelope is applied at response time through the same path as uncached responses; `X-Cache` headers are unchanged.

--- a/.changeset/prisma-range-filter-merge.md
+++ b/.changeset/prisma-range-filter-merge.md
@@ -1,0 +1,5 @@
+---
+"@hono-crud/prisma": patch
+---
+
+Fix `buildPrismaWhere` dropping conditions when a field had more than one filter operator. List and search queries like `?views[gte]=100&views[lte]=200` silently lost the `gte` because each condition overwrote the previous one per field; multiple conditions on one field now combine into a top-level `AND`.

--- a/.changeset/prisma-rollback-404.md
+++ b/.changeset/prisma-rollback-404.md
@@ -1,0 +1,5 @@
+---
+"@hono-crud/prisma": patch
+---
+
+Version rollback now returns 404 `NOT_FOUND` when the target record no longer exists, honoring the endpoint's declared OpenAPI contract. Previously the adapter threw a plain `Error`, which surfaced as 500 `INTERNAL_ERROR`.

--- a/.changeset/publish-metadata.md
+++ b/.changeset/publish-metadata.md
@@ -1,0 +1,14 @@
+---
+"@hono-crud/cache": patch
+"@hono-crud/drizzle": patch
+"@hono-crud/health": patch
+"@hono-crud/idempotency": patch
+"@hono-crud/mcp": patch
+"@hono-crud/memory": patch
+"@hono-crud/prisma": patch
+"@hono-crud/rate-limit": patch
+"@hono-crud/scalar": patch
+"@hono-crud/swagger": patch
+---
+
+Publishing metadata fixes: `CHANGELOG.md` is now included in the published npm artifact (it was missing from the `files` allowlist everywhere except core), and the lazily-loaded libraries `drizzle-zod` (drizzle), `pluralize` and `fastest-levenshtein` (prisma) are now optional peer dependencies — they are dynamically imported with graceful fallbacks, so consumers who don't use those features no longer have to install them.

--- a/.changeset/swagger-scalar-link.md
+++ b/.changeset/swagger-scalar-link.md
@@ -1,0 +1,5 @@
+---
+"@hono-crud/swagger": patch
+---
+
+The docs-hub Scalar card now links to `/reference` (the path `@hono-crud/scalar` actually serves by default) instead of `/scalar`, which 404'd. The `scalarPath` option remains configurable.

--- a/.changeset/waituntil-single-source.md
+++ b/.changeset/waituntil-single-source.md
@@ -1,0 +1,5 @@
+---
+"hono-crud": patch
+---
+
+Consolidate the three divergent `executionCtx.waitUntil` helpers onto one guarded implementation (breaking, patch). The public `getWaitUntil` exported from `hono-crud/cloudflare` no longer throws outside a Workers runtime — it now returns `WaitUntil | undefined` like the internal helper always did. `OpenAPIRoute.runAfterResponse` reuses the shared `getWaitUntil` from `utils/wait-until` instead of an inlined copy, and the dead thunk-based `runAfterResponse` free function was removed.

--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -800,9 +800,8 @@ GET /users?age[null]=true
 ```typescript
 class UserList extends MemoryListEndpoint {
   _meta = userMeta;
-  orderByFields = ['name', 'createdAt', 'age'];
-  defaultOrderBy = 'createdAt';
-  defaultOrderDirection: 'asc' | 'desc' = 'desc';
+  sortFields = ['name', 'createdAt', 'age'];
+  defaultSort = { field: 'createdAt', order: 'desc' as const };
   defaultPerPage = 20;
   maxPerPage = 100;
 }

--- a/docs/alternative-api-patterns.md
+++ b/docs/alternative-api-patterns.md
@@ -69,8 +69,8 @@ class UserList extends MemoryListEndpoint {
   schema = { tags: ['Users'], summary: 'List users' };
   filterFields = ['role', 'status'];
   searchFields = ['name', 'email'];
-  orderByFields = ['name', 'createdAt'];
-  defaultOrderDirection = 'desc';
+  sortFields = ['name', 'createdAt'];
+  defaultSort = { field: 'createdAt', order: 'desc' as const };
 }
 
 registerCrud(app, '/users', {
@@ -137,8 +137,8 @@ const UserList = createList({
   schema: { tags: ['Users'], summary: 'List users' },
   filterFields: ['role', 'status'],
   searchFields: ['name', 'email'],
-  orderByFields: ['name', 'createdAt'],
-  defaultOrderDirection: 'desc',
+  sortFields: ['name', 'createdAt'],
+  defaultSort: { field: 'createdAt', order: 'desc' },
   defaultPerPage: 20,
   maxPerPage: 100,
 }, MemoryListEndpoint);
@@ -195,9 +195,8 @@ registerCrud(app, '/users', {
 | `filterConfig` | `object` | Advanced filter operators per field |
 | `searchFields` | `string[]` | Fields available for search |
 | `searchFieldName` | `string` | Search query parameter name (default: 'search') |
-| `orderByFields` | `string[]` | Fields available for sorting |
-| `defaultOrderBy` | `string` | Default sort field |
-| `defaultOrderDirection` | `'asc' \| 'desc'` | Default sort direction |
+| `sortFields` | `string[]` | Fields available for sorting |
+| `defaultSort` | `{ field: string; order: 'asc' \| 'desc' }` | Default sort field and direction |
 | `defaultPerPage` | `number` | Default page size (default: 20) |
 | `maxPerPage` | `number` | Maximum page size (default: 100) |
 | `allowedIncludes` | `string[]` | Allowed relation names |
@@ -431,7 +430,7 @@ const userEndpoints = defineEndpoints({
     sorting: {
       fields: ['name', 'createdAt'],
       default: 'createdAt',
-      defaultDirection: 'desc',
+      defaultOrder: 'desc',
     },
     pagination: { defaultPerPage: 20, maxPerPage: 100 },
     includes: ['profile', 'posts'],

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -101,7 +101,8 @@ class UserRead extends withCache(MemoryReadEndpoint) {
 | `setCachedResponse<T>(data)` | Store data in cache |
 | `invalidateCache(options?)` | Manually invalidate cache entries |
 | `getCacheStatus()` | Returns `'HIT'` or `'MISS'` |
-| `successWithCache(result)` | Response with `X-Cache` header |
+| `successWithCache(result)` | Single-item response with `X-Cache` header (body formatted by the configured `responseEnvelope`) |
+| `successPaginatedWithCache(result, info)` | List response with `X-Cache` header and pagination `info` threaded through the `responseEnvelope` |
 
 ---
 

--- a/docs/database-adapters.md
+++ b/docs/database-adapters.md
@@ -186,7 +186,7 @@ class UserList extends User.List {
   schema = { tags: ['Users'], summary: 'List users' };
   filterFields = ['role'];
   searchFields = ['name', 'email'];
-  orderByFields = ['name', 'createdAt'];
+  sortFields = ['name', 'createdAt'];
 }
 
 class UserRead extends User.Read {
@@ -331,9 +331,8 @@ class UserList extends PrismaListEndpoint {
   schema = { tags: ['Users'], summary: 'List users' };
   filterFields = ['role'];
   searchFields = ['name', 'email'];
-  orderByFields = ['name', 'createdAt'];
-  defaultOrderBy = 'createdAt';
-  defaultOrderDirection: 'asc' | 'desc' = 'desc';
+  sortFields = ['name', 'createdAt'];
+  defaultSort = { field: 'createdAt', order: 'desc' as const };
   defaultPerPage = 20;
   maxPerPage = 100;
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -63,7 +63,7 @@ a health check at `/health`.
 
 `examples/local-consumer` is the consumer-style example. It installs this
 library as `"hono-crud": "file:../.."`, imports from `hono-crud` and
-`hono-crud/adapters/memory`, and runs a real Hono HTTP server. This is the
+`@hono-crud/memory`, and runs a real Hono HTTP server. This is the
 closest local simulation of installing the package from npm.
 
 Spin up the API from the repo root:

--- a/examples/drizzle/basic-crud.ts
+++ b/examples/drizzle/basic-crud.ts
@@ -79,9 +79,8 @@ class UserList extends DrizzleListEndpoint {
   searchFields = ['name', 'email'];
 
   // Configure sorting
-  orderByFields = ['name', 'createdAt', 'age'];
-  defaultOrderBy = 'createdAt';
-  defaultOrderDirection: 'asc' | 'desc' = 'desc';
+  sortFields = ['name', 'createdAt', 'age'];
+  defaultSort = { field: 'createdAt', order: 'desc' as const };
 
   // Pagination defaults
   defaultPerPage = 20;

--- a/examples/drizzle/comprehensive.ts
+++ b/examples/drizzle/comprehensive.ts
@@ -155,9 +155,8 @@ class UserList extends DrizzleListEndpoint {
   };
 
   searchFields = ['name', 'email'];
-  orderByFields = ['name', 'age', 'createdAt'];
-  defaultOrderBy = 'createdAt';
-  defaultOrderDirection: 'asc' | 'desc' = 'desc';
+  sortFields = ['name', 'age', 'createdAt'];
+  defaultSort = { field: 'createdAt', order: 'desc' as const };
 
   allowedIncludes = ['posts', 'profile', 'comments'];
 }
@@ -252,7 +251,7 @@ class PostList extends DrizzleListEndpoint {
   schema = { tags: ['Posts'], summary: 'List posts' };
   filterFields = ['status'];
   searchFields = ['title', 'content'];
-  orderByFields = ['title', 'createdAt'];
+  sortFields = ['title', 'createdAt'];
   allowedIncludes = ['author', 'comments'];
 }
 
@@ -353,8 +352,8 @@ class CategoryList extends DrizzleListEndpoint {
   filterConfig = {
     sortOrder: ['eq', 'gt', 'gte', 'lt', 'lte', 'between'] as const,
   };
-  orderByFields = ['name', 'sortOrder'];
-  defaultOrderBy = 'sortOrder';
+  sortFields = ['name', 'sortOrder'];
+  defaultSort = { field: 'sortOrder', order: 'asc' as const };
 }
 
 class CategoryUpsert extends DrizzleUpsertEndpoint {

--- a/examples/drizzle/d1-crud.ts
+++ b/examples/drizzle/d1-crud.ts
@@ -154,9 +154,8 @@ class TaskList extends TaskCrud.List {
   };
 
   searchFields = ['title', 'description'];
-  orderByFields = ['createdAt', 'priority', 'title'];
-  defaultOrderBy = 'createdAt';
-  defaultOrderDirection: 'asc' | 'desc' = 'desc';
+  sortFields = ['createdAt', 'priority', 'title'];
+  defaultSort = { field: 'createdAt', order: 'desc' as const };
 
   defaultPerPage = 20;
   maxPerPage = 100;

--- a/examples/drizzle/filtering.ts
+++ b/examples/drizzle/filtering.ts
@@ -92,7 +92,7 @@ Supports multiple filter operators:
   };
 
   searchFields = ['name', 'email'];
-  orderByFields = ['name', 'age', 'createdAt'];
+  sortFields = ['name', 'age', 'createdAt'];
 }
 
 // ============================================================================
@@ -132,9 +132,8 @@ class CategoryList extends DrizzleListEndpoint {
     description: ['null'] as const,
   };
 
-  orderByFields = ['name', 'sortOrder'];
-  defaultOrderBy = 'sortOrder';
-  defaultOrderDirection: 'asc' | 'desc' = 'asc';
+  sortFields = ['name', 'sortOrder'];
+  defaultSort = { field: 'sortOrder', order: 'asc' as const };
 }
 
 // ============================================================================

--- a/examples/drizzle/soft-delete.ts
+++ b/examples/drizzle/soft-delete.ts
@@ -86,7 +86,7 @@ Query parameters:
 
   filterFields = ['role', 'status'];
   searchFields = ['name', 'email'];
-  orderByFields = ['name', 'createdAt'];
+  sortFields = ['name', 'createdAt'];
 }
 
 class UserRead extends DrizzleReadEndpoint {

--- a/examples/drizzle/upsert.ts
+++ b/examples/drizzle/upsert.ts
@@ -171,7 +171,7 @@ class ProductList extends DrizzleListEndpoint {
 
   schema = { tags: ['Products'], summary: 'List products' };
   searchFields = ['name', 'sku'];
-  orderByFields = ['name', 'price', 'stock'];
+  sortFields = ['name', 'price', 'stock'];
 }
 
 // Batch upsert inventory by SKU + warehouseId (composite key)
@@ -205,7 +205,7 @@ class InventoryList extends DrizzleListEndpoint {
 
   schema = { tags: ['Inventory'], summary: 'List inventory' };
   filterFields = ['sku', 'warehouseId'];
-  orderByFields = ['sku', 'warehouseId', 'quantity'];
+  sortFields = ['sku', 'warehouseId', 'quantity'];
 }
 
 // ============================================================================

--- a/examples/drizzle/with-drizzle-zod.ts
+++ b/examples/drizzle/with-drizzle-zod.ts
@@ -172,9 +172,8 @@ export async function createApp() {
 
     filterFields = ['category', 'inStock'];
     searchFields = ['name', 'description'];
-    orderByFields = ['name', 'price', 'createdAt'];
-    defaultOrderBy = 'createdAt';
-    defaultOrderDirection: 'asc' | 'desc' = 'desc';
+    sortFields = ['name', 'price', 'createdAt'];
+    defaultSort = { field: 'createdAt', order: 'desc' as const };
   }
 
   class ProductRead extends DrizzleReadEndpoint<Env, typeof productMeta> {

--- a/examples/memory/alternative-apis.ts
+++ b/examples/memory/alternative-apis.ts
@@ -87,8 +87,8 @@ class ClassUserList extends MemoryListEndpoint {
   schema = { tags: ['Users (Class-based)'], summary: 'List users (class)' };
   filterFields = ['role', 'status'];
   searchFields = ['name', 'email'];
-  orderByFields = ['name', 'createdAt'];
-  defaultOrderDirection: 'asc' | 'desc' = 'desc';
+  sortFields = ['name', 'createdAt'];
+  defaultSort = { field: 'createdAt', order: 'desc' as const };
 }
 
 class ClassUserRead extends MemoryReadEndpoint {
@@ -130,8 +130,8 @@ const FnUserList = createList(
     schema: { tags: ['Users (Function-based)'], summary: 'List users (function)' },
     filterFields: ['role', 'status'],
     searchFields: ['name', 'email'],
-    orderByFields: ['name', 'createdAt'],
-    defaultOrderDirection: 'desc',
+    sortFields: ['name', 'createdAt'],
+    defaultSort: { field: 'createdAt', order: 'desc' },
   },
   MemoryListEndpoint,
 );
@@ -226,7 +226,7 @@ const configEndpoints = defineEndpoints(
       sorting: {
         fields: ['name', 'createdAt'],
         default: 'createdAt',
-        defaultDirection: 'desc',
+        defaultOrder: 'desc',
       },
       pagination: { defaultPerPage: 20, maxPerPage: 100 },
     },

--- a/examples/memory/basic-crud.ts
+++ b/examples/memory/basic-crud.ts
@@ -85,9 +85,8 @@ class UserList extends MemoryListEndpoint {
   // Configure filtering
   filterFields = ['role'];
   searchFields = ['name', 'email'];
-  orderByFields = ['name', 'createdAt'];
-  defaultOrderBy = 'createdAt';
-  defaultOrderDirection: 'asc' | 'desc' = 'desc';
+  sortFields = ['name', 'createdAt'];
+  defaultSort = { field: 'createdAt', order: 'desc' as const };
 }
 
 class UserRead extends MemoryReadEndpoint {

--- a/examples/memory/comprehensive.ts
+++ b/examples/memory/comprehensive.ts
@@ -186,9 +186,8 @@ class UserList extends MemoryListEndpoint {
   };
 
   searchFields = ['name', 'email'];
-  orderByFields = ['name', 'age', 'createdAt'];
-  defaultOrderBy = 'createdAt';
-  defaultOrderDirection: 'asc' | 'desc' = 'desc';
+  sortFields = ['name', 'age', 'createdAt'];
+  defaultSort = { field: 'createdAt', order: 'desc' as const };
 
   allowedIncludes = ['posts', 'profile', 'comments'];
 }
@@ -271,7 +270,7 @@ class PostList extends MemoryListEndpoint {
   schema = { tags: ['Posts'], summary: 'List posts' };
   filterFields = ['status'];
   searchFields = ['title', 'content'];
-  orderByFields = ['title', 'createdAt'];
+  sortFields = ['title', 'createdAt'];
   allowedIncludes = ['author', 'comments'];
 }
 
@@ -359,8 +358,8 @@ class CategoryList extends MemoryListEndpoint {
   filterConfig = {
     sortOrder: ['eq', 'gt', 'gte', 'lt', 'lte', 'between'] as const,
   };
-  orderByFields = ['name', 'sortOrder'];
-  defaultOrderBy = 'sortOrder';
+  sortFields = ['name', 'sortOrder'];
+  defaultSort = { field: 'sortOrder', order: 'asc' as const };
 }
 
 class CategoryUpsert extends MemoryUpsertEndpoint {

--- a/examples/memory/computed-fields.ts
+++ b/examples/memory/computed-fields.ts
@@ -176,7 +176,7 @@ class UserList extends MemoryListEndpoint {
 
   filterFields = ['status', 'emailVerified'];
   searchFields = ['firstName', 'lastName', 'email'];
-  orderByFields = ['firstName', 'lastName', 'createdAt'];
+  sortFields = ['firstName', 'lastName', 'createdAt'];
 
   schema = {
     tags: ['Users'],

--- a/examples/memory/field-selection.ts
+++ b/examples/memory/field-selection.ts
@@ -146,7 +146,7 @@ List users with optional field selection.
   // Allow filtering and sorting
   filterFields = ['role'];
   searchFields = ['name', 'email'];
-  orderByFields = ['name', 'createdAt'];
+  sortFields = ['name', 'createdAt'];
 }
 
 /**

--- a/examples/memory/soft-delete.ts
+++ b/examples/memory/soft-delete.ts
@@ -89,9 +89,8 @@ class UserList extends MemoryListEndpoint {
 
   filterFields = ['role'];
   searchFields = ['name', 'email'];
-  orderByFields = ['name', 'createdAt'];
-  defaultOrderBy = 'createdAt';
-  defaultOrderDirection: 'asc' | 'desc' = 'desc';
+  sortFields = ['name', 'createdAt'];
+  defaultSort = { field: 'createdAt', order: 'desc' as const };
 }
 
 class UserRead extends MemoryReadEndpoint {

--- a/examples/prisma/basic-crud.ts
+++ b/examples/prisma/basic-crud.ts
@@ -74,9 +74,8 @@ class UserList extends PrismaListEndpoint {
   searchFields = ['name', 'email'];
 
   // Configure sorting
-  orderByFields = ['name', 'createdAt', 'age'];
-  defaultOrderBy = 'createdAt';
-  defaultOrderDirection: 'asc' | 'desc' = 'desc';
+  sortFields = ['name', 'createdAt', 'age'];
+  defaultSort = { field: 'createdAt', order: 'desc' as const };
 
   // Pagination defaults
   defaultPerPage = 20;

--- a/examples/prisma/comprehensive.ts
+++ b/examples/prisma/comprehensive.ts
@@ -134,9 +134,8 @@ class UserList extends PrismaListEndpoint {
   };
 
   searchFields = ['name', 'email'];
-  orderByFields = ['name', 'age', 'createdAt'];
-  defaultOrderBy = 'createdAt';
-  defaultOrderDirection: 'asc' | 'desc' = 'desc';
+  sortFields = ['name', 'age', 'createdAt'];
+  defaultSort = { field: 'createdAt', order: 'desc' as const };
 
   allowedIncludes = ['posts', 'profile', 'comments'];
 }
@@ -230,7 +229,7 @@ class PostList extends PrismaListEndpoint {
   schema = { tags: ['Posts'], summary: 'List posts' };
   filterFields = ['status'];
   searchFields = ['title', 'content'];
-  orderByFields = ['title', 'createdAt'];
+  sortFields = ['title', 'createdAt'];
   allowedIncludes = ['author', 'comments'];
 }
 
@@ -329,8 +328,8 @@ class CategoryList extends PrismaListEndpoint {
   filterConfig = {
     sortOrder: ['eq', 'gt', 'gte', 'lt', 'lte', 'between'] as const,
   };
-  orderByFields = ['name', 'sortOrder'];
-  defaultOrderBy = 'sortOrder';
+  sortFields = ['name', 'sortOrder'];
+  defaultSort = { field: 'sortOrder', order: 'asc' as const };
 }
 
 class CategoryUpsert extends PrismaUpsertEndpoint {

--- a/examples/prisma/filtering.ts
+++ b/examples/prisma/filtering.ts
@@ -85,7 +85,7 @@ Supports multiple filter operators:
   };
 
   searchFields = ['name', 'email'];
-  orderByFields = ['name', 'age', 'createdAt'];
+  sortFields = ['name', 'age', 'createdAt'];
 }
 
 // ============================================================================
@@ -123,9 +123,8 @@ class CategoryList extends PrismaListEndpoint {
     description: ['null'] as const,
   };
 
-  orderByFields = ['name', 'sortOrder'];
-  defaultOrderBy = 'sortOrder';
-  defaultOrderDirection: 'asc' | 'desc' = 'asc';
+  sortFields = ['name', 'sortOrder'];
+  defaultSort = { field: 'sortOrder', order: 'asc' as const };
 }
 
 // ============================================================================

--- a/examples/prisma/soft-delete.ts
+++ b/examples/prisma/soft-delete.ts
@@ -76,7 +76,7 @@ Query parameters:
 
   filterFields = ['role', 'status'];
   searchFields = ['name', 'email'];
-  orderByFields = ['name', 'createdAt'];
+  sortFields = ['name', 'createdAt'];
 }
 
 class UserRead extends PrismaReadEndpoint {

--- a/examples/prisma/upsert.ts
+++ b/examples/prisma/upsert.ts
@@ -85,8 +85,8 @@ class CategoryList extends PrismaListEndpoint {
 
   schema = { tags: ['Categories'], summary: 'List categories' };
   searchFields = ['name'];
-  orderByFields = ['name', 'sortOrder'];
-  defaultOrderBy = 'sortOrder';
+  sortFields = ['name', 'sortOrder'];
+  defaultSort = { field: 'sortOrder', order: 'asc' as const };
 }
 
 // ============================================================================

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -28,20 +28,9 @@
     "clean": "rm -rf dist .tsup",
     "lint": "biome check src/"
   },
-  "keywords": [
-    "hono",
-    "crud",
-    "cache",
-    "caching",
-    "redis",
-    "kv"
-  ],
+  "keywords": ["hono", "crud", "cache", "caching", "redis", "kv"],
   "sideEffects": false,
-  "files": [
-    "dist",
-    "README.md",
-    "LICENSE"
-  ],
+  "files": ["dist", "README.md", "LICENSE", "CHANGELOG.md"],
   "engines": {
     "node": ">=20.19.0"
   },

--- a/packages/cache/src/mixin.ts
+++ b/packages/cache/src/mixin.ts
@@ -1,5 +1,10 @@
 import type { Context, Env } from 'hono';
-import type { Constructor, MetaInput, OpenAPIRoute } from 'hono-crud/internal';
+import type {
+  Constructor,
+  MetaInput,
+  OpenAPIRoute,
+  ResponseEnvelopeInfo,
+} from 'hono-crud/internal';
 import { ConfigurationException, createRegistryWithDefault, getLogger } from 'hono-crud/internal';
 import {
   createInvalidationPattern,
@@ -98,7 +103,19 @@ export interface CacheEndpointMethods {
   invalidateCache(options?: { pattern?: string; tags?: string[] }): Promise<void>;
   getCacheStatus(): 'HIT' | 'MISS';
   successWithCache<T>(result: T, status?: number): Response;
-  jsonWithCache<T>(data: T, status?: number): Response;
+  successPaginatedWithCache<T>(result: T, info: ResponseEnvelopeInfo, status?: number): Response;
+}
+
+/**
+ * Subset of the base `OpenAPIRoute` body formatters the cache mixin delegates
+ * to. These are `protected` on the base and invisible to the mixin through
+ * the generic constructor (TS#17744), so we reach them via this cast. They
+ * are the single source of truth for the response envelope — the mixin only
+ * layers the `X-Cache` header on top.
+ */
+interface EnvelopeFormatters {
+  success(result: unknown, status?: number): Response;
+  successPaginated(result: unknown, info: ResponseEnvelopeInfo, status?: number): Response;
 }
 
 /**
@@ -245,29 +262,38 @@ export function withCache<TBase extends Constructor<OpenAPIRoute>>(
     }
 
     /**
-     * Create a response with cache header included.
+     * Create a single-item success response with the `X-Cache` header.
+     *
+     * Body formatting is delegated to the inherited `success()` so the
+     * configured `ResponseEnvelope` is the single source of truth — the cache
+     * HIT path and the MISS path (which also calls `success()` upstream) emit
+     * byte-identical bodies. We only attach `X-Cache` on top.
      */
     protected successWithCache<T>(result: T, status = 200): Response {
-      return new Response(JSON.stringify({ success: true, result }), {
-        status,
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Cache': this.getCacheStatus(),
-        },
-      });
+      const response = (this as unknown as EnvelopeFormatters).success(result, status);
+      response.headers.set('X-Cache', this.getCacheStatus());
+      return response;
     }
 
     /**
-     * Create a JSON response with cache header included.
+     * Create a paginated/list success response with the `X-Cache` header.
+     *
+     * Delegates body formatting to the inherited `successPaginated()` so the
+     * pagination metadata is threaded through the configured
+     * `ResponseEnvelope` exactly as on a cache miss.
      */
-    protected jsonWithCache<T>(data: T, status = 200): Response {
-      return new Response(JSON.stringify(data), {
+    protected successPaginatedWithCache<T>(
+      result: T,
+      info: ResponseEnvelopeInfo,
+      status = 200,
+    ): Response {
+      const response = (this as unknown as EnvelopeFormatters).successPaginated(
+        result,
+        info,
         status,
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Cache': this.getCacheStatus(),
-        },
-      });
+      );
+      response.headers.set('X-Cache', this.getCacheStatus());
+      return response;
     }
 
     /**

--- a/packages/core/src/core/route.ts
+++ b/packages/core/src/core/route.ts
@@ -1,6 +1,7 @@
 import type { Context, Env } from 'hono';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import type { ZodObject, ZodRawShape } from 'zod';
+import { getWaitUntil } from '../utils/wait-until';
 import { getLogger } from './logger';
 import {
   type OpenAPIRouteSchema,
@@ -209,17 +210,7 @@ export abstract class OpenAPIRoute<
    * otherwise falls back to fire-and-forget with error logging.
    */
   protected runAfterResponse(promise: Promise<unknown>): void {
-    let waitUntil: ((p: Promise<unknown>) => void) | undefined;
-    try {
-      const execCtx = this.getContext().executionCtx;
-      if (execCtx && typeof (execCtx as { waitUntil?: unknown }).waitUntil === 'function') {
-        waitUntil = (execCtx as { waitUntil: (p: Promise<unknown>) => void }).waitUntil.bind(
-          execCtx,
-        );
-      }
-    } catch {
-      // executionCtx getter throws when not in a Workers/edge runtime
-    }
+    const waitUntil = getWaitUntil(this.getContext());
     if (waitUntil) {
       waitUntil(promise);
     } else {

--- a/packages/core/src/types/cloudflare.ts
+++ b/packages/core/src/types/cloudflare.ts
@@ -31,6 +31,31 @@ import type { KVNamespace } from '../shared/cloudflare-kv-types';
 export type { KVNamespace };
 
 /**
+ * Extracts the bound `executionCtx.waitUntil` from a Hono context, returning
+ * `undefined` (rather than throwing) when no execution context is available —
+ * e.g. outside a Workers/edge runtime, where Hono's `executionCtx` getter
+ * throws `This context has no ExecutionContext`.
+ *
+ * Re-exported from the shared `utils/wait-until` implementation, the single
+ * source of truth for this behaviour.
+ *
+ * @example
+ * ```ts
+ * import { getWaitUntil } from 'hono-crud/cloudflare';
+ * import { registerWebhooks } from 'hono-crud';
+ *
+ * app.use('*', async (c, next) => {
+ *   registerWebhooks({
+ *     endpoints: [{ url: 'https://hooks.example.com', events: ['create'] }],
+ *     waitUntil: getWaitUntil(c),
+ *   });
+ *   await next();
+ * });
+ * ```
+ */
+export { getWaitUntil } from '../utils/wait-until';
+
+/**
  * Type for the `waitUntil` function available on Workers execution context.
  * Extends the lifetime of the event past the response.
  */
@@ -54,30 +79,3 @@ export type WaitUntilFn = (promise: Promise<unknown>) => void;
 export type CloudflareEnv<B extends Record<string, unknown> = Record<string, unknown>> = {
   Bindings: B;
 };
-
-/**
- * Extracts the `waitUntil` function from a Hono context's execution context.
- * Bind it to `executionCtx` so it can be passed as a standalone function.
- *
- * @param ctx - The Hono context (must have `executionCtx.waitUntil`)
- * @returns Bound `waitUntil` function
- *
- * @example
- * ```ts
- * import { getWaitUntil } from 'hono-crud/cloudflare';
- * import { registerWebhooks } from 'hono-crud';
- *
- * app.use('*', async (c, next) => {
- *   registerWebhooks({
- *     endpoints: [{ url: 'https://hooks.example.com', events: ['create'] }],
- *     waitUntil: getWaitUntil(c),
- *   });
- *   await next();
- * });
- * ```
- */
-export function getWaitUntil(ctx: {
-  executionCtx: { waitUntil: WaitUntilFn };
-}): WaitUntilFn {
-  return ctx.executionCtx.waitUntil.bind(ctx.executionCtx);
-}

--- a/packages/core/src/utils/wait-until.ts
+++ b/packages/core/src/utils/wait-until.ts
@@ -24,24 +24,3 @@ export function getWaitUntil<E extends Env>(ctx: Context<E>): WaitUntil | undefi
   }
   return undefined;
 }
-
-/**
- * Schedule `fn` to run after the response is sent. Falls back to running
- * inline if no executionCtx is available. Errors are caught and reported via
- * the optional `onError` callback to avoid unhandled rejections.
- */
-export function runAfterResponse<E extends Env>(
-  ctx: Context<E>,
-  fn: () => Promise<unknown>,
-  onError?: (err: unknown) => void,
-): void {
-  const waitUntil = getWaitUntil(ctx);
-  const promise = (async () => {
-    try {
-      await fn();
-    } catch (err) {
-      if (onError) onError(err);
-    }
-  })();
-  if (waitUntil) waitUntil(promise);
-}

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -28,19 +28,9 @@
     "clean": "rm -rf dist .tsup",
     "lint": "biome check src/"
   },
-  "keywords": [
-    "hono",
-    "crud",
-    "drizzle",
-    "drizzle-orm",
-    "adapter"
-  ],
+  "keywords": ["hono", "crud", "drizzle", "drizzle-orm", "adapter"],
   "sideEffects": false,
-  "files": [
-    "dist",
-    "README.md",
-    "LICENSE"
-  ],
+  "files": ["dist", "README.md", "LICENSE", "CHANGELOG.md"],
   "engines": {
     "node": ">=20.19.0"
   },
@@ -63,5 +53,10 @@
     "tsup": "^8.4.0",
     "typescript": "^5.8.3",
     "zod": "^4.3.5"
+  },
+  "peerDependenciesMeta": {
+    "drizzle-zod": {
+      "optional": true
+    }
   }
 }

--- a/packages/drizzle/src/advanced.ts
+++ b/packages/drizzle/src/advanced.ts
@@ -10,13 +10,13 @@ import {
   VersionRollbackEndpoint,
 } from 'hono-crud/internal';
 import { AggregateEndpoint, computeAggregations } from 'hono-crud/internal';
+import { isFilterOperator } from 'hono-crud/internal';
 import { SearchEndpoint, searchInMemory } from 'hono-crud/internal';
 import { ExportEndpoint } from 'hono-crud/internal';
 import { ImportEndpoint } from 'hono-crud/internal';
 import type {
   AggregateOptions,
   AggregateResult,
-  FilterCondition,
   IncludeOptions,
   ListFilters,
   MetaInput,
@@ -604,11 +604,19 @@ export abstract class DrizzleAggregateEndpoint<
     if (options.filters) {
       for (const [field, value] of Object.entries(options.filters)) {
         if (typeof value === 'object' && value !== null) {
-          // Operator syntax
+          // Operator syntax. `op` may be untrusted (it reaches the aggregate
+          // path unvalidated, unlike the list path), so it MUST be validated
+          // before constructing a FilterCondition — `buildWhereCondition`'s
+          // `assertNever` would otherwise throw at runtime. An unrecognized
+          // operator fails closed: a never-true condition that matches nothing.
           for (const [op, opValue] of Object.entries(value as Record<string, unknown>)) {
+            if (!isFilterOperator(op)) {
+              conditions.push(sql`1 = 0`);
+              continue;
+            }
             const condition = buildWhereCondition(table, {
               field,
-              operator: op as FilterCondition['operator'],
+              operator: op,
               value: opValue,
             });
             if (condition) {

--- a/packages/health/package.json
+++ b/packages/health/package.json
@@ -30,7 +30,7 @@
   },
   "keywords": ["hono", "crud", "health", "healthcheck"],
   "sideEffects": false,
-  "files": ["dist", "README.md", "LICENSE"],
+  "files": ["dist", "README.md", "LICENSE", "CHANGELOG.md"],
   "engines": {
     "node": ">=20.19.0"
   },

--- a/packages/idempotency/package.json
+++ b/packages/idempotency/package.json
@@ -28,19 +28,9 @@
     "clean": "rm -rf dist .tsup",
     "lint": "biome check src/"
   },
-  "keywords": [
-    "hono",
-    "crud",
-    "idempotency",
-    "idempotency-key",
-    "retries"
-  ],
+  "keywords": ["hono", "crud", "idempotency", "idempotency-key", "retries"],
   "sideEffects": false,
-  "files": [
-    "dist",
-    "README.md",
-    "LICENSE"
-  ],
+  "files": ["dist", "README.md", "LICENSE", "CHANGELOG.md"],
   "engines": {
     "node": ">=20.19.0"
   },

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -28,21 +28,9 @@
     "clean": "rm -rf dist .tsup",
     "lint": "biome check src/"
   },
-  "keywords": [
-    "hono",
-    "crud",
-    "mcp",
-    "model-context-protocol",
-    "ai",
-    "llm",
-    "tools"
-  ],
+  "keywords": ["hono", "crud", "mcp", "model-context-protocol", "ai", "llm", "tools"],
   "sideEffects": false,
-  "files": [
-    "dist",
-    "README.md",
-    "LICENSE"
-  ],
+  "files": ["dist", "README.md", "LICENSE", "CHANGELOG.md"],
   "engines": {
     "node": ">=20.19.0"
   },

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -28,18 +28,9 @@
     "clean": "rm -rf dist .tsup",
     "lint": "biome check src/"
   },
-  "keywords": [
-    "hono",
-    "crud",
-    "in-memory",
-    "adapter"
-  ],
+  "keywords": ["hono", "crud", "in-memory", "adapter"],
   "sideEffects": false,
-  "files": [
-    "dist",
-    "README.md",
-    "LICENSE"
-  ],
+  "files": ["dist", "README.md", "LICENSE", "CHANGELOG.md"],
   "engines": {
     "node": ">=20.19.0"
   },

--- a/packages/memory/src/advanced.ts
+++ b/packages/memory/src/advanced.ts
@@ -26,6 +26,7 @@ import type {
   SearchResult,
 } from 'hono-crud/internal';
 import type { ModelObject } from 'hono-crud/internal';
+import { isFilterOperator } from 'hono-crud/internal';
 import { matchesFilter } from './filter';
 import { getStore, loadRelations } from './helpers';
 import { isVisible } from './visibility';
@@ -437,37 +438,25 @@ export abstract class MemoryAggregateEndpoint<
       }
     }
 
-    // Apply filters
+    // Apply filters. All operator handling delegates to `matchesFilter` (the
+    // single source of truth shared with list/search/export), which fails CLOSED
+    // on unknown operators. We adapt the aggregate `{ field: { op: value } }`
+    // shape into the `FilterCondition` shape it expects; an operator that isn't a
+    // recognized `FilterOperator` (e.g. from untrusted input) matches nothing
+    // rather than every record.
     if (options.filters) {
       for (const [field, value] of Object.entries(options.filters)) {
         records = records.filter((record) => {
-          // Handle operator syntax: field[op]=value
+          const recordValue = record[field];
+          // Operator syntax: { field: { op: value } }
           if (typeof value === 'object' && value !== null) {
-            for (const [op, opValue] of Object.entries(value as Record<string, unknown>)) {
-              const recordValue = record[field];
-              switch (op) {
-                case 'eq':
-                  return String(recordValue) === String(opValue);
-                case 'ne':
-                  return String(recordValue) !== String(opValue);
-                case 'gt':
-                  return Number(recordValue) > Number(opValue);
-                case 'gte':
-                  return Number(recordValue) >= Number(opValue);
-                case 'lt':
-                  return Number(recordValue) < Number(opValue);
-                case 'lte':
-                  return Number(recordValue) <= Number(opValue);
-                case 'in':
-                  return (opValue as unknown[]).map(String).includes(String(recordValue));
-                default:
-                  return true;
-              }
-            }
-            return true;
+            return Object.entries(value as Record<string, unknown>).every(([op, opValue]) => {
+              if (!isFilterOperator(op)) return false;
+              return matchesFilter(recordValue, { field, operator: op, value: opValue });
+            });
           }
           // Simple equality
-          return String(record[field]) === String(value);
+          return matchesFilter(recordValue, { field, operator: 'eq', value });
         });
       }
     }

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -28,18 +28,9 @@
     "clean": "rm -rf dist .tsup",
     "lint": "biome check src/"
   },
-  "keywords": [
-    "hono",
-    "crud",
-    "prisma",
-    "adapter"
-  ],
+  "keywords": ["hono", "crud", "prisma", "adapter"],
   "sideEffects": false,
-  "files": [
-    "dist",
-    "README.md",
-    "LICENSE"
-  ],
+  "files": ["dist", "README.md", "LICENSE", "CHANGELOG.md"],
   "engines": {
     "node": ">=20.19.0"
   },
@@ -62,6 +53,12 @@
       "optional": true
     },
     "@prisma/client": {
+      "optional": true
+    },
+    "pluralize": {
+      "optional": true
+    },
+    "fastest-levenshtein": {
       "optional": true
     }
   },

--- a/packages/prisma/src/advanced.ts
+++ b/packages/prisma/src/advanced.ts
@@ -8,6 +8,8 @@ import {
   VersionRollbackEndpoint,
 } from 'hono-crud/internal';
 import { AggregateEndpoint, computeAggregations } from 'hono-crud/internal';
+import { isFilterOperator } from 'hono-crud/internal';
+import { NotFoundException } from 'hono-crud/internal';
 import { SearchEndpoint, searchInMemory } from 'hono-crud/internal';
 import { ExportEndpoint } from 'hono-crud/internal';
 import { ImportEndpoint } from 'hono-crud/internal';
@@ -15,6 +17,7 @@ import type {
   AggregateField,
   AggregateOptions,
   AggregateResult,
+  FilterCondition,
   IncludeOptions,
   ListFilters,
   MetaInput,
@@ -484,7 +487,7 @@ export abstract class PrismaVersionRollbackEndpoint<
     });
 
     if (!existing) {
-      throw new Error(`Record not found: ${lookupValue}`);
+      throw new NotFoundException(this._meta.model.tableName, lookupValue);
     }
 
     // Update the record with version data and new version number
@@ -523,6 +526,13 @@ export abstract class PrismaAggregateEndpoint<
 
   /**
    * Builds the where clause for aggregation queries.
+   *
+   * Filter operators reach this path UNVALIDATED (unlike the list path, which
+   * runs through allow-listed query parsing), so each operator is checked with
+   * `isFilterOperator` and conversion is delegated to the canonical
+   * `buildPrismaWhere` rather than a duplicated inline switch. A field carrying
+   * any unrecognized operator fails CLOSED — it matches NOTHING (`{ in: [] }`)
+   * instead of forwarding an arbitrary operator string into the Prisma query.
    */
   protected async buildAggregateWhere(options: AggregateOptions): Promise<Record<string, unknown>> {
     const where: Record<string, unknown> = {};
@@ -540,45 +550,34 @@ export abstract class PrismaAggregateEndpoint<
 
     // Apply filters
     if (options.filters) {
+      const conditions: FilterCondition[] = [];
+      const matchNothingFields: string[] = [];
+
       for (const [field, value] of Object.entries(options.filters)) {
         if (typeof value === 'object' && value !== null) {
-          // Operator syntax - convert to Prisma format
-          const prismaCondition: Record<string, unknown> = {};
-          for (const [op, opValue] of Object.entries(value as Record<string, unknown>)) {
-            switch (op) {
-              case 'eq':
-                prismaCondition.equals = opValue;
-                break;
-              case 'ne':
-                prismaCondition.not = opValue;
-                break;
-              case 'gt':
-                prismaCondition.gt = opValue;
-                break;
-              case 'gte':
-                prismaCondition.gte = opValue;
-                break;
-              case 'lt':
-                prismaCondition.lt = opValue;
-                break;
-              case 'lte':
-                prismaCondition.lte = opValue;
-                break;
-              case 'in':
-                prismaCondition.in = opValue;
-                break;
-              case 'nin':
-                prismaCondition.notIn = opValue;
-                break;
-              default:
-                prismaCondition[op] = opValue;
+          // Operator syntax: { field: { op: value } }
+          const ops = Object.entries(value as Record<string, unknown>);
+          if (ops.some(([op]) => !isFilterOperator(op))) {
+            matchNothingFields.push(field);
+            continue;
+          }
+          for (const [op, opValue] of ops) {
+            // `isFilterOperator` narrowed every `op` above.
+            if (isFilterOperator(op)) {
+              conditions.push({ field, operator: op, value: opValue });
             }
           }
-          where[field] = prismaCondition;
         } else {
           // Simple equality
-          where[field] = value;
+          conditions.push({ field, operator: 'eq', value });
         }
+      }
+
+      Object.assign(where, buildPrismaWhere(conditions));
+
+      // A field with an unrecognized operator matches nothing.
+      for (const field of matchNothingFields) {
+        where[field] = { in: [] };
       }
     }
 

--- a/packages/prisma/src/helpers.ts
+++ b/packages/prisma/src/helpers.ts
@@ -112,66 +112,87 @@ export function coerceValue(value: unknown): unknown {
 }
 
 /**
- * Converts filter conditions to Prisma where clause.
+ * Converts a single filter condition to its Prisma where value (the right-hand
+ * side keyed by `filter.field`). Exhaustive over `FilterOperator` so a new
+ * operator must be handled here; the `assertNever` default is unreachable at
+ * runtime because operators are validated upstream (`parseFilterValue` /
+ * allow-listed query parsing) before reaching an adapter.
+ */
+function filterToPrismaValue(filter: FilterCondition): unknown {
+  const value = coerceValue(filter.value);
+
+  switch (filter.operator) {
+    case 'eq':
+      return value;
+    case 'ne':
+      return { not: value };
+    case 'gt':
+      return { gt: value };
+    case 'gte':
+      return { gte: value };
+    case 'lt':
+      return { lt: value };
+    case 'lte':
+      return { lte: value };
+    case 'in': {
+      const arr = Array.isArray(filter.value) ? filter.value : [filter.value];
+      return { in: arr.map(coerceValue) };
+    }
+    case 'nin': {
+      const arr = Array.isArray(filter.value) ? filter.value : [filter.value];
+      return { notIn: arr.map(coerceValue) };
+    }
+    case 'like':
+      return { contains: String(filter.value).replace(/%/g, '') };
+    case 'ilike':
+      return {
+        contains: String(filter.value).replace(/%/g, ''),
+        mode: 'insensitive',
+      };
+    case 'null':
+      return filter.value ? null : { not: null };
+    case 'between': {
+      const [min, max] = filter.value as [unknown, unknown];
+      return { gte: coerceValue(min), lte: coerceValue(max) };
+    }
+    default:
+      return assertNever(filter.operator);
+  }
+}
+
+/**
+ * Converts filter conditions to a Prisma where clause.
+ *
+ * Multiple conditions on the SAME field (e.g. `views[gte]` + `views[lte]`, which
+ * `parseListFilters` emits as two separate `FilterCondition`s) must be ANDed,
+ * not overwritten. A field with a single condition is keyed directly; a field
+ * with two or more conditions emits each into a top-level `AND: [...]` array
+ * (Prisma combines top-level `AND` entries conjunctively) so none is lost.
  */
 export function buildPrismaWhere(filters: FilterCondition[]): Record<string, unknown> {
-  const where: Record<string, unknown> = {};
-
+  // Preserve input order while grouping every condition by its field.
+  const byField = new Map<string, unknown[]>();
   for (const filter of filters) {
-    const value = coerceValue(filter.value);
+    const conditions = byField.get(filter.field) ?? [];
+    conditions.push(filterToPrismaValue(filter));
+    byField.set(filter.field, conditions);
+  }
 
-    switch (filter.operator) {
-      case 'eq':
-        where[filter.field] = value;
-        break;
-      case 'ne':
-        where[filter.field] = { not: value };
-        break;
-      case 'gt':
-        where[filter.field] = { gt: value };
-        break;
-      case 'gte':
-        where[filter.field] = { gte: value };
-        break;
-      case 'lt':
-        where[filter.field] = { lt: value };
-        break;
-      case 'lte':
-        where[filter.field] = { lte: value };
-        break;
-      case 'in': {
-        const arr = Array.isArray(filter.value) ? filter.value : [filter.value];
-        where[filter.field] = { in: arr.map(coerceValue) };
-        break;
+  const where: Record<string, unknown> = {};
+  const and: Record<string, unknown>[] = [];
+
+  for (const [field, conditions] of byField) {
+    if (conditions.length === 1) {
+      where[field] = conditions[0];
+    } else {
+      for (const condition of conditions) {
+        and.push({ [field]: condition });
       }
-      case 'nin': {
-        const arr = Array.isArray(filter.value) ? filter.value : [filter.value];
-        where[filter.field] = { notIn: arr.map(coerceValue) };
-        break;
-      }
-      case 'like':
-        where[filter.field] = { contains: String(filter.value).replace(/%/g, '') };
-        break;
-      case 'ilike':
-        where[filter.field] = {
-          contains: String(filter.value).replace(/%/g, ''),
-          mode: 'insensitive',
-        };
-        break;
-      case 'null':
-        where[filter.field] = filter.value ? null : { not: null };
-        break;
-      case 'between': {
-        const [min, max] = filter.value as [unknown, unknown];
-        where[filter.field] = { gte: coerceValue(min), lte: coerceValue(max) };
-        break;
-      }
-      default:
-        // Exhaustive over FilterOperator: a new operator must be handled here.
-        // Unreachable at runtime — operators are validated upstream
-        // (`parseFilterValue` / allow-listed query parsing) before reaching an adapter.
-        assertNever(filter.operator);
     }
+  }
+
+  if (and.length > 0) {
+    where.AND = and;
   }
 
   return where;

--- a/packages/rate-limit/package.json
+++ b/packages/rate-limit/package.json
@@ -28,21 +28,9 @@
     "clean": "rm -rf dist .tsup",
     "lint": "biome check src/"
   },
-  "keywords": [
-    "hono",
-    "crud",
-    "rate-limit",
-    "ratelimit",
-    "throttle",
-    "redis",
-    "kv"
-  ],
+  "keywords": ["hono", "crud", "rate-limit", "ratelimit", "throttle", "redis", "kv"],
   "sideEffects": false,
-  "files": [
-    "dist",
-    "README.md",
-    "LICENSE"
-  ],
+  "files": ["dist", "README.md", "LICENSE", "CHANGELOG.md"],
   "engines": {
     "node": ">=20.19.0"
   },

--- a/packages/scalar/package.json
+++ b/packages/scalar/package.json
@@ -28,19 +28,9 @@
     "clean": "rm -rf dist .tsup",
     "lint": "biome check src/"
   },
-  "keywords": [
-    "hono",
-    "crud",
-    "scalar",
-    "openapi",
-    "docs"
-  ],
+  "keywords": ["hono", "crud", "scalar", "openapi", "docs"],
   "sideEffects": false,
-  "files": [
-    "dist",
-    "README.md",
-    "LICENSE"
-  ],
+  "files": ["dist", "README.md", "LICENSE", "CHANGELOG.md"],
   "engines": {
     "node": ">=20.19.0"
   },

--- a/packages/swagger/package.json
+++ b/packages/swagger/package.json
@@ -30,7 +30,7 @@
   },
   "keywords": ["hono", "crud", "swagger", "openapi", "redoc", "docs"],
   "sideEffects": false,
-  "files": ["dist", "README.md", "LICENSE"],
+  "files": ["dist", "README.md", "LICENSE", "CHANGELOG.md"],
   "engines": {
     "node": ">=20.19.0"
   },

--- a/packages/swagger/src/index.ts
+++ b/packages/swagger/src/index.ts
@@ -11,7 +11,7 @@ export interface UIOptions {
    */
   redocPath?: string;
   /**
-   * Path to serve Scalar (default: '/scalar')
+   * Path to serve Scalar (default: '/reference')
    */
   scalarPath?: string;
   /**
@@ -71,7 +71,7 @@ export function setupDocsIndex<E extends Env>(
     indexPath = '/',
     docsPath = '/docs',
     redocPath = '/redoc',
-    scalarPath = '/scalar',
+    scalarPath = '/reference',
     specPath = '/openapi.json',
     title = 'API Documentation',
   } = options;

--- a/tests/aggregate.test.ts
+++ b/tests/aggregate.test.ts
@@ -433,4 +433,66 @@ describe('Aggregations', () => {
       expect(result.result.groups.length).toBeGreaterThan(3);
     });
   });
+
+  // Operator-object filter shape (`{ field: { op: value } }`) is not reachable
+  // through plain query strings, so these call `aggregate()` directly via a route
+  // that exposes the endpoint instance with a live Hono context.
+  describe('MemoryAggregateEndpoint operator filters', () => {
+    let app: Hono;
+
+    beforeEach(() => {
+      app = new Hono();
+
+      app.onError((err, c) => {
+        return c.json({ success: false, error: { message: err.message } }, 400);
+      });
+
+      // Crafted filters are passed as a JSON-encoded `filters` query param so the
+      // operator-object shape survives into the endpoint, which then runs
+      // aggregate() against it directly.
+      app.get('/products/aggregate-filtered', async (c) => {
+        const endpoint = new ProductAggregate();
+        endpoint.setContext(c);
+        const filters = JSON.parse(c.req.query('filters') ?? '{}') as Record<string, unknown>;
+        const result = await endpoint.aggregate({
+          aggregations: [{ operation: 'count', field: '*' }],
+          filters,
+        });
+        return c.json({ result });
+      });
+    });
+
+    it('should match NOTHING for an unknown/unsupported operator (fail-closed)', async () => {
+      const filters = encodeURIComponent(JSON.stringify({ price: { bogus: 999 } }));
+      const response = await app.request(`/products/aggregate-filtered?filters=${filters}`);
+
+      expect(response.status).toBe(200);
+      const result = (await response.json()) as { result: { values: Record<string, number> } };
+      // An unrecognized operator must filter out every record, not match all of
+      // them (the previous inline switch failed OPEN with `default: return true`).
+      expect(result.result.values.count).toBe(0);
+    });
+
+    it('should support operators the inline switch lacked (e.g. between)', async () => {
+      const filters = encodeURIComponent(JSON.stringify({ price: { between: [100, 600] } }));
+      const response = await app.request(`/products/aggregate-filtered?filters=${filters}`);
+
+      expect(response.status).toBe(200);
+      const result = (await response.json()) as { result: { values: Record<string, number> } };
+      // Phone (599), Tablet (399), Desk (299), Chair (199) are within [100, 600].
+      expect(result.result.values.count).toBe(4);
+    });
+
+    it('should support nin (not-in), also missing from the inline switch', async () => {
+      const filters = encodeURIComponent(
+        JSON.stringify({ category: { nin: ['electronics', 'books'] } }),
+      );
+      const response = await app.request(`/products/aggregate-filtered?filters=${filters}`);
+
+      expect(response.status).toBe(200);
+      const result = (await response.json()) as { result: { values: Record<string, number> } };
+      // Only the 3 furniture rows remain.
+      expect(result.result.values.count).toBe(3);
+    });
+  });
 });

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -22,7 +22,7 @@ import {
 } from '@hono-crud/memory';
 import { Hono } from 'hono';
 import { fromHono, registerCrud } from 'hono-crud';
-import type { MetaInput, Model } from 'hono-crud';
+import type { MetaInput, Model, ResponseEnvelope } from 'hono-crud';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 
@@ -548,11 +548,7 @@ describe('withCache Mixin', () => {
     async handle(): Promise<Response> {
       const cached = await this.getCachedResponse<UserItem[]>();
       if (cached) {
-        return this.jsonWithCache({
-          success: true,
-          result: cached,
-          result_info: { page: 1, per_page: 20 },
-        });
+        return this.successPaginatedWithCache(cached, { page: 1, per_page: 20 });
       }
 
       const response = await super.handle();
@@ -562,7 +558,7 @@ describe('withCache Mixin', () => {
         await this.setCachedResponse(data.result);
 
         // Return with cache header
-        return this.jsonWithCache(data);
+        return this.successPaginatedWithCache(data.result, data.result_info);
       }
 
       return response;
@@ -743,11 +739,7 @@ describe('withCacheInvalidation Mixin', () => {
     async handle(): Promise<Response> {
       const cached = await this.getCachedResponse<UserItem[]>();
       if (cached) {
-        return this.jsonWithCache({
-          success: true,
-          result: cached,
-          result_info: { page: 1, per_page: 20 },
-        });
+        return this.successPaginatedWithCache(cached, { page: 1, per_page: 20 });
       }
 
       const response = await super.handle();
@@ -756,7 +748,7 @@ describe('withCacheInvalidation Mixin', () => {
         const data = await response.clone().json();
         await this.setCachedResponse(data.result);
 
-        return this.jsonWithCache(data);
+        return this.successPaginatedWithCache(data.result, data.result_info);
       }
 
       return response;
@@ -937,5 +929,155 @@ describe('Global Cache Storage', () => {
 
     // Reset to default
     setCacheStorage(new MemoryCacheStorage());
+  });
+});
+
+// ============================================================================
+// Cache + responseEnvelope: HIT and MISS must share the configured shape
+// ============================================================================
+
+describe('withCache + responseEnvelope', () => {
+  // RFC-7807-ish envelope, observably different from the legacy
+  // `{ success, result }` shape so any leak of the default body is caught.
+  const dataEnvelope: ResponseEnvelope = {
+    success: (result, info) => (info ? { data: result, meta: info } : { data: result }),
+    error: (err) => ({ error: err }),
+  };
+
+  // Read endpoint: BOTH MISS and HIT route their body through the cache
+  // helper. The helper must apply the configured envelope so the two share
+  // one shape. `setCachedResponse` stores the raw row, not a serialised body.
+  class CachedUserRead extends withCache(MemoryReadEndpoint) {
+    _meta = userMeta;
+    cacheConfig = { ttl: 300 };
+
+    async handle(): Promise<Response> {
+      const cached = await this.getCachedResponse<UserItem>();
+      if (cached) {
+        return this.successWithCache(cached);
+      }
+
+      const response = await super.handle();
+      if (response.status === 200) {
+        // Read the raw row from inside the envelope-applied body, store the
+        // raw row, then re-emit via the cache helper.
+        const data = (await response.clone().json()) as { data: UserItem };
+        await this.setCachedResponse(data.data);
+        return this.successWithCache(data.data);
+      }
+      return response;
+    }
+  }
+
+  // List endpoint: BOTH MISS and HIT route through successPaginatedWithCache
+  // so the configured envelope (with pagination `info`) is applied uniformly.
+  class CachedUserList extends withCache(MemoryListEndpoint) {
+    _meta = userMeta;
+    cacheConfig = { ttl: 300, keyFields: ['page', 'per_page'] };
+
+    async handle(): Promise<Response> {
+      const cached = await this.getCachedResponse<UserItem[]>();
+      if (cached) {
+        return this.successPaginatedWithCache(cached, { page: 1, per_page: 20 });
+      }
+
+      const response = await super.handle();
+      if (response.status === 200) {
+        const data = (await response.clone().json()) as {
+          data: UserItem[];
+          meta: { page: number; per_page: number };
+        };
+        await this.setCachedResponse(data.data);
+        return this.successPaginatedWithCache(data.data, data.meta);
+      }
+      return response;
+    }
+  }
+
+  class UserCreate extends MemoryCreateEndpoint<any, UserMeta> {
+    _meta = userMeta;
+  }
+
+  let app: ReturnType<typeof fromHono>;
+  let cacheStorage: MemoryCacheStorage;
+
+  beforeEach(() => {
+    clearStorage();
+    cacheStorage = new MemoryCacheStorage();
+    setCacheStorage(cacheStorage);
+
+    app = fromHono(new Hono());
+    registerCrud(
+      app,
+      '/users',
+      {
+        create: UserCreate as any,
+        list: CachedUserList as any,
+        read: CachedUserRead as any,
+      },
+      { responseEnvelope: dataEnvelope },
+    );
+  });
+
+  afterEach(() => {
+    cacheStorage.clear();
+  });
+
+  it('read: MISS and HIT bodies share the configured envelope shape', async () => {
+    const createRes = await app.request('/users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'John', email: 'john@example.com' }),
+    });
+    const { data: user } = await createRes.json();
+
+    const missRes = await app.request(`/users/${user.id}`);
+    expect(missRes.headers.get('X-Cache')).toBe('MISS');
+    const missBody = await missRes.json();
+
+    const hitRes = await app.request(`/users/${user.id}`);
+    expect(hitRes.headers.get('X-Cache')).toBe('HIT');
+    const hitBody = await hitRes.json();
+
+    // The envelope shape is honoured on MISS...
+    expect(missBody).toEqual({
+      data: { id: user.id, name: 'John', email: 'john@example.com', status: 'active' },
+    });
+    // ...and the HIT must match it byte-for-byte (no default-shape leak).
+    expect(hitBody).toEqual(missBody);
+    expect(hitBody.success).toBeUndefined();
+    expect(hitBody.result).toBeUndefined();
+  });
+
+  it('list: MISS and HIT bodies share the configured envelope shape', async () => {
+    await app.request('/users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'John', email: 'john@example.com' }),
+    });
+
+    const missRes = await app.request('/users');
+    expect(missRes.headers.get('X-Cache')).toBe('MISS');
+    const missBody = await missRes.json();
+
+    const hitRes = await app.request('/users');
+    expect(hitRes.headers.get('X-Cache')).toBe('HIT');
+    const hitBody = await hitRes.json();
+
+    // MISS honours the envelope: `{ data: [...], meta: {...} }`, no legacy keys.
+    expect(Array.isArray(missBody.data)).toBe(true);
+    expect(missBody.data.length).toBe(1);
+    expect(missBody.meta).toBeDefined();
+    expect(missBody.success).toBeUndefined();
+    expect(missBody.result).toBeUndefined();
+    expect(missBody.result_info).toBeUndefined();
+
+    // HIT must carry the same envelope-shaped body (no default-shape leak).
+    expect(Array.isArray(hitBody.data)).toBe(true);
+    expect(hitBody.data).toEqual(missBody.data);
+    expect(hitBody.meta).toBeDefined();
+    expect(hitBody.success).toBeUndefined();
+    expect(hitBody.result).toBeUndefined();
+    expect(hitBody.result_info).toBeUndefined();
   });
 });

--- a/tests/class-sort-fields.test.ts
+++ b/tests/class-sort-fields.test.ts
@@ -1,0 +1,68 @@
+import { MemoryCreateEndpoint, MemoryListEndpoint, clearStorage } from '@hono-crud/memory';
+import { Hono } from 'hono';
+import { fromHono, registerCrud } from 'hono-crud';
+import type { MetaInput, Model, SortSpec } from 'hono-crud';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+// Regression: class-based ListEndpoint subclasses must configure sorting via the
+// canonical `sortFields` / `defaultSort` fields that the base ListEndpoint reads.
+// The `orderByFields` / `defaultOrderBy` / `defaultOrderDirection` names only
+// exist as aliases inside the functional createList() config — as class fields
+// they are silently ignored, so sorting is dead.
+
+const ItemSchema = z.object({
+  id: z.uuid(),
+  name: z.string().min(1),
+});
+
+type ItemMeta = MetaInput<typeof ItemSchema>;
+
+const itemMeta: ItemMeta = {
+  model: {
+    tableName: 'sort_items',
+    schema: ItemSchema,
+    primaryKeys: ['id'],
+  } satisfies Model<typeof ItemSchema>,
+};
+
+class ItemCreate extends MemoryCreateEndpoint<Record<string, never>, ItemMeta> {
+  _meta = itemMeta;
+}
+
+class ItemList extends MemoryListEndpoint<Record<string, never>, ItemMeta> {
+  _meta = itemMeta;
+  // Canonical fields that the base ListEndpoint actually reads.
+  sortFields = ['name'];
+  defaultSort: SortSpec = { field: 'name', order: 'desc' };
+}
+
+describe('class-based sort configuration', () => {
+  let app: ReturnType<typeof fromHono>;
+
+  beforeEach(async () => {
+    clearStorage();
+    app = fromHono(new Hono());
+    registerCrud(app, '/items', {
+      create: ItemCreate as never,
+      list: ItemList as never,
+    });
+
+    for (const name of ['banana', 'apple', 'cherry']) {
+      await app.request('/items', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name }),
+      });
+    }
+  });
+
+  it('applies defaultSort when no sort query param is provided', async () => {
+    const res = await app.request('/items');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const names = body.result.map((r: { name: string }) => r.name);
+    // descending by name → cherry, banana, apple (NOT insertion order)
+    expect(names).toEqual(['cherry', 'banana', 'apple']);
+  });
+});

--- a/tests/drizzle.test.ts
+++ b/tests/drizzle.test.ts
@@ -17,7 +17,7 @@ import { sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/libsql';
 import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 import { Hono } from 'hono';
-import { defineModel, fromHono, registerCrud } from 'hono-crud';
+import { type AggregateOptions, defineModel, fromHono, registerCrud } from 'hono-crud';
 /**
  * Tests for Drizzle ORM adapter.
  * Uses SQLite via libsql for testing.
@@ -197,6 +197,27 @@ class PostAggregate extends DrizzleAggregateEndpoint {
   };
 }
 
+// Operator-syntax aggregate filters ({ field: { op: value } }) cannot be
+// produced from a flat query string, so this endpoint injects them directly to
+// exercise the aggregate filter conversion path (buildWhereCondition).
+let injectedAggregateFilters: AggregateOptions['filters'];
+
+class PostAggregateFiltered extends DrizzleAggregateEndpoint {
+  _meta = { model: PostModel };
+  db = db as unknown as DrizzleDatabase;
+
+  aggregateConfig = {
+    sumFields: ['views'],
+    avgFields: ['views'],
+    minMaxFields: ['views'],
+  };
+
+  protected async getAggregateOptions(): Promise<AggregateOptions> {
+    const base = await super.getAggregateOptions();
+    return { ...base, filters: injectedAggregateFilters };
+  }
+}
+
 // ============================================================================
 // App Setup
 // ============================================================================
@@ -236,6 +257,7 @@ function createApp() {
   // Post endpoints
   // Note: aggregate must be before :id to avoid conflict
   app.get('/posts/aggregate', withContext(PostAggregate));
+  app.get('/posts/aggregate-filtered', withContext(PostAggregateFiltered));
   app.post('/posts', withContext(PostCreate));
   app.get('/posts', withContext(PostList));
   app.get('/posts/:id', withContext(PostRead));
@@ -715,6 +737,46 @@ describe('Drizzle Adapter', () => {
       const result = (await response.json()) as { result: { groups: unknown[] } };
 
       expect(result.result.groups).toHaveLength(2);
+    });
+  });
+
+  describe('Aggregate operator-syntax filters', () => {
+    beforeEach(async () => {
+      const user = await db
+        .insert(usersTable)
+        .values({
+          id: crypto.randomUUID(),
+          name: 'Author',
+          email: 'author@example.com',
+          role: 'user',
+        })
+        .returning();
+
+      await db.insert(postsTable).values([
+        { id: crypto.randomUUID(), title: 'Post 1', authorId: user[0].id, views: 100 },
+        { id: crypto.randomUUID(), title: 'Post 2', authorId: user[0].id, views: 200 },
+        { id: crypto.randomUUID(), title: 'Post 3', authorId: user[0].id, views: 50 },
+      ]);
+    });
+
+    it('honors a documented operator (gte) in aggregate filters', async () => {
+      injectedAggregateFilters = { views: { gte: 100 } };
+      const response = await app.request('/posts/aggregate-filtered?count=*');
+
+      expect(response.status).toBe(200);
+      const result = (await response.json()) as { result: { values: { count: number } } };
+      // Two posts have views >= 100 (100 and 200).
+      expect(result.result.values.count).toBe(2);
+    });
+
+    it('matches nothing (count 0, HTTP 200) for an unknown operator instead of throwing', async () => {
+      // An unknown/untrusted operator must fail closed, not throw assertNever -> 500.
+      injectedAggregateFilters = { views: { contains: 100 } as Record<string, unknown> };
+      const response = await app.request('/posts/aggregate-filtered?count=*');
+
+      expect(response.status).toBe(200);
+      const result = (await response.json()) as { result: { values: { count: number } } };
+      expect(result.result.values.count).toBe(0);
     });
   });
 

--- a/tests/logging.test.ts
+++ b/tests/logging.test.ts
@@ -689,7 +689,9 @@ describe('Logging Middleware', () => {
       await new Promise((r) => setTimeout(r, 50));
 
       const logs = await storage.query({});
-      expect(logs[0].response.responseTimeMs).toBeGreaterThanOrEqual(50);
+      // Tolerance below the 50ms sleep: Date.now() truncates to whole ms on
+      // both reads, so the measured delta can land 1-2ms under the slept time.
+      expect(logs[0].response.responseTimeMs).toBeGreaterThanOrEqual(45);
     });
   });
 

--- a/tests/prisma.test.ts
+++ b/tests/prisma.test.ts
@@ -13,12 +13,22 @@ import {
   PrismaSearchEndpoint,
   PrismaUpdateEndpoint,
   PrismaUpsertEndpoint,
+  PrismaVersionRollbackEndpoint,
   clearPrismaModelMappings,
   registerPrismaModelMapping,
   registerPrismaModelMappings,
 } from '@hono-crud/prisma';
 import { Hono } from 'hono';
-import { defineModel, fromHono, registerCrud } from 'hono-crud';
+import {
+  type AggregateOptions,
+  MemoryVersioningStorage,
+  createVersionManager,
+  defineModel,
+  fromHono,
+  getVersioningConfig,
+  registerCrud,
+  setVersioningStorage,
+} from 'hono-crud';
 /**
  * Tests for Prisma ORM adapter.
  * Uses a mock Prisma client for testing without requiring a real database.
@@ -57,9 +67,43 @@ function clearMockStorage() {
   postStorage = [];
 }
 
+// Predicate per Prisma field-operator: returns true when the condition HOLDS for
+// `fieldVal`. `mode` is a modifier on `contains` (already case-folded) so it is a
+// no-op. Any operator key NOT in this map is unknown — the adapter must never
+// emit one — and is treated as a non-match so a leak is observable.
+const FIELD_OP_PREDICATES: Record<string, (fieldVal: unknown, opVal: unknown) => boolean> = {
+  not: (fieldVal, opVal) =>
+    opVal === null ? fieldVal !== null && fieldVal !== undefined : fieldVal !== opVal,
+  in: (fieldVal, opVal) => (opVal as unknown[]).includes(fieldVal),
+  notIn: (fieldVal, opVal) => !(opVal as unknown[]).includes(fieldVal),
+  gt: (fieldVal, opVal) => (fieldVal as number) > (opVal as number),
+  gte: (fieldVal, opVal) => (fieldVal as number) >= (opVal as number),
+  lt: (fieldVal, opVal) => (fieldVal as number) < (opVal as number),
+  lte: (fieldVal, opVal) => (fieldVal as number) <= (opVal as number),
+  equals: (fieldVal, opVal) => fieldVal === opVal,
+  contains: (fieldVal, opVal) =>
+    String(fieldVal ?? '')
+      .toLowerCase()
+      .includes(String(opVal).toLowerCase()),
+  mode: () => true,
+};
+
+// Evaluate a single Prisma field-condition object (e.g. { gte: 100, lte: 200 })
+// against a record value. Models real Prisma semantics where every operator key
+// present must hold (an empty object matches everything).
+function matchesFieldCondition(fieldVal: unknown, cond: Record<string, unknown>): boolean {
+  return Object.entries(cond).every(([op, opVal]) => {
+    const predicate = FIELD_OP_PREDICATES[op];
+    return predicate ? predicate(fieldVal, opVal) : false;
+  });
+}
+
 function matchesWhere(record: MockRecord, where: Record<string, unknown>): boolean {
   for (const [key, value] of Object.entries(where)) {
-    if (key === 'OR') {
+    if (key === 'AND') {
+      const andConditions = value as Record<string, unknown>[];
+      if (!andConditions.every((cond) => matchesWhere(record, cond))) return false;
+    } else if (key === 'OR') {
       const orConditions = value as Record<string, unknown>[];
       const matches = orConditions.some((cond) => {
         for (const [ck, cv] of Object.entries(cond)) {
@@ -75,27 +119,8 @@ function matchesWhere(record: MockRecord, where: Record<string, unknown>): boole
     } else if (value === null) {
       // value === null means we want records where field IS NULL
       if (record[key] !== null && record[key] !== undefined) return false;
-    } else if (typeof value === 'object' && value !== null && 'not' in value) {
-      if ((value as { not: unknown }).not === null) {
-        // { not: null } means we want records where field IS NOT NULL
-        if (record[key] === null || record[key] === undefined) return false;
-      } else {
-        if (record[key] === (value as { not: unknown }).not) return false;
-      }
-    } else if (typeof value === 'object' && value !== null && 'in' in value) {
-      if (!(value as { in: unknown[] }).in.includes(record[key])) return false;
-    } else if (typeof value === 'object' && value !== null && 'gt' in value) {
-      if ((record[key] as number) <= (value as { gt: number }).gt) return false;
-    } else if (typeof value === 'object' && value !== null && 'gte' in value) {
-      if ((record[key] as number) < (value as { gte: number }).gte) return false;
-    } else if (typeof value === 'object' && value !== null && 'lt' in value) {
-      if ((record[key] as number) >= (value as { lt: number }).lt) return false;
-    } else if (typeof value === 'object' && value !== null && 'lte' in value) {
-      if ((record[key] as number) > (value as { lte: number }).lte) return false;
-    } else if (typeof value === 'object' && value !== null && 'contains' in value) {
-      const searchVal = (value as { contains: string; mode?: string }).contains.toLowerCase();
-      const fieldVal = String(record[key] || '').toLowerCase();
-      if (!fieldVal.includes(searchVal)) return false;
+    } else if (typeof value === 'object' && value !== null) {
+      if (!matchesFieldCondition(record[key], value as Record<string, unknown>)) return false;
     } else if (record[key] !== value) {
       return false;
     }
@@ -328,6 +353,13 @@ const PostModel = defineModel({
   },
 });
 
+const VersionedUserModel = defineModel({
+  tableName: 'users',
+  schema: UserSchema.extend({ version: z.number().default(1) }),
+  primaryKeys: ['id'],
+  versioning: { enabled: true, field: 'version' },
+});
+
 // ============================================================================
 // Endpoint Classes
 // ============================================================================
@@ -429,6 +461,13 @@ class UserClone extends PrismaCloneEndpoint {
   }
 }
 
+class UserVersionRollback extends PrismaVersionRollbackEndpoint {
+  _meta = { model: VersionedUserModel };
+  get prisma() {
+    return mockPrisma;
+  }
+}
+
 class PostCreate extends PrismaCreateEndpoint {
   _meta = { model: PostModel };
   get prisma() {
@@ -444,6 +483,17 @@ class PostList extends PrismaListEndpoint {
   orderByFields = ['title', 'views'];
 }
 
+// Allows range filters on `views` so two operators land on the SAME field,
+// exercising the per-field merge in buildPrismaWhere.
+class PostListRanged extends PrismaListEndpoint {
+  _meta = { model: PostModel };
+  get prisma() {
+    return mockPrisma;
+  }
+  orderByFields = ['title', 'views'];
+  filterConfig = { views: ['gte' as const, 'lte' as const] };
+}
+
 class PostAggregate extends PrismaAggregateEndpoint {
   _meta = { model: PostModel };
   get prisma() {
@@ -457,6 +507,33 @@ class PostAggregate extends PrismaAggregateEndpoint {
     countDistinctFields: ['authorId'],
     groupByFields: ['authorId'],
   };
+}
+
+// Operator-syntax aggregate filters ({ field: { op: value } }) cannot be
+// produced from a flat query string, so this endpoint injects them directly to
+// exercise the aggregate filter -> Prisma where conversion path.
+let injectedAggregateFilters: AggregateOptions['filters'];
+
+class PostAggregateFiltered extends PrismaAggregateEndpoint {
+  _meta = { model: PostModel };
+  get prisma() {
+    return mockPrisma;
+  }
+
+  // The mock Prisma model has no `aggregate`/`groupBy` methods, so native
+  // aggregation throws and the endpoint falls back to findMany({ where }) +
+  // in-memory computation — which means the built where clause is actually
+  // evaluated by the mock's matchesWhere.
+  aggregateConfig = {
+    sumFields: ['views'],
+    avgFields: ['views'],
+    minMaxFields: ['views'],
+  };
+
+  protected async getAggregateOptions(): Promise<AggregateOptions> {
+    const base = await super.getAggregateOptions();
+    return { ...base, filters: injectedAggregateFilters };
+  }
 }
 
 // ============================================================================
@@ -512,11 +589,14 @@ function createApp() {
   app.delete('/users/:id', withContext(UserDelete));
   app.post('/users/:id/restore', withContext(UserRestore));
   app.post('/users/:id/clone', withContext(UserClone));
+  app.post('/users/:id/versions/:version/rollback', withContext(UserVersionRollback));
 
   // Post endpoints
   app.get('/posts/aggregate', withContext(PostAggregate));
+  app.get('/posts/aggregate-filtered', withContext(PostAggregateFiltered));
   app.post('/posts', withContext(PostCreate));
   app.get('/posts', withContext(PostList));
+  app.get('/posts-ranged', withContext(PostListRanged));
 
   return app;
 }
@@ -1041,6 +1121,63 @@ describe('Prisma Adapter', () => {
     });
   });
 
+  describe('Aggregate operator-syntax filters', () => {
+    beforeEach(() => {
+      postStorage.push(
+        { id: crypto.randomUUID(), title: 'Post 1', authorId: 'a1', views: 100 },
+        { id: crypto.randomUUID(), title: 'Post 2', authorId: 'a1', views: 200 },
+        { id: crypto.randomUUID(), title: 'Post 3', authorId: 'a1', views: 50 },
+      );
+    });
+
+    it('honors the documented between operator (mishandled by the old switch)', async () => {
+      injectedAggregateFilters = { views: { between: [75, 150] } };
+      const response = await app.request('/posts/aggregate-filtered?count=*');
+
+      expect(response.status).toBe(200);
+      const result = (await response.json()) as { result: { values: { count: number } } };
+      // Only the views=100 post is in [75, 150].
+      expect(result.result.values.count).toBe(1);
+    });
+
+    it('ANDs multiple operators on the same field instead of overwriting', async () => {
+      injectedAggregateFilters = { views: { gte: 100, lte: 200 } };
+      const response = await app.request('/posts/aggregate-filtered?count=*');
+
+      expect(response.status).toBe(200);
+      const result = (await response.json()) as { result: { values: { count: number } } };
+      // Posts with 100 <= views <= 200: the 100 and 200 posts (the 50 is excluded).
+      // A regression that drops the gte would also count the 50 post (=3).
+      expect(result.result.values.count).toBe(2);
+    });
+
+    it('matches nothing for an unknown/untrusted operator instead of forwarding it', async () => {
+      // `contains` is a real Prisma operator that must NOT be reachable via an
+      // untrusted aggregate filter. The old default-case forwarded it verbatim.
+      injectedAggregateFilters = { views: { contains: '0' } as Record<string, unknown> };
+      const response = await app.request('/posts/aggregate-filtered?count=*');
+
+      expect(response.status).toBe(200);
+      const result = (await response.json()) as { result: { values: { count: number } } };
+      expect(result.result.values.count).toBe(0);
+    });
+
+    it('list path: two range operators on one field ANDs (no per-field overwrite)', async () => {
+      // ?views[gte]=100&views[lte]=200 produces two FilterConditions on `views`.
+      // buildPrismaWhere must merge them (AND) rather than letting the second
+      // overwrite the first — otherwise the gte is lost and the 50 post leaks in.
+      const response = await app.request('/posts-ranged?views[gte]=100&views[lte]=200');
+
+      expect(response.status).toBe(200);
+      const result = (await response.json()) as {
+        result: Array<{ views: number }>;
+        result_info: { total_count: number };
+      };
+      const views = result.result.map((p) => p.views).sort((a, b) => a - b);
+      expect(views).toEqual([100, 200]);
+    });
+  });
+
   describe('Clone', () => {
     it('clones a record with a fresh primary key, copying source data', async () => {
       const sourceId = crypto.randomUUID();
@@ -1124,6 +1261,39 @@ describe('Prisma Adapter', () => {
       });
 
       expect(response.status).toBe(404);
+    });
+  });
+
+  describe('Version Rollback', () => {
+    beforeEach(() => {
+      setVersioningStorage(new MemoryVersioningStorage());
+    });
+
+    it('returns 404 NOT_FOUND when rolling back a record that no longer exists', async () => {
+      const userId = crypto.randomUUID();
+
+      // Seed a version so the base handler passes its version-existence check,
+      // but leave the table empty so the adapter's rollback finds no record.
+      const manager = createVersionManager(
+        getVersioningConfig(VersionedUserModel.versioning, VersionedUserModel.tableName),
+        VersionedUserModel.tableName,
+      );
+      await manager.saveVersion(userId, {
+        id: userId,
+        name: 'Gone',
+        email: 'gone@example.com',
+        role: 'user',
+        version: 1,
+      });
+
+      const response = await app.request(`/users/${userId}/versions/1/rollback`, {
+        method: 'POST',
+      });
+
+      expect(response.status).toBe(404);
+      const result = (await response.json()) as { success: boolean; error: { code: string } };
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('NOT_FOUND');
     });
   });
 });

--- a/tests/scalar-ui.test.ts
+++ b/tests/scalar-ui.test.ts
@@ -1,5 +1,6 @@
 import { scalarUI, setupScalar } from '@hono-crud/scalar';
 import type { ScalarConfig, ScalarTheme } from '@hono-crud/scalar';
+import { setupDocsIndex } from '@hono-crud/swagger';
 import { Hono } from 'hono';
 import { describe, expect, it } from 'vitest';
 
@@ -290,5 +291,24 @@ describe('Scalar Integration', () => {
 
     const html = await res.text();
     expect(html).toContain('https://api.example.com');
+  });
+
+  it('docs hub links to the path scalar serves by default', async () => {
+    const app = new Hono();
+
+    // Mount both packages with their respective defaults: the swagger docs hub
+    // and the scalar reference UI must agree on a single path.
+    setupDocsIndex(app);
+    setupScalar(app);
+
+    // The hub renders a link to Scalar; extract its href and follow it.
+    const hubRes = await app.request('/');
+    const hubHtml = await hubRes.text();
+    const scalarHref = hubHtml.match(/href="([^"]*)"[^>]*>Open Scalar/)?.[1];
+    expect(scalarHref).toBeDefined();
+
+    const linkedRes = await app.request(scalarHref as string);
+    expect(linkedRes.status).toBe(200);
+    expect(linkedRes.headers.get('content-type')).toContain('text/html');
   });
 });

--- a/tests/wait-until.test.ts
+++ b/tests/wait-until.test.ts
@@ -1,0 +1,103 @@
+import type { Context } from 'hono';
+import { OpenAPIRoute } from 'hono-crud';
+// Published as the `hono-crud/cloudflare` subpath export
+// (package.json maps it to dist/types/cloudflare).
+import { getWaitUntil as getWaitUntilCloudflare } from 'hono-crud/types/cloudflare';
+import { getWaitUntil } from 'hono-crud/utils/wait-until';
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * Builds a context-like object whose `executionCtx` getter throws, mirroring
+ * Hono's real behaviour outside a Workers/edge runtime
+ * (`This context has no ExecutionContext`).
+ */
+function ctxWithoutExecutionCtx(): Context {
+  return {
+    get executionCtx(): never {
+      throw new Error('This context has no ExecutionContext');
+    },
+  } as unknown as Context;
+}
+
+function ctxWithExecutionCtx(waitUntil: (p: Promise<unknown>) => void): Context {
+  return {
+    executionCtx: { waitUntil },
+  } as unknown as Context;
+}
+
+describe('getWaitUntil (utils/wait-until)', () => {
+  it('returns undefined (no throw) when the context has no ExecutionContext', () => {
+    const ctx = ctxWithoutExecutionCtx();
+    expect(() => getWaitUntil(ctx)).not.toThrow();
+    expect(getWaitUntil(ctx)).toBeUndefined();
+  });
+
+  it('returns a bound waitUntil function when executionCtx exists', () => {
+    const spy = vi.fn();
+    const ctx = ctxWithExecutionCtx(spy);
+    const waitUntil = getWaitUntil(ctx);
+    expect(typeof waitUntil).toBe('function');
+    const promise = Promise.resolve();
+    // biome-ignore lint/style/noNonNullAssertion: asserted to be a function above
+    waitUntil!(promise);
+    expect(spy).toHaveBeenCalledWith(promise);
+  });
+});
+
+describe('getWaitUntil (hono-crud/cloudflare public export)', () => {
+  it('does not throw when the context has no ExecutionContext', () => {
+    const ctx = ctxWithoutExecutionCtx();
+    expect(() => getWaitUntilCloudflare(ctx)).not.toThrow();
+    expect(getWaitUntilCloudflare(ctx)).toBeUndefined();
+  });
+
+  it('returns a bound waitUntil function when executionCtx exists', () => {
+    const spy = vi.fn();
+    const ctx = ctxWithExecutionCtx(spy);
+    const waitUntil = getWaitUntilCloudflare(ctx);
+    expect(typeof waitUntil).toBe('function');
+    const promise = Promise.resolve();
+    // biome-ignore lint/style/noNonNullAssertion: asserted to be a function above
+    waitUntil!(promise);
+    expect(spy).toHaveBeenCalledWith(promise);
+  });
+});
+
+/**
+ * Minimal concrete route that exposes the protected `runAfterResponse`
+ * so the inline-fallback behaviour can be exercised directly.
+ */
+class TestRoute extends OpenAPIRoute {
+  handle(): Response {
+    return new Response(null);
+  }
+
+  exec(promise: Promise<unknown>): void {
+    this.runAfterResponse(promise);
+  }
+}
+
+describe('OpenAPIRoute.runAfterResponse', () => {
+  it('runs the promise inline when waitUntil is absent', async () => {
+    const route = new TestRoute();
+    route.setContext(ctxWithoutExecutionCtx());
+
+    let ran = false;
+    const promise = Promise.resolve().then(() => {
+      ran = true;
+    });
+    route.exec(promise);
+    await promise;
+    expect(ran).toBe(true);
+  });
+
+  it('hands the promise to executionCtx.waitUntil when available', () => {
+    const spy = vi.fn();
+    const route = new TestRoute();
+    route.setContext(ctxWithExecutionCtx(spy));
+
+    const promise = Promise.resolve();
+    route.exec(promise);
+    expect(spy).toHaveBeenCalledWith(promise);
+  });
+});


### PR DESCRIPTION
## Summary

First batch from the codebase drift audit: the 9 findings that are actual bugs (not just inconsistencies). Each behavioral fix was developed test-first (red → green) and independently reviewed before landing.

### Behavioral fixes

| Fix | Package | Bug |
|---|---|---|
| Aggregate fail-closed | memory, prisma, drizzle | Memory's aggregate matched **every record** on unknown filter operators (fail-open data exposure); prisma forwarded untrusted operator strings verbatim into the Prisma where clause and 500'd on documented ops like `between`; drizzle crashed via `assertNever`. All three now validate with `isFilterOperator()` and match nothing on unknown ops, delegating to each adapter's canonical converter (`matchesFilter` / `buildPrismaWhere` / `buildWhereCondition`). |
| Range-filter merge | prisma | `buildPrismaWhere` overwrote per-field conditions, so list/search queries like `?views[gte]=100&views[lte]=200` silently dropped the `gte`. Multiple conditions per field now combine into a top-level `AND`. |
| Rollback 404 | prisma | Version rollback threw plain `Error` when the record no longer exists → 500 `INTERNAL_ERROR`, violating the declared 404 contract. Now throws `NotFoundException`. |
| Envelope on cache HIT | cache | The mixin hardcoded `{success, result}` when serving from cache, so a custom `ResponseEnvelope` produced different body shapes on HIT vs MISS. Raw data is cached; the envelope is applied at response time via the same path as MISS. |
| `getWaitUntil` consolidation | core | Three divergent copies; the **public** `hono-crud/cloudflare` one was the only unguarded variant and threw outside Workers. Now one guarded implementation (`utils/wait-until.ts`); public signature is `WaitUntil \| undefined` (breaking, patch — pre-1.0). Dead thunk helper deleted. |
| Scalar link | swagger | Docs hub linked `/scalar`; the scalar package serves `/reference` → shipped 404. Default unified on `/reference`, still configurable. |

### Docs / examples / packaging

- **Dead sorting config**: ~30 class-based example sites + 4 docs set `orderByFields`/`defaultOrderBy`/`defaultOrderDirection` as class fields — names the base class never reads, so sorting was silently unconfigured. Converted to the real `sortFields`/`defaultSort`; deprecated config aliases purged from docs; `examples/README.md` import path corrected to `@hono-crud/memory`.
- **CHANGELOG.md in tarballs**: added to the `files` allowlist in all 10 non-core packages (Changesets generated them, npm never shipped them).
- **Optional peers**: `drizzle-zod`, `pluralize`, `fastest-levenshtein` are dynamically imported with graceful fallbacks — now marked `peerDependenciesMeta.optional`.

### Verification

- `pnpm -r build`, `pnpm -r typecheck`, `pnpm run typecheck:examples`: green
- Unit suite: 998 passed, 0 regressions (`tests/examples/db-comprehensive.test.ts` fails identically on a clean tree — needs a provisioned DB)
- New/extended tests: `aggregate`, `cache`, `prisma`, `drizzle`, `scalar-ui`, `wait-until` (new), `class-sort-fields` (new) — every behavioral fix proven red first
- 7 changesets included, all patch bumps

Not in this PR: the audit's consistency themes (storage-injection unification, storage-contract verbs/TTL/getter alignment, naming conventions) — those are follow-up batches.