### PR TITLE
ci: bump actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,12 @@ jobs:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/hono_crud?schema=public
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -9,7 +9,7 @@ jobs:
     name: Validate PR Title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,15 +18,15 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
           registry-url: https://registry.npmjs.org
 


### PR DESCRIPTION
GitHub deprecation: `actions/checkout@v4`, `actions/setup-node@v4`, `pnpm/action-setup@v4`, and `amannn/action-semantic-pull-request@v5` all run on the Node 20 action runtime, which GitHub force-migrates to Node 24 on **2026-06-16**.

- `actions/checkout` v4 → v6 — v5 was the Node 24 bump; v6 persists git credentials to a separate file but **still persists by default**, so the changesets release push keeps working
- `actions/setup-node` v4 → v6
- `pnpm/action-setup` v4 → v6 — v5 was the Node 24 bump; v6 adds pnpm v11 support, still installs the version pinned by `packageManager`
- `amannn/action-semantic-pull-request` v5 → v6 — breaking change is only the Node 24/ESM runtime; all config options (`types`, `requireScope`, `subjectPattern`) unchanged
- Release job `node-version` 20 → 22 — Node 20 reached EOL April 2026; CI already tests on 22

No changeset: workflow-only change, nothing published.

Note: the CI test matrix still includes Node 20 (the library's support floor) — kept as-is since that's a support-policy decision, not a runtime requirement.