### PR TITLE
refactor: dedup TTL stores, cache entry codec, and relation batching

### DIFF
--- a/.changeset/dedup-batch.md
+++ b/.changeset/dedup-batch.md
@@ -1,0 +1,17 @@
+---
+"hono-crud": patch
+"@hono-crud/cache": patch
+"@hono-crud/rate-limit": patch
+"@hono-crud/idempotency": patch
+"@hono-crud/drizzle": patch
+"@hono-crud/prisma": patch
+"@hono-crud/memory": patch
+---
+
+Dedup batch: the edge-safe in-memory TTL machinery, the cache entry wire format, and the relation-batching control flow each now live in exactly one place.
+
+- New internal `MemoryTtlStore` in core (exported via `hono-crud/internal`) owns lazy cleanup-on-access, expiry-on-read, and insertion-order capacity eviction. The cache, rate-limit, and idempotency memory storages compose it, supplying only their entry shapes and domain indices (cache tag index via an eviction hook, idempotency locks as a second store). Public constructor options are unchanged. The logging memory storage intentionally stays standalone — its newest-first ordering is a different structure, not drift.
+- New cache entry codec (`packages/cache/src/entry.ts`, internal): `buildCacheEntry` / `normalizeStoredEntry` / `isCacheEntryExpired` shared by the memory, Redis, and Cloudflare KV backends — including the single canonical legacy-Date migration guard, so already-persisted entries keep reading identically.
+- New relation-batching orchestrator in core (exported via `hono-crud/internal`): the ORM-agnostic control flow (key collection, grouping, map-back, lookup-map dispatch over hasOne/hasMany/belongsTo) is shared; drizzle, prisma, and memory supply only their query adapters. N+1 batching fixes now land in one place.
+- Two deliberate behavior fixes that the dedup surfaced: (1) single-item relation reads in the memory and drizzle adapters now always set the relation key (`null` / `[]` instead of absent), matching the batch path and prisma — this also fixes memory's belongsTo gating on the row's own `id` instead of the foreign key; (2) the rate-limit fixed window no longer slides its stored expiry on within-window increments — the window keeps its original `windowStart + windowMs` end.
+- Internal-only removals (never publicly exported): memory's `loadRelation`, prisma's `loadPrismaRelation`.

--- a/packages/cache/src/entry.ts
+++ b/packages/cache/src/entry.ts
@@ -1,0 +1,61 @@
+import type { CacheEntry } from 'hono-crud/internal';
+
+/**
+ * Cache entry codec shared across the memory/redis/KV backends. Centralizes the
+ * entry literal, the legacy ISO-Date-string migration, and the expiry guard so
+ * all three backends stay byte-for-byte consistent.
+ *
+ * This module is internal/alias-only — it is NOT published as a package subpath
+ * (`@hono-crud/cache` declares only `'.'` in its `exports`). Consumers reach it
+ * through the build entrypoint or, in tests, the vitest alias.
+ */
+
+/**
+ * Build a fresh cache entry. `ttlMs <= 0` means "never expires"
+ * (`expiresAt = null`). Byte-equivalent to the literal previously inlined in
+ * the memory/redis/KV `set()` methods.
+ */
+export function buildCacheEntry<T>(
+  data: T,
+  ttlMs: number,
+  tags: string[] | undefined,
+  now: number = Date.now(),
+): CacheEntry<T> {
+  return {
+    data,
+    createdAt: now,
+    expiresAt: ttlMs > 0 ? now + ttlMs : null,
+    tags,
+  };
+}
+
+/**
+ * Normalize a parsed/persisted entry IN PLACE: migrate legacy ISO-Date-string
+ * `createdAt`/`expiresAt` (pre-PR#56 builds) to epoch ms. Mutates & returns the
+ * same object so the caller can run expiry checks afterward. Wire-format compat:
+ * redis/KV entries persisted with string dates keep reading. Numeric fields pass
+ * through untouched.
+ */
+export function normalizeStoredEntry<T>(entry: CacheEntry<T>): CacheEntry<T> {
+  const legacyCreatedAt = entry.createdAt as unknown;
+  if (typeof legacyCreatedAt === 'string') {
+    const parsed = Date.parse(legacyCreatedAt);
+    entry.createdAt = Number.isNaN(parsed) ? Date.now() : parsed;
+  }
+  const legacyExpiresAt = entry.expiresAt as unknown;
+  if (typeof legacyExpiresAt === 'string') {
+    const parsed = Date.parse(legacyExpiresAt);
+    entry.expiresAt = Number.isNaN(parsed) ? null : parsed;
+  }
+  return entry;
+}
+
+/**
+ * Expiry predicate shared across backends. `null`/falsy `expiresAt` means the
+ * entry never expires (load-bearing: `now > expiresAt` would wrongly expire a
+ * `null` `expiresAt`). Mirrors the `entry.expiresAt && entry.expiresAt < now`
+ * guard used in all three backends.
+ */
+export function isCacheEntryExpired(entry: CacheEntry<unknown>, now: number = Date.now()): boolean {
+  return entry.expiresAt != null && entry.expiresAt < now;
+}

--- a/packages/cache/src/storage/cloudflare-kv.ts
+++ b/packages/cache/src/storage/cloudflare-kv.ts
@@ -1,4 +1,5 @@
 import type { KVNamespace } from 'hono-crud/internal';
+import { buildCacheEntry, isCacheEntryExpired, normalizeStoredEntry } from '../entry';
 import type { CacheEntry, CacheSetOptions, CacheStats, CacheStorage } from '../types';
 
 const KV_BATCH_CONCURRENCY = 50;
@@ -84,22 +85,10 @@ export class KVCacheStorage implements CacheStorage {
     }
 
     try {
-      const entry = JSON.parse(raw) as CacheEntry<T>;
-
-      // Migration guard: convert legacy Date strings to epoch ms
-      const legacyCreatedAt = entry.createdAt as unknown;
-      if (typeof legacyCreatedAt === 'string') {
-        const parsed = Date.parse(legacyCreatedAt);
-        entry.createdAt = Number.isNaN(parsed) ? Date.now() : parsed;
-      }
-      const legacyExpiresAt = entry.expiresAt as unknown;
-      if (typeof legacyExpiresAt === 'string') {
-        const parsed = Date.parse(legacyExpiresAt);
-        entry.expiresAt = Number.isNaN(parsed) ? null : parsed;
-      }
+      const entry = normalizeStoredEntry(JSON.parse(raw) as CacheEntry<T>);
 
       // Check expiration (KV TTL handles this, but guard against clock skew)
-      if (entry.expiresAt && entry.expiresAt < Date.now()) {
+      if (isCacheEntryExpired(entry)) {
         this.stats.misses++;
         return null;
       }
@@ -117,12 +106,7 @@ export class KVCacheStorage implements CacheStorage {
     const tags = options?.tags;
     const now = Date.now();
 
-    const entry: CacheEntry<T> = {
-      data,
-      createdAt: now,
-      expiresAt: ttlMs > 0 ? now + ttlMs : null,
-      tags,
-    };
+    const entry = buildCacheEntry(data, ttlMs, tags, now);
 
     const kvOptions = ttlMs > 0 ? { expirationTtl: this.getExpirationTtl(ttlMs) } : undefined;
     await this.kv.put(this.getKey(key), JSON.stringify(entry), kvOptions);

--- a/packages/cache/src/storage/memory.ts
+++ b/packages/cache/src/storage/memory.ts
@@ -1,3 +1,5 @@
+import { MemoryTtlStore } from 'hono-crud/internal';
+import { buildCacheEntry, isCacheEntryExpired } from '../entry';
 import { matchesPattern } from '../key-generator';
 import type { CacheEntry, CacheSetOptions, CacheStats, CacheStorage } from '../types';
 
@@ -24,8 +26,8 @@ import type { CacheEntry, CacheSetOptions, CacheStats, CacheStorage } from '../t
  * ```
  */
 export class MemoryCacheStorage implements CacheStorage {
-  /** Main storage: key -> CacheEntry */
-  private storage = new Map<string, CacheEntry>();
+  /** Generic TTL Map store: key -> CacheEntry (composed). */
+  private store: MemoryTtlStore<CacheEntry>;
 
   /** Tag index: tag -> Set of keys */
   private tagIndex = new Map<string, Set<string>>();
@@ -46,6 +48,37 @@ export class MemoryCacheStorage implements CacheStorage {
   constructor(options?: { defaultTtlMs?: number; maxEntries?: number }) {
     this.defaultTtlMs = options?.defaultTtlMs ?? 300_000; // 5 minutes
     this.maxEntries = options?.maxEntries ?? 10_000;
+    this.store = new MemoryTtlStore<CacheEntry>({
+      isExpired: isCacheEntryExpired,
+      maxEntries: this.maxEntries,
+      onEvict: (key, entry) => this.removeFromTagIndex(key, entry),
+    });
+  }
+
+  /**
+   * Remove a key from every tag bucket it belongs to. Fired by the store's
+   * `onEvict` on eviction/expiry-on-read/delete/overwrite (old value).
+   */
+  private removeFromTagIndex(key: string, entry: CacheEntry): void {
+    if (entry.tags) {
+      for (const tag of entry.tags) {
+        this.tagIndex.get(tag)?.delete(key);
+      }
+    }
+  }
+
+  /**
+   * Add a key to every tag bucket in `tags`.
+   */
+  private addToTagIndex(key: string, tags: string[] | undefined): void {
+    if (tags) {
+      for (const tag of tags) {
+        if (!this.tagIndex.has(tag)) {
+          this.tagIndex.set(tag, new Set());
+        }
+        this.tagIndex.get(tag)!.add(key);
+      }
+    }
   }
 
   /**
@@ -53,17 +86,11 @@ export class MemoryCacheStorage implements CacheStorage {
    * Returns null if not found or expired.
    */
   async get<T>(key: string): Promise<CacheEntry<T> | null> {
-    const entry = this.storage.get(key) as CacheEntry<T> | undefined;
+    const entry = this.store.get(key) as CacheEntry<T> | undefined;
+    // Re-sync: expiry-on-read may have evicted the entry.
+    this.stats.size = this.store.size;
 
     if (!entry) {
-      this.stats.misses++;
-      return null;
-    }
-
-    // Check expiration
-    if (entry.expiresAt && entry.expiresAt < Date.now()) {
-      // Entry has expired, delete it
-      await this.delete(key);
       this.stats.misses++;
       return null;
     }
@@ -79,65 +106,22 @@ export class MemoryCacheStorage implements CacheStorage {
     const ttlMs = options?.ttlMs ?? this.defaultTtlMs;
     const tags = options?.tags;
 
-    // Evict if at capacity
-    if (this.maxEntries > 0 && this.storage.size >= this.maxEntries && !this.storage.has(key)) {
-      this.evictOldest();
-    }
+    const entry = buildCacheEntry(data, ttlMs, tags);
 
-    const now = Date.now();
-    const entry: CacheEntry<T> = {
-      data,
-      createdAt: now,
-      expiresAt: ttlMs > 0 ? now + ttlMs : null,
-      tags,
-    };
-
-    // Remove old entry from tag index if exists
-    const oldEntry = this.storage.get(key);
-    if (oldEntry?.tags) {
-      for (const tag of oldEntry.tags) {
-        this.tagIndex.get(tag)?.delete(key);
-      }
-    }
-
-    // Delete and re-insert to move to newest position (Map insertion order)
-    if (oldEntry) {
-      this.storage.delete(key);
-    }
-    this.storage.set(key, entry);
-    this.stats.size = this.storage.size;
-
-    // Update tag index
-    if (tags) {
-      for (const tag of tags) {
-        if (!this.tagIndex.has(tag)) {
-          this.tagIndex.set(tag, new Set());
-        }
-        this.tagIndex.get(tag)!.add(key);
-      }
-    }
+    // Overwrite re-tags via `refreshLruOnOverwrite` (fires `onEvict` for the old
+    // value → removes stale tag entries) + moves the key to the newest position.
+    this.store.set(key, entry, /* refreshLruOnOverwrite */ true);
+    this.addToTagIndex(key, tags);
+    this.stats.size = this.store.size;
   }
 
   /**
    * Delete a cache entry by key.
    */
   async delete(key: string): Promise<boolean> {
-    const entry = this.storage.get(key);
-
-    if (!entry) {
-      return false;
-    }
-
-    // Remove from tag index
-    if (entry.tags) {
-      for (const tag of entry.tags) {
-        this.tagIndex.get(tag)?.delete(key);
-      }
-    }
-
-    this.storage.delete(key);
-    this.stats.size = this.storage.size;
-    return true;
+    const ok = this.store.delete(key);
+    this.stats.size = this.store.size;
+    return ok;
   }
 
   /**
@@ -147,7 +131,7 @@ export class MemoryCacheStorage implements CacheStorage {
     let count = 0;
     const keysToDelete: string[] = [];
 
-    for (const key of this.storage.keys()) {
+    for (const key of this.store.getKeys()) {
       if (matchesPattern(key, pattern)) {
         keysToDelete.push(key);
       }
@@ -183,7 +167,9 @@ export class MemoryCacheStorage implements CacheStorage {
       }
     }
 
-    // Clean up empty tag set
+    // Clean up empty tag set. `onEvict` → `removeFromTagIndex` only removes the
+    // key from the Set, so the now-empty tag bucket must be dropped explicitly
+    // to keep `getTags()` consistent.
     this.tagIndex.delete(tag);
 
     return count;
@@ -193,26 +179,17 @@ export class MemoryCacheStorage implements CacheStorage {
    * Check if a key exists in the cache (and is not expired).
    */
   async has(key: string): Promise<boolean> {
-    const entry = this.storage.get(key);
-
-    if (!entry) {
-      return false;
-    }
-
-    // Check expiration
-    if (entry.expiresAt && entry.expiresAt < Date.now()) {
-      await this.delete(key);
-      return false;
-    }
-
-    return true;
+    const ok = this.store.has(key);
+    // Re-sync: expiry-on-read may have evicted the entry.
+    this.stats.size = this.store.size;
+    return ok;
   }
 
   /**
    * Clear all cache entries.
    */
   async clear(): Promise<void> {
-    this.storage.clear();
+    this.store.clear();
     this.tagIndex.clear();
     this.stats.size = 0;
   }
@@ -236,7 +213,7 @@ export class MemoryCacheStorage implements CacheStorage {
    * Get all keys (for debugging).
    */
   getKeys(): string[] {
-    return Array.from(this.storage.keys());
+    return this.store.getKeys();
   }
 
   /**
@@ -247,35 +224,11 @@ export class MemoryCacheStorage implements CacheStorage {
   }
 
   /**
-   * Evict oldest entry when at capacity.
-   * Uses Map insertion order for O(1) lookup instead of scanning all entries.
-   */
-  private evictOldest(): void {
-    const oldestKey = this.storage.keys().next().value;
-    if (oldestKey !== undefined) {
-      this.delete(oldestKey).catch(() => {});
-    }
-  }
-
-  /**
    * Clean up expired entries (manual garbage collection).
    */
   async cleanup(): Promise<number> {
-    const now = Date.now();
-    let count = 0;
-    const keysToDelete: string[] = [];
-
-    for (const [key, entry] of this.storage.entries()) {
-      if (entry.expiresAt && entry.expiresAt < now) {
-        keysToDelete.push(key);
-      }
-    }
-
-    for (const key of keysToDelete) {
-      await this.delete(key);
-      count++;
-    }
-
-    return count;
+    const n = this.store.cleanup();
+    this.stats.size = this.store.size;
+    return n;
   }
 }

--- a/packages/cache/src/storage/redis.ts
+++ b/packages/cache/src/storage/redis.ts
@@ -1,4 +1,5 @@
 import { getLogger } from 'hono-crud/internal';
+import { buildCacheEntry, isCacheEntryExpired, normalizeStoredEntry } from '../entry';
 import type { CacheEntry, CacheSetOptions, CacheStats, CacheStorage } from '../types';
 
 /**
@@ -129,22 +130,10 @@ export class RedisCacheStorage implements CacheStorage {
     }
 
     try {
-      const entry = JSON.parse(value) as CacheEntry<T>;
-
-      // Migration guard: convert legacy Date strings to epoch ms
-      const legacyCreatedAt = entry.createdAt as unknown;
-      if (typeof legacyCreatedAt === 'string') {
-        const parsed = Date.parse(legacyCreatedAt);
-        entry.createdAt = Number.isNaN(parsed) ? Date.now() : parsed;
-      }
-      const legacyExpiresAt = entry.expiresAt as unknown;
-      if (typeof legacyExpiresAt === 'string') {
-        const parsed = Date.parse(legacyExpiresAt);
-        entry.expiresAt = Number.isNaN(parsed) ? null : parsed;
-      }
+      const entry = normalizeStoredEntry(JSON.parse(value) as CacheEntry<T>);
 
       // Redis handles TTL, but check just in case
-      if (entry.expiresAt && entry.expiresAt < Date.now()) {
+      if (isCacheEntryExpired(entry)) {
         this.stats.misses++;
         return null;
       }
@@ -166,12 +155,7 @@ export class RedisCacheStorage implements CacheStorage {
     const tags = options?.tags;
 
     const now = Date.now();
-    const entry: CacheEntry<T> = {
-      data,
-      createdAt: now,
-      expiresAt: ttlMs > 0 ? now + ttlMs : null,
-      tags,
-    };
+    const entry = buildCacheEntry(data, ttlMs, tags, now);
 
     const value = JSON.stringify(entry);
     // Redis expirations are in whole seconds; round up so a sub-second TTL

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -58,3 +58,25 @@ export type { PathPattern } from './utils/path-match';
 export { getClientIp } from './utils/request-info';
 export type { ClientIpOptions } from './utils/request-info';
 export { defaultExtractToken as extractBearerToken } from './auth/middleware/jwt';
+
+// Generic TTL Map store composed by the in-memory cache/rate-limit/idempotency backends.
+export { MemoryTtlStore } from './storage/memory-ttl-store';
+export type { MemoryTtlStoreOptions } from './storage/memory-ttl-store';
+
+// Relation batch/single-item orchestrator consumed by the drizzle/prisma/memory adapters.
+export {
+  batchLoadRelations,
+  loadRelationsForItem,
+  loadRelationsForItemSync,
+  resolveRelationValueAsync,
+  resolveRelationValueSync,
+} from './relations/batch-loader';
+export type {
+  RelatedRecord,
+  ResolveRelation,
+  FetchRelated,
+  RelationLoaderAdapter,
+  SyncResolveRelation,
+  SyncFetchRelated,
+  SyncRelationLoaderAdapter,
+} from './relations/batch-loader';

--- a/packages/core/src/relations/batch-loader.ts
+++ b/packages/core/src/relations/batch-loader.ts
@@ -1,0 +1,263 @@
+/**
+ * ORM-agnostic relation batch + single-item orchestration. Adapters inject
+ * `fetchRelated` (their one-line ORM query) and `resolveRelation` (drizzle:
+ * requires `table`; prisma: resolves a model handle; memory: returns the backing
+ * Map). The async path uses `PromiseLike`; memory uses a separate sync adapter +
+ * sync loader so memory stays fully synchronous.
+ */
+
+import type { IncludeOptions, MetaInput, RelationConfig, RelationType } from '../core/types';
+
+/** A loaded related record (opaque to the orchestrator). */
+export type RelatedRecord = Record<string, unknown>;
+
+// --- ASYNC adapter (drizzle, prisma) ---
+// MUST be PromiseLike, NOT Promise: drizzle's fetchRelated returns a
+// QueryBuilder<Row> which `extends PromiseLike<Row[]>` (drizzle helpers.ts:77),
+// NOT a Promise — tsc rejects Promise<...> with TS2322 ('missing catch, finally,
+// [Symbol.toStringTag]'). The orchestrator only `await`s these, so PromiseLike
+// is sufficient.
+
+export type ResolveRelation<Handle> = (
+  relationConfig: RelationConfig,
+) => Handle | null | PromiseLike<Handle | null>;
+
+export type FetchRelated<Handle> = (
+  handle: Handle,
+  keyField: string,
+  values: unknown[],
+) => RelatedRecord[] | PromiseLike<RelatedRecord[]>;
+
+export interface RelationLoaderAdapter<Handle> {
+  resolveRelation: ResolveRelation<Handle>;
+  fetchRelated: FetchRelated<Handle>;
+}
+
+// --- SYNC adapter (memory) ---
+// Strictly non-Promise returns so loadRelationsForItemSync runs await-free and
+// returns T (not Promise<T>). Memory's crud.ts/advanced.ts call sites stay sync.
+
+export type SyncResolveRelation<Handle> = (relationConfig: RelationConfig) => Handle | null;
+export type SyncFetchRelated<Handle> = (
+  handle: Handle,
+  keyField: string,
+  values: unknown[],
+) => RelatedRecord[];
+
+export interface SyncRelationLoaderAdapter<Handle> {
+  resolveRelation: SyncResolveRelation<Handle>;
+  fetchRelated: SyncFetchRelated<Handle>;
+}
+
+/** Batch-load all requested relations for `items`, avoiding N+1 by issuing one
+ *  `fetchRelated` per relation. Clones items (no input mutation). hasOne/hasMany
+ *  group by foreign key, belongsTo maps 1:1 by local key (last-writer-wins). */
+export async function batchLoadRelations<
+  T extends Record<string, unknown>,
+  M extends MetaInput,
+  Handle,
+>(
+  items: T[],
+  meta: M,
+  adapter: RelationLoaderAdapter<Handle>,
+  includeOptions?: IncludeOptions,
+): Promise<T[]> {
+  if (!items.length || !includeOptions?.relations?.length || !meta.model.relations) {
+    return items;
+  }
+  let results = items.map((item) => ({ ...item })) as T[];
+
+  for (const relationName of includeOptions.relations) {
+    const relationConfig = meta.model.relations[relationName] as RelationConfig | undefined;
+    if (!relationConfig) continue;
+    const handle = await adapter.resolveRelation(relationConfig);
+    if (handle == null) continue;
+
+    // VARIANCE LAUNDER (required): RelationLoaderAdapter<Handle> is NOT
+    // assignable to RelationLoaderAdapter<unknown> because Handle sits in
+    // contravariant position via fetchRelated(handle: Handle, ...). The dispatch
+    // map is keyed on RelationType with BatchHandler<unknown>; without the
+    // launder tsc emits TS2345. handle is the resolved value (already widened to
+    // its concrete type at runtime); cast both through unknown.
+    results = await RELATION_BATCH_DISPATCH[relationConfig.type](
+      results,
+      relationName,
+      relationConfig,
+      handle as unknown,
+      adapter as unknown as RelationLoaderAdapter<unknown>,
+    );
+  }
+  return results;
+}
+
+type BatchHandler = <T extends Record<string, unknown>>(
+  results: T[],
+  relationName: string,
+  config: RelationConfig,
+  handle: unknown,
+  adapter: RelationLoaderAdapter<unknown>,
+) => Promise<T[]>;
+
+/** Shared hasOne/hasMany grouping; `single` shapes the map-back. */
+function makeHasHandler(single: boolean): BatchHandler {
+  return async (results, relationName, config, handle, adapter) => {
+    const localKey = config.localKey || 'id';
+    const localValues = [
+      ...new Set(results.map((i) => i[localKey]).filter((v) => v !== undefined && v !== null)),
+    ];
+    if (localValues.length === 0) {
+      return results.map((i) => ({ ...i, [relationName]: single ? null : [] }));
+    }
+    const records = await adapter.fetchRelated(handle, config.foreignKey, localValues);
+    const byForeignKey = new Map<unknown, RelatedRecord[]>();
+    for (const record of records) {
+      const fk = record[config.foreignKey];
+      const bucket = byForeignKey.get(fk);
+      if (bucket) bucket.push(record);
+      else byForeignKey.set(fk, [record]);
+    }
+    return results.map((i) => {
+      const related = byForeignKey.get(i[localKey]) || [];
+      return { ...i, [relationName]: single ? related[0] || null : related };
+    });
+  };
+}
+
+function makeBelongsToHandler(): BatchHandler {
+  return async (results, relationName, config, handle, adapter) => {
+    const refLocalKey = config.localKey || 'id';
+    const foreignValues = [
+      ...new Set(
+        results.map((i) => i[config.foreignKey]).filter((v) => v !== undefined && v !== null),
+      ),
+    ];
+    if (foreignValues.length === 0) {
+      return results.map((i) => ({ ...i, [relationName]: null }));
+    }
+    const records = await adapter.fetchRelated(handle, refLocalKey, foreignValues);
+    const byLocalKey = new Map<unknown, RelatedRecord>();
+    for (const record of records) byLocalKey.set(record[refLocalKey], record); // last-writer-wins
+    return results.map((i) => ({
+      ...i,
+      [relationName]: byLocalKey.get(i[config.foreignKey]) || null,
+    }));
+  };
+}
+
+const RELATION_BATCH_DISPATCH: Record<RelationType, BatchHandler> = {
+  hasOne: makeHasHandler(true),
+  hasMany: makeHasHandler(false),
+  belongsTo: makeBelongsToHandler(),
+};
+
+// Map a relation type to its single-item shape via a generic 1-record reducer
+// that both async and sync paths reuse. `records` is the (already awaited or
+// already plain) fetch result; the reducer is pure & synchronous.
+type SingleReducer = (records: RelatedRecord[]) => unknown;
+const RELATION_SINGLE_REDUCER: Record<RelationType, SingleReducer> = {
+  hasOne: (records) => records[0] ?? null,
+  hasMany: (records) => records,
+  belongsTo: (records) => records[0] ?? null,
+};
+
+// Which key drives the IN-list for a single item, per relation type:
+//  - hasOne/hasMany fetch by foreignKey, gated on item[localKey]
+//  - belongsTo fetch by localKey, gated on item[foreignKey]
+// Returned: { gateValue, keyField } or null when the gate value is null/undefined
+// (in which case the reducer is applied to an EMPTY record list — ALWAYS setting
+// the key: hasOne/belongsTo -> null, hasMany -> []). This is the unified
+// always-set-key behavior (DRIFT #1).
+function singleQueryPlan(
+  config: RelationConfig,
+  item: Record<string, unknown>,
+): { gateValue: unknown; keyField: string } | null {
+  const localKey = config.localKey || 'id';
+  if (config.type === 'belongsTo') {
+    const fv = item[config.foreignKey];
+    return fv === undefined || fv === null ? null : { gateValue: fv, keyField: localKey };
+  }
+  const lv = item[localKey];
+  return lv === undefined || lv === null ? null : { gateValue: lv, keyField: config.foreignKey };
+}
+
+/** Resolve ONE relation for ONE item; returns the relation value (record/array/
+ *  null), NOT a merged item. Always-set semantics: when the gate value is null/
+ *  undefined, the reducer runs over an empty list. */
+export async function resolveRelationValueAsync<Handle>(
+  item: Record<string, unknown>,
+  config: RelationConfig,
+  handle: Handle,
+  fetchRelated: FetchRelated<Handle>,
+): Promise<unknown> {
+  const reducer = RELATION_SINGLE_REDUCER[config.type];
+  const plan = singleQueryPlan(config, item);
+  if (!plan) return reducer([]);
+  const records = await fetchRelated(handle, plan.keyField, [plan.gateValue]);
+  return reducer(records);
+}
+
+export function resolveRelationValueSync<Handle>(
+  item: Record<string, unknown>,
+  config: RelationConfig,
+  handle: Handle,
+  fetchRelated: SyncFetchRelated<Handle>,
+): unknown {
+  const reducer = RELATION_SINGLE_REDUCER[config.type];
+  const plan = singleQueryPlan(config, item);
+  if (!plan) return reducer([]);
+  const records = fetchRelated(handle, plan.keyField, [plan.gateValue]);
+  return reducer(records);
+}
+
+/** Load all requested relations for ONE item (async). Always sets the relation
+ *  key (hasOne/belongsTo -> record-or-null, hasMany -> array), including when the
+ *  gate value is null. Clones the item. */
+export async function loadRelationsForItem<
+  T extends Record<string, unknown>,
+  M extends MetaInput,
+  Handle,
+>(
+  item: T,
+  meta: M,
+  adapter: RelationLoaderAdapter<Handle>,
+  includeOptions?: IncludeOptions,
+): Promise<T> {
+  if (!includeOptions?.relations?.length || !meta.model.relations) return item;
+  const result = { ...item } as Record<string, unknown>;
+  for (const relationName of includeOptions.relations) {
+    const config = meta.model.relations[relationName] as RelationConfig | undefined;
+    if (!config) continue;
+    const handle = await adapter.resolveRelation(config);
+    if (handle == null) continue;
+    result[relationName] = await resolveRelationValueAsync(
+      result,
+      config,
+      handle,
+      adapter.fetchRelated,
+    );
+  }
+  return result as T;
+}
+
+/** Synchronous variant for memory (no microtask; keeps memory callers sync). */
+export function loadRelationsForItemSync<
+  T extends Record<string, unknown>,
+  M extends MetaInput,
+  Handle,
+>(
+  item: T,
+  meta: M,
+  adapter: SyncRelationLoaderAdapter<Handle>,
+  includeOptions?: IncludeOptions,
+): T {
+  if (!includeOptions?.relations?.length || !meta.model.relations) return item;
+  const result = { ...item } as Record<string, unknown>;
+  for (const relationName of includeOptions.relations) {
+    const config = meta.model.relations[relationName] as RelationConfig | undefined;
+    if (!config) continue;
+    const handle = adapter.resolveRelation(config);
+    if (handle == null) continue;
+    result[relationName] = resolveRelationValueSync(result, config, handle, adapter.fetchRelated);
+  }
+  return result as T;
+}

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -31,6 +31,10 @@ export {
 export { createStorageFeature } from './feature';
 export type { StorageFeature, StorageFeatureOptions } from './feature';
 
+// Generic TTL Map store composed by the in-memory cache/rate-limit/idempotency backends
+export { MemoryTtlStore } from './memory-ttl-store';
+export type { MemoryTtlStoreOptions } from './memory-ttl-store';
+
 // Helpers
 export {
   getStorage,

--- a/packages/core/src/storage/memory-ttl-store.ts
+++ b/packages/core/src/storage/memory-ttl-store.ts
@@ -1,0 +1,139 @@
+/**
+ * Generic, edge-safe TTL Map store composed by the cache, rate-limit, and
+ * idempotency in-memory backends. Insertion-order keyed with lazy
+ * cleanup-on-access, optional capacity eviction, count-returning sweep, and
+ * debug accessors. Value-shape agnostic: the owner supplies an `isExpired`
+ * predicate and (optionally) an `onEvict` hook so domain side-indices (e.g. the
+ * cache tag index) stay consistent.
+ */
+
+/** Options for {@link MemoryTtlStore}. All durations are milliseconds. */
+export interface MemoryTtlStoreOptions<V> {
+  /** Predicate deciding whether a stored value is expired at `now`. Called on
+   *  read (get/has) and during sweeps. Must be pure. */
+  isExpired: (value: V, now: number) => boolean;
+
+  /** Minimum interval between lazy cleanup-on-access sweeps (ms). `<= 0`
+   *  disables lazy sweeping (explicit `cleanup()` still works). @default 0 */
+  cleanupInterval?: number;
+
+  /** Maximum entries before evicting the oldest (insertion order). `<= 0`
+   *  disables capacity eviction. @default 0 (unlimited) */
+  maxEntries?: number;
+
+  /** Invoked synchronously with key+value of every entry removed by eviction,
+   *  expiry-on-read, sweep, or `delete()` — used by owners with side-indices
+   *  (e.g. cache tag index). NOT called by `clear()` (owners reset side-indices
+   *  wholesale there). */
+  onEvict?: (key: string, value: V) => void;
+}
+
+export class MemoryTtlStore<V> {
+  private readonly map = new Map<string, V>();
+  private readonly isExpired: (value: V, now: number) => boolean;
+  private readonly cleanupInterval: number;
+  private readonly maxEntries: number;
+  private readonly onEvict?: (key: string, value: V) => void;
+  private lastCleanup = 0;
+
+  constructor(options: MemoryTtlStoreOptions<V>) {
+    this.isExpired = options.isExpired;
+    this.cleanupInterval = options.cleanupInterval ?? 0;
+    this.maxEntries = options.maxEntries ?? 0;
+    this.onEvict = options.onEvict;
+  }
+
+  /** Lazy cleanup-on-access. No-op when `cleanupInterval <= 0`. */
+  maybeCleanup(now: number = Date.now()): void {
+    if (this.cleanupInterval <= 0) return;
+    if (now - this.lastCleanup >= this.cleanupInterval) {
+      this.lastCleanup = now;
+      this.cleanup(now);
+    }
+  }
+
+  /** Get a live (non-expired) value. Expired entries are deleted on read
+   *  (firing `onEvict`) and treated as absent. Does NOT call `maybeCleanup`. */
+  get(key: string, now: number = Date.now()): V | undefined {
+    const value = this.map.get(key);
+    if (value === undefined) return undefined;
+    if (this.isExpired(value, now)) {
+      this.delete(key);
+      return undefined;
+    }
+    return value;
+  }
+
+  /** Raw stored value, no expiry check (peek). Used by mutate-in-place callers
+   *  (rate-limit increment/addTimestamp) that must NOT delete on expiry mid-op. */
+  peek(key: string): V | undefined {
+    return this.map.get(key);
+  }
+
+  /** True if a live (non-expired) value exists; deletes on expiry-on-read. */
+  has(key: string, now: number = Date.now()): boolean {
+    return this.get(key, now) !== undefined;
+  }
+
+  /** Insert/overwrite. When `refreshLruOnOverwrite` is true and the key exists,
+   *  the old entry is deleted first (firing `onEvict` for the OLD value) so the
+   *  key moves to the newest position (cache's delete-then-reinsert LRU refresh).
+   *  Capacity eviction runs BEFORE insert only when the key is new and at/over
+   *  `maxEntries`. */
+  set(key: string, value: V, refreshLruOnOverwrite = false): void {
+    const existed = this.map.has(key);
+    if (this.maxEntries > 0 && this.map.size >= this.maxEntries && !existed) {
+      this.evictOldest();
+    }
+    if (existed && refreshLruOnOverwrite) {
+      const old = this.map.get(key) as V;
+      this.map.delete(key);
+      this.onEvict?.(key, old);
+    }
+    this.map.set(key, value);
+  }
+
+  /** Delete a key, firing `onEvict` if present. Returns true if removed. */
+  delete(key: string): boolean {
+    const value = this.map.get(key);
+    if (value === undefined) return false;
+    this.map.delete(key);
+    this.onEvict?.(key, value);
+    return true;
+  }
+
+  private evictOldest(): void {
+    const oldestKey = this.map.keys().next().value;
+    if (oldestKey !== undefined) this.delete(oldestKey);
+  }
+
+  /** Remove all expired entries. Returns the number removed. */
+  cleanup(now: number = Date.now()): number {
+    let count = 0;
+    const stale: string[] = [];
+    for (const [key, value] of this.map.entries()) {
+      if (this.isExpired(value, now)) stale.push(key);
+    }
+    for (const key of stale) {
+      if (this.delete(key)) count++;
+    }
+    return count;
+  }
+
+  /** Clear all entries WITHOUT firing `onEvict` (owner resets side-indices). */
+  clear(): void {
+    this.map.clear();
+  }
+
+  get size(): number {
+    return this.map.size;
+  }
+
+  getKeys(): string[] {
+    return Array.from(this.map.keys());
+  }
+
+  entries(): IterableIterator<[string, V]> {
+    return this.map.entries();
+  }
+}

--- a/packages/drizzle/src/helpers.ts
+++ b/packages/drizzle/src/helpers.ts
@@ -20,9 +20,16 @@ import type {
   FilterCondition,
   IncludeOptions,
   MetaInput,
+  RelatedRecord,
   RelationConfig,
+  RelationLoaderAdapter,
 } from 'hono-crud/internal';
-import { assertNever } from 'hono-crud/internal';
+import {
+  assertNever,
+  batchLoadRelations,
+  loadRelationsForItem,
+  resolveRelationValueAsync,
+} from 'hono-crud/internal';
 
 // ============================================================================
 // Local stand-ins for drizzle-orm builder types
@@ -234,7 +241,28 @@ export function getColumn(table: DrizzleTable, field: string): DrizzleColumn {
 }
 
 /**
- * Loads related records for a given item using Drizzle queries.
+ * Builds the relation-loader adapter for Drizzle: resolves a relation's
+ * {@link DrizzleTable} handle and issues the single `inArray` fetch the core
+ * orchestrator drives. Drizzle's query builder satisfies the orchestrator's
+ * `PromiseLike<RelatedRecord[]>` `fetchRelated` return.
+ */
+function drizzleRelationAdapter(
+  db: DrizzleDatabaseConstraint,
+): RelationLoaderAdapter<DrizzleTable> {
+  return {
+    resolveRelation: (config) => (config as RelationConfig<DrizzleTable>).table ?? null,
+    fetchRelated: (table, keyField, values) =>
+      cast<RelatedRecord>(db)
+        .select()
+        .from(table)
+        .where(inArray(getColumn(table, keyField), values)),
+  };
+}
+
+/**
+ * Loads a single related record/collection for a given item using Drizzle
+ * queries. Always sets the relation key: hasOne/belongsTo → record-or-null,
+ * hasMany → array (including when the gate value is null).
  */
 export async function loadDrizzleRelation<T extends Record<string, unknown>>(
   db: DrizzleDatabaseConstraint,
@@ -242,58 +270,14 @@ export async function loadDrizzleRelation<T extends Record<string, unknown>>(
   relationName: string,
   relationConfig: RelationConfig<DrizzleTable>,
 ): Promise<T> {
-  if (!relationConfig.table) {
+  const table = relationConfig.table;
+  if (!table) {
     // Can't load relation without table reference
     return item;
   }
-
-  const relatedTable = relationConfig.table;
-
-  switch (relationConfig.type) {
-    case 'hasOne': {
-      const localKey = relationConfig.localKey || 'id';
-      const localValue = item[localKey];
-      if (localValue === undefined || localValue === null) {
-        return item;
-      }
-      const foreignKeyColumn = getColumn(relatedTable, relationConfig.foreignKey);
-      const results = await cast(db)
-        .select()
-        .from(relatedTable)
-        .where(eq(foreignKeyColumn, localValue))
-        .limit(1);
-      return { ...item, [relationName]: results[0] || null };
-    }
-    case 'hasMany': {
-      const localKey = relationConfig.localKey || 'id';
-      const localValue = item[localKey];
-      if (localValue === undefined || localValue === null) {
-        return { ...item, [relationName]: [] };
-      }
-      const foreignKeyColumn = getColumn(relatedTable, relationConfig.foreignKey);
-      const results = await cast(db)
-        .select()
-        .from(relatedTable)
-        .where(eq(foreignKeyColumn, localValue));
-      return { ...item, [relationName]: results };
-    }
-    case 'belongsTo': {
-      // For belongsTo, the foreign key is on the current item
-      const foreignValue = item[relationConfig.foreignKey];
-      if (foreignValue === undefined || foreignValue === null) {
-        return { ...item, [relationName]: null };
-      }
-      const localKeyColumn = getColumn(relatedTable, relationConfig.localKey || 'id');
-      const results = await cast(db)
-        .select()
-        .from(relatedTable)
-        .where(eq(localKeyColumn, foreignValue))
-        .limit(1);
-      return { ...item, [relationName]: results[0] || null };
-    }
-    default:
-      return item;
-  }
+  const adapter = drizzleRelationAdapter(db);
+  const value = await resolveRelationValueAsync(item, relationConfig, table, adapter.fetchRelated);
+  return { ...item, [relationName]: value } as T;
 }
 
 /**
@@ -306,22 +290,7 @@ export async function loadDrizzleRelations<T extends Record<string, unknown>, M 
   meta: M,
   includeOptions?: IncludeOptions,
 ): Promise<T> {
-  if (!includeOptions?.relations?.length || !meta.model.relations) {
-    return item;
-  }
-
-  let result = { ...item } as T;
-
-  for (const relationName of includeOptions.relations) {
-    const relationConfig = meta.model.relations[relationName] as
-      | RelationConfig<DrizzleTable>
-      | undefined;
-    if (relationConfig) {
-      result = await loadDrizzleRelation(db, result, relationName, relationConfig);
-    }
-  }
-
-  return result;
+  return loadRelationsForItem(item, meta, drizzleRelationAdapter(db), includeOptions);
 }
 
 /**
@@ -337,125 +306,7 @@ export async function batchLoadDrizzleRelations<
   meta: M,
   includeOptions?: IncludeOptions,
 ): Promise<T[]> {
-  if (!items.length || !includeOptions?.relations?.length || !meta.model.relations) {
-    return items;
-  }
-
-  // Clone all items to avoid mutation
-  let results = items.map((item) => ({ ...item })) as T[];
-
-  for (const relationName of includeOptions.relations) {
-    const relationConfig = meta.model.relations[relationName] as
-      | RelationConfig<DrizzleTable>
-      | undefined;
-    if (!relationConfig || !relationConfig.table) {
-      continue;
-    }
-
-    const relatedTable = relationConfig.table;
-
-    switch (relationConfig.type) {
-      case 'hasOne':
-      case 'hasMany': {
-        const localKey = relationConfig.localKey || 'id';
-
-        // Collect all unique local values
-        const localValues = [
-          ...new Set(
-            results
-              .map((item) => item[localKey])
-              .filter((val) => val !== undefined && val !== null),
-          ),
-        ];
-
-        if (localValues.length === 0) {
-          // Set empty results for all items
-          results = results.map((item) => ({
-            ...item,
-            [relationName]: relationConfig.type === 'hasMany' ? [] : null,
-          }));
-          continue;
-        }
-
-        // Batch query: Load all related records in a single query
-        const foreignKeyColumn = getColumn(relatedTable, relationConfig.foreignKey);
-        const relatedRecords = await cast(db)
-          .select()
-          .from(relatedTable)
-          .where(inArray(foreignKeyColumn, localValues));
-
-        // Group related records by foreign key
-        const recordsByForeignKey = new Map<unknown, Record<string, unknown>[]>();
-        for (const record of relatedRecords) {
-          const foreignVal = (record as Record<string, unknown>)[relationConfig.foreignKey];
-          if (!recordsByForeignKey.has(foreignVal)) {
-            recordsByForeignKey.set(foreignVal, []);
-          }
-          recordsByForeignKey.get(foreignVal)!.push(record as Record<string, unknown>);
-        }
-
-        // Map results back to items
-        results = results.map((item) => {
-          const localValue = item[localKey];
-          const related = recordsByForeignKey.get(localValue) || [];
-          return {
-            ...item,
-            [relationName]: relationConfig.type === 'hasMany' ? related : related[0] || null,
-          };
-        });
-        break;
-      }
-
-      case 'belongsTo': {
-        // For belongsTo, the foreign key is on the current item
-        const refLocalKey = relationConfig.localKey || 'id';
-
-        // Collect all unique foreign key values
-        const foreignValues = [
-          ...new Set(
-            results
-              .map((item) => item[relationConfig.foreignKey])
-              .filter((val) => val !== undefined && val !== null),
-          ),
-        ];
-
-        if (foreignValues.length === 0) {
-          // Set null for all items
-          results = results.map((item) => ({
-            ...item,
-            [relationName]: null,
-          }));
-          continue;
-        }
-
-        // Batch query: Load all parent records in a single query
-        const localKeyColumn = getColumn(relatedTable, refLocalKey);
-        const relatedRecords = await cast(db)
-          .select()
-          .from(relatedTable)
-          .where(inArray(localKeyColumn, foreignValues));
-
-        // Create a map for quick lookup
-        const recordsByLocalKey = new Map<unknown, Record<string, unknown>>();
-        for (const record of relatedRecords) {
-          const localVal = (record as Record<string, unknown>)[refLocalKey];
-          recordsByLocalKey.set(localVal, record as Record<string, unknown>);
-        }
-
-        // Map results back to items
-        results = results.map((item) => {
-          const foreignValue = item[relationConfig.foreignKey];
-          return {
-            ...item,
-            [relationName]: recordsByLocalKey.get(foreignValue) || null,
-          };
-        });
-        break;
-      }
-    }
-  }
-
-  return results;
+  return batchLoadRelations(items, meta, drizzleRelationAdapter(db), includeOptions);
 }
 
 /**

--- a/packages/idempotency/src/storage/memory.ts
+++ b/packages/idempotency/src/storage/memory.ts
@@ -1,3 +1,4 @@
+import { MemoryTtlStore } from 'hono-crud/internal';
 import type { IdempotencyEntry, IdempotencyStorage } from '../types';
 
 /**
@@ -14,19 +15,32 @@ import type { IdempotencyEntry, IdempotencyStorage } from '../types';
  * ```
  */
 export class MemoryIdempotencyStorage implements IdempotencyStorage {
-  private entries = new Map<string, { entry: IdempotencyEntry; expiresAt: number }>();
-  private locks = new Map<string, number>();
+  /** Entry store. The wrapper carries the per-entry expiry timestamp. */
+  private entryStore: MemoryTtlStore<{ entry: IdempotencyEntry; expiresAt: number }>;
+  /** Lock store. The value IS the lock's expiry timestamp. */
+  private lockStore: MemoryTtlStore<number>;
 
   /** Minimum interval between cleanup runs (ms) */
   private cleanupInterval: number;
   /** Timestamp of last cleanup run */
   private lastCleanup = 0;
-  /** Maximum number of entries before evicting oldest */
-  private maxEntries: number;
 
   constructor(options?: { cleanupInterval?: number; maxEntries?: number }) {
     this.cleanupInterval = options?.cleanupInterval ?? 60000;
-    this.maxEntries = options?.maxEntries ?? 10_000;
+    const maxEntries = options?.maxEntries ?? 10_000;
+    // Both inner stores keep `cleanupInterval: 0` so their built-in
+    // `maybeCleanup` is a no-op; the domain class owns the single guarded
+    // lazy sweep over BOTH maps (see `maybeCleanup` below).
+    this.entryStore = new MemoryTtlStore({
+      isExpired: (wrapper, now) => now > wrapper.expiresAt,
+      cleanupInterval: 0,
+      maxEntries,
+    });
+    this.lockStore = new MemoryTtlStore<number>({
+      isExpired: (expiresAt, now) => now > expiresAt,
+      cleanupInterval: 0,
+      maxEntries: 0,
+    });
   }
 
   private maybeCleanup(): void {
@@ -34,26 +48,9 @@ export class MemoryIdempotencyStorage implements IdempotencyStorage {
     const now = Date.now();
     if (now - this.lastCleanup >= this.cleanupInterval) {
       this.lastCleanup = now;
-      this.cleanupExpired();
+      this.entryStore.cleanup(now);
+      this.lockStore.cleanup(now);
     }
-  }
-
-  private cleanupExpired(): number {
-    const now = Date.now();
-    let removed = 0;
-    for (const [key, value] of this.entries.entries()) {
-      if (now > value.expiresAt) {
-        this.entries.delete(key);
-        removed++;
-      }
-    }
-    for (const [key, expiresAt] of this.locks.entries()) {
-      if (now > expiresAt) {
-        this.locks.delete(key);
-        removed++;
-      }
-    }
-    return removed;
   }
 
   /**
@@ -61,61 +58,42 @@ export class MemoryIdempotencyStorage implements IdempotencyStorage {
    * @returns Number of expired entries and locks removed.
    */
   async cleanup(): Promise<number> {
-    return this.cleanupExpired();
+    return this.entryStore.cleanup() + this.lockStore.cleanup();
   }
 
   async get(key: string): Promise<IdempotencyEntry | null> {
     this.maybeCleanup();
-    const stored = this.entries.get(key);
-    if (!stored) return null;
-    if (Date.now() > stored.expiresAt) {
-      this.entries.delete(key);
-      return null;
-    }
-    return stored.entry;
+    const wrapper = this.entryStore.get(key);
+    return wrapper ? wrapper.entry : null;
   }
 
   async set(key: string, entry: IdempotencyEntry, ttlMs: number): Promise<void> {
     this.maybeCleanup();
-    // Evict oldest entry if at capacity
-    if (this.maxEntries > 0 && this.entries.size >= this.maxEntries && !this.entries.has(key)) {
-      const oldestKey = this.entries.keys().next().value;
-      if (oldestKey !== undefined) {
-        this.entries.delete(oldestKey);
-      }
-    }
-    this.entries.set(key, {
-      entry,
-      expiresAt: Date.now() + ttlMs,
-    });
+    // Capacity eviction (oldest-first) happens inside the store.
+    this.entryStore.set(key, { entry, expiresAt: Date.now() + ttlMs });
   }
 
   async isLocked(key: string): Promise<boolean> {
-    const expiresAt = this.locks.get(key);
-    if (!expiresAt) return false;
-    if (Date.now() > expiresAt) {
-      this.locks.delete(key);
-      return false;
-    }
-    return true;
+    // Expiry-on-read deletes a stale lock and reports it as absent.
+    return this.lockStore.has(key);
   }
 
   async lock(key: string, ttlMs: number): Promise<boolean> {
     if (await this.isLocked(key)) return false;
-    this.locks.set(key, Date.now() + ttlMs);
+    this.lockStore.set(key, Date.now() + ttlMs);
     return true;
   }
 
   async unlock(key: string): Promise<void> {
-    this.locks.delete(key);
+    this.lockStore.delete(key);
   }
 
   destroy(): void {
-    this.entries.clear();
-    this.locks.clear();
+    this.entryStore.clear();
+    this.lockStore.clear();
   }
 
   getSize(): number {
-    return this.entries.size;
+    return this.entryStore.size;
   }
 }

--- a/packages/memory/src/helpers.ts
+++ b/packages/memory/src/helpers.ts
@@ -1,4 +1,10 @@
-import type { IncludeOptions, MetaInput, RelationConfig } from 'hono-crud/internal';
+import {
+  type IncludeOptions,
+  type MetaInput,
+  type RelatedRecord,
+  type SyncRelationLoaderAdapter,
+  loadRelationsForItemSync,
+} from 'hono-crud/internal';
 
 /**
  * Module-level in-memory storage.
@@ -24,68 +30,34 @@ export function getStore<T>(tableName: string): Map<string, T> {
 }
 
 /**
- * Loads related records for a given item based on relation configuration.
+ * Builds the synchronous relation-loader adapter backing the in-memory store.
+ *
+ * The handle is the backing per-table Map; `resolveRelation` never returns
+ * `null` because `getStore` always creates the table lazily (memory never skips
+ * a relation). `fetchRelated` filters the store's records by the requested key.
  */
-export function loadRelation<T extends Record<string, unknown>>(
-  item: T,
-  relationName: string,
-  relationConfig: RelationConfig,
-): T {
-  const relatedStore = getStore<Record<string, unknown>>(relationConfig.model);
-  const localKey = relationConfig.localKey || 'id';
-  const localValue = item[localKey];
-
-  if (localValue === undefined || localValue === null) {
-    return item;
-  }
-
-  const relatedItems = Array.from(relatedStore.values()).filter((relatedItem) => {
-    return relatedItem[relationConfig.foreignKey] === localValue;
-  });
-
-  switch (relationConfig.type) {
-    case 'hasOne':
-      return { ...item, [relationName]: relatedItems[0] || null };
-    case 'hasMany':
-      return { ...item, [relationName]: relatedItems };
-    case 'belongsTo': {
-      // For belongsTo, the foreign key is on the current item
-      const foreignValue = item[relationConfig.foreignKey];
-      if (foreignValue === undefined || foreignValue === null) {
-        return { ...item, [relationName]: null };
-      }
-      const parentItem = Array.from(relatedStore.values()).find(
-        (r) => r[relationConfig.localKey || 'id'] === foreignValue,
-      );
-      return { ...item, [relationName]: parentItem || null };
-    }
-    default:
-      return item;
-  }
+function memoryRelationAdapter(): SyncRelationLoaderAdapter<Map<string, RelatedRecord>> {
+  return {
+    resolveRelation: (config) => getStore<RelatedRecord>(config.model),
+    fetchRelated: (store, keyField, values) =>
+      Array.from(store.values()).filter((r) => values.includes(r[keyField])),
+  };
 }
 
 /**
  * Loads all requested relations for an item.
+ *
+ * Delegates to the core synchronous orchestrator so the single-item read path
+ * always sets the relation key (hasOne/belongsTo → record-or-null, hasMany →
+ * array), gating belongsTo on `item[foreignKey]` and hasOne/hasMany on
+ * `item[localKey]`.
  */
 export function loadRelations<T extends Record<string, unknown>, M extends MetaInput>(
   item: T,
   meta: M,
   includeOptions?: IncludeOptions,
 ): T {
-  if (!includeOptions?.relations?.length || !meta.model.relations) {
-    return item;
-  }
-
-  let result = { ...item } as T;
-
-  for (const relationName of includeOptions.relations) {
-    const relationConfig = meta.model.relations[relationName];
-    if (relationConfig) {
-      result = loadRelation(result, relationName, relationConfig);
-    }
-  }
-
-  return result;
+  return loadRelationsForItemSync(item, meta, memoryRelationAdapter(), includeOptions);
 }
 
 /**

--- a/packages/prisma/src/helpers.ts
+++ b/packages/prisma/src/helpers.ts
@@ -12,9 +12,9 @@ import type {
   ListFilters,
   MetaInput,
   PaginatedResult,
-  RelationConfig,
+  RelationLoaderAdapter,
 } from 'hono-crud/internal';
-import { assertNever } from 'hono-crud/internal';
+import { assertNever, batchLoadRelations, loadRelationsForItem } from 'hono-crud/internal';
 import { inlineSingular, levenshteinDistance } from './pluralize';
 
 /**
@@ -388,60 +388,21 @@ export async function getPrismaModel<Row = Record<string, unknown>>(
 }
 
 /**
- * Loads a single relation for an item.
+ * Builds the Prisma relation-loader adapter for the core orchestrator.
+ *
+ * - `resolveRelation` resolves the related model delegate by name (async because
+ *   `getModelName` is async), returning `null` to skip when the model is not
+ *   found in the client.
+ * - `fetchRelated` issues the one-line `findMany({ where: { [keyField]: { in } } })`
+ *   query the batch + single-item loaders share.
  */
-export async function loadPrismaRelation<T extends Record<string, unknown>>(
-  prisma: PrismaClient,
-  item: T,
-  relationName: string,
-  relationConfig: RelationConfig,
-): Promise<T> {
-  const relatedModelName = await getModelName(relationConfig.model);
-  const relatedModel = getPrismaModelByName(prisma, relatedModelName);
-
-  if (!relatedModel) {
-    // Can't load relation without the related model
-    return item;
-  }
-
-  switch (relationConfig.type) {
-    case 'hasOne': {
-      const localKey = relationConfig.localKey || 'id';
-      const localValue = item[localKey];
-      if (localValue === undefined || localValue === null) {
-        return { ...item, [relationName]: null };
-      }
-      const result = await relatedModel.findFirst({
-        where: { [relationConfig.foreignKey]: localValue },
-      });
-      return { ...item, [relationName]: result || null };
-    }
-    case 'hasMany': {
-      const localKey = relationConfig.localKey || 'id';
-      const localValue = item[localKey];
-      if (localValue === undefined || localValue === null) {
-        return { ...item, [relationName]: [] };
-      }
-      const results = await relatedModel.findMany({
-        where: { [relationConfig.foreignKey]: localValue },
-      });
-      return { ...item, [relationName]: results };
-    }
-    case 'belongsTo': {
-      // For belongsTo, the foreign key is on the current item
-      const foreignValue = item[relationConfig.foreignKey];
-      if (foreignValue === undefined || foreignValue === null) {
-        return { ...item, [relationName]: null };
-      }
-      const localKey = relationConfig.localKey || 'id';
-      const result = await relatedModel.findFirst({
-        where: { [localKey]: foreignValue },
-      });
-      return { ...item, [relationName]: result || null };
-    }
-    default:
-      return item;
-  }
+function prismaRelationAdapter(prisma: PrismaClient): RelationLoaderAdapter<PrismaModelOperations> {
+  return {
+    resolveRelation: async (config) =>
+      getPrismaModelByName(prisma, await getModelName(config.model)) ?? null,
+    fetchRelated: (model, keyField, values) =>
+      model.findMany({ where: { [keyField]: { in: values } } }),
+  };
 }
 
 /**
@@ -454,20 +415,7 @@ export async function loadPrismaRelations<T extends Record<string, unknown>, M e
   meta: M,
   includeOptions?: IncludeOptions,
 ): Promise<T> {
-  if (!includeOptions?.relations?.length || !meta.model.relations) {
-    return item;
-  }
-
-  let result = { ...item } as T;
-
-  for (const relationName of includeOptions.relations) {
-    const relationConfig = meta.model.relations[relationName];
-    if (relationConfig) {
-      result = await loadPrismaRelation(prisma, result, relationName, relationConfig);
-    }
-  }
-
-  return result;
+  return loadRelationsForItem(item, meta, prismaRelationAdapter(prisma), includeOptions);
 }
 
 /**
@@ -478,124 +426,7 @@ export async function batchLoadPrismaRelations<
   T extends Record<string, unknown>,
   M extends MetaInput,
 >(prisma: PrismaClient, items: T[], meta: M, includeOptions?: IncludeOptions): Promise<T[]> {
-  if (!items.length || !includeOptions?.relations?.length || !meta.model.relations) {
-    return items;
-  }
-
-  // Clone all items to avoid mutation
-  let results = items.map((item) => ({ ...item })) as T[];
-
-  for (const relationName of includeOptions.relations) {
-    const relationConfig = meta.model.relations[relationName];
-    if (!relationConfig) {
-      continue;
-    }
-
-    const relatedModelName = await getModelName(relationConfig.model);
-    const relatedModel = getPrismaModelByName(prisma, relatedModelName);
-
-    if (!relatedModel) {
-      continue;
-    }
-
-    switch (relationConfig.type) {
-      case 'hasOne':
-      case 'hasMany': {
-        const localKey = relationConfig.localKey || 'id';
-
-        // Collect all unique local values
-        const localValues = [
-          ...new Set(
-            results
-              .map((item) => item[localKey])
-              .filter((val) => val !== undefined && val !== null),
-          ),
-        ];
-
-        if (localValues.length === 0) {
-          // Set empty results for all items
-          results = results.map((item) => ({
-            ...item,
-            [relationName]: relationConfig.type === 'hasMany' ? [] : null,
-          }));
-          continue;
-        }
-
-        // Batch query: Load all related records in a single query
-        const relatedRecords = await relatedModel.findMany({
-          where: { [relationConfig.foreignKey]: { in: localValues } },
-        });
-
-        // Group related records by foreign key
-        const recordsByForeignKey = new Map<unknown, Record<string, unknown>[]>();
-        for (const record of relatedRecords) {
-          const foreignVal = record[relationConfig.foreignKey];
-          if (!recordsByForeignKey.has(foreignVal)) {
-            recordsByForeignKey.set(foreignVal, []);
-          }
-          recordsByForeignKey.get(foreignVal)!.push(record);
-        }
-
-        // Map results back to items
-        results = results.map((item) => {
-          const localValue = item[localKey];
-          const related = recordsByForeignKey.get(localValue) || [];
-          return {
-            ...item,
-            [relationName]: relationConfig.type === 'hasMany' ? related : related[0] || null,
-          };
-        });
-        break;
-      }
-
-      case 'belongsTo': {
-        // For belongsTo, the foreign key is on the current item
-        const refLocalKey = relationConfig.localKey || 'id';
-
-        // Collect all unique foreign key values
-        const foreignValues = [
-          ...new Set(
-            results
-              .map((item) => item[relationConfig.foreignKey])
-              .filter((val) => val !== undefined && val !== null),
-          ),
-        ];
-
-        if (foreignValues.length === 0) {
-          // Set null for all items
-          results = results.map((item) => ({
-            ...item,
-            [relationName]: null,
-          }));
-          continue;
-        }
-
-        // Batch query: Load all parent records in a single query
-        const relatedRecords = await relatedModel.findMany({
-          where: { [refLocalKey]: { in: foreignValues } },
-        });
-
-        // Create a map for quick lookup
-        const recordsByLocalKey = new Map<unknown, Record<string, unknown>>();
-        for (const record of relatedRecords) {
-          const localVal = record[refLocalKey];
-          recordsByLocalKey.set(localVal, record);
-        }
-
-        // Map results back to items
-        results = results.map((item) => {
-          const foreignValue = item[relationConfig.foreignKey];
-          return {
-            ...item,
-            [relationName]: recordsByLocalKey.get(foreignValue) || null,
-          };
-        });
-        break;
-      }
-    }
-  }
-
-  return results;
+  return batchLoadRelations(items, meta, prismaRelationAdapter(prisma), includeOptions);
 }
 
 /**

--- a/packages/rate-limit/src/storage/memory.ts
+++ b/packages/rate-limit/src/storage/memory.ts
@@ -1,3 +1,4 @@
+import { MemoryTtlStore } from 'hono-crud/internal';
 import type {
   FixedWindowEntry,
   RateLimitEntry,
@@ -17,6 +18,16 @@ export interface MemoryRateLimitStorageOptions {
    * @default 60000 (1 minute)
    */
   cleanupInterval?: number;
+}
+
+/**
+ * Wrapper folding the entry together with its expiration timestamp so a single
+ * {@link MemoryTtlStore} owns both (replacing the old separate `expirations` Map).
+ */
+interface RateLimitWrapper {
+  entry: RateLimitEntry;
+  /** Expiration timestamp (ms). Entry is expired once `now > expiresAt`. */
+  expiresAt: number;
 }
 
 /**
@@ -43,49 +54,15 @@ export interface MemoryRateLimitStorageOptions {
  * ```
  */
 export class MemoryRateLimitStorage implements RateLimitStorage {
-  /** Main storage: key -> entry */
-  private storage = new Map<string, RateLimitEntry>();
-
-  /** Expiration times: key -> expiration timestamp (ms) */
-  private expirations = new Map<string, number>();
-
-  /** Minimum interval between cleanup runs (ms) */
-  private cleanupInterval: number;
-
-  /** Timestamp of last cleanup run */
-  private lastCleanup = 0;
+  /** Main storage: key -> { entry, expiresAt } wrapper. */
+  private store: MemoryTtlStore<RateLimitWrapper>;
 
   constructor(options?: MemoryRateLimitStorageOptions) {
-    this.cleanupInterval = options?.cleanupInterval ?? 60000;
-  }
-
-  /**
-   * Runs cleanup if enough time has passed since last cleanup.
-   * Called lazily on access to avoid background timers.
-   */
-  private maybeCleanup(): void {
-    if (this.cleanupInterval <= 0) return;
-    const now = Date.now();
-    if (now - this.lastCleanup >= this.cleanupInterval) {
-      this.lastCleanup = now;
-      this.cleanupSync();
-    }
-  }
-
-  /**
-   * Synchronous cleanup of expired entries.
-   */
-  private cleanupSync(): number {
-    const now = Date.now();
-    let count = 0;
-    for (const [key, expiration] of this.expirations.entries()) {
-      if (now > expiration) {
-        this.storage.delete(key);
-        this.expirations.delete(key);
-        count++;
-      }
-    }
-    return count;
+    this.store = new MemoryTtlStore<RateLimitWrapper>({
+      isExpired: (wrapper, now) => now > wrapper.expiresAt,
+      cleanupInterval: options?.cleanupInterval ?? 60000,
+      maxEntries: 0,
+    });
   }
 
   /**
@@ -93,29 +70,27 @@ export class MemoryRateLimitStorage implements RateLimitStorage {
    * Creates the entry if it doesn't exist or window has expired.
    */
   async increment(key: string, windowMs: number): Promise<FixedWindowEntry> {
-    this.maybeCleanup();
+    this.store.maybeCleanup();
     const now = Date.now();
-    const existing = this.storage.get(key) as FixedWindowEntry | undefined;
+    // peek: read the raw wrapper without expiry-deleting it mid-mutation.
+    const wrapper = this.store.peek(key);
+    const existing = wrapper?.entry as FixedWindowEntry | undefined;
 
-    // Check if we have a valid existing entry
-    if (existing && 'count' in existing) {
-      const windowEnd = existing.windowStart + windowMs;
-
-      if (now < windowEnd) {
-        // Within current window, increment
-        existing.count++;
-        return existing;
-      }
+    // Check if we have a valid existing entry within the current window.
+    if (existing && 'count' in existing && now < existing.windowStart + windowMs) {
+      // Within current window: increment the live entry in place. The wrapper is
+      // the same object the store holds, and the fixed-window expiry stays at
+      // `windowStart + windowMs` (do NOT slide it), so no re-set is needed.
+      existing.count++;
+      return existing;
     }
 
-    // Start new window
+    // Start new window and set its expiry.
     const entry: FixedWindowEntry = {
       count: 1,
       windowStart: now,
     };
-
-    this.storage.set(key, entry);
-    this.expirations.set(key, now + windowMs);
+    this.store.set(key, { entry, expiresAt: now + windowMs });
 
     return entry;
   }
@@ -125,27 +100,27 @@ export class MemoryRateLimitStorage implements RateLimitStorage {
    * Removes timestamps outside the window.
    */
   async addTimestamp(key: string, windowMs: number, now?: number): Promise<SlidingWindowEntry> {
-    this.maybeCleanup();
+    this.store.maybeCleanup();
     const currentTime = now ?? Date.now();
     const windowStart = currentTime - windowMs;
 
-    const existing = this.storage.get(key) as SlidingWindowEntry | undefined;
+    // peek: read the raw wrapper without expiry-deleting it mid-mutation.
+    const wrapper = this.store.peek(key);
+    const existing = wrapper?.entry as SlidingWindowEntry | undefined;
 
     let timestamps: number[];
     if (existing && 'timestamps' in existing) {
-      // Filter out expired timestamps and add new one
+      // Filter out expired timestamps and add new one.
       timestamps = existing.timestamps.filter((t) => t > windowStart);
       timestamps.push(currentTime);
       existing.timestamps = timestamps;
+      // Sliding window refreshes expiry every call (window duration from now).
+      this.store.set(key, { entry: existing, expiresAt: currentTime + windowMs });
     } else {
-      // Create new entry
+      // Create new entry.
       timestamps = [currentTime];
-      const entry: SlidingWindowEntry = { timestamps };
-      this.storage.set(key, entry);
+      this.store.set(key, { entry: { timestamps }, expiresAt: currentTime + windowMs });
     }
-
-    // Set expiration (window duration from now)
-    this.expirations.set(key, currentTime + windowMs);
 
     return { timestamps };
   }
@@ -154,58 +129,43 @@ export class MemoryRateLimitStorage implements RateLimitStorage {
    * Get the current entry for a key.
    */
   async get(key: string): Promise<RateLimitEntry | null> {
-    this.maybeCleanup();
-    const entry = this.storage.get(key);
-
-    if (!entry) {
-      return null;
-    }
-
-    // Check expiration
-    const expiration = this.expirations.get(key);
-    if (expiration && Date.now() > expiration) {
-      this.storage.delete(key);
-      this.expirations.delete(key);
-      return null;
-    }
-
-    return entry;
+    this.store.maybeCleanup();
+    const wrapper = this.store.get(key);
+    return wrapper ? wrapper.entry : null;
   }
 
   /**
    * Reset the rate limit for a key.
    */
   async reset(key: string): Promise<void> {
-    this.storage.delete(key);
-    this.expirations.delete(key);
+    this.store.delete(key);
   }
 
   /**
    * Clean up expired entries.
    */
   async cleanup(): Promise<number> {
-    return this.cleanupSync();
+    return this.store.cleanup();
   }
 
   /**
    * Destroy the storage and clear all data.
    */
   destroy(): void {
-    this.storage.clear();
-    this.expirations.clear();
+    this.store.clear();
   }
 
   /**
    * Get the number of entries (for debugging/monitoring).
    */
   getSize(): number {
-    return this.storage.size;
+    return this.store.size;
   }
 
   /**
    * Get all keys (for debugging).
    */
   getKeys(): string[] {
-    return Array.from(this.storage.keys());
+    return this.store.getKeys();
   }
 }

--- a/tests/cache-entry-codec.test.ts
+++ b/tests/cache-entry-codec.test.ts
@@ -1,0 +1,205 @@
+// Unit tests for the cache entry codec shared by the memory/redis/KV backends.
+//
+// IMPORT NOTE: `@hono-crud/cache/entry` is internal/alias-only — it is NOT
+// published as a package subpath (`@hono-crud/cache` declares only `'.'` in its
+// `exports`). These tests reach it through the vitest source alias (the same
+// alias-only pattern the other `@hono-crud/cache/storage/*` tests use); the
+// import is not a public API surface.
+import { buildCacheEntry, isCacheEntryExpired, normalizeStoredEntry } from '@hono-crud/cache/entry';
+import type { CacheEntry } from 'hono-crud/internal';
+import { describe, expect, it } from 'vitest';
+
+describe('cache entry codec', () => {
+  describe('buildCacheEntry', () => {
+    it('sets expiresAt = now + ttlMs for positive ttlMs (numbers, no x1000)', () => {
+      const now = 1_000_000;
+      const entry = buildCacheEntry({ name: 'a' }, 5000, ['t1'], now);
+
+      expect(entry.data).toEqual({ name: 'a' });
+      expect(entry.createdAt).toBe(now);
+      expect(entry.expiresAt).toBe(now + 5000);
+      expect(entry.tags).toEqual(['t1']);
+      expect(entry.createdAt).toBeTypeOf('number');
+      expect(entry.expiresAt).toBeTypeOf('number');
+    });
+
+    it('sets expiresAt = null for ttlMs === 0 ("never expires")', () => {
+      const now = 2_000_000;
+      const entry = buildCacheEntry('payload', 0, undefined, now);
+
+      expect(entry.createdAt).toBe(now);
+      expect(entry.expiresAt).toBeNull();
+      expect(entry.tags).toBeUndefined();
+    });
+
+    it('sets expiresAt = null for negative ttlMs', () => {
+      const entry = buildCacheEntry('payload', -1, undefined, 3_000_000);
+      expect(entry.expiresAt).toBeNull();
+    });
+
+    it('passes tags through untouched (including undefined)', () => {
+      const tags = ['users', 'tenant:1'];
+      const withTags = buildCacheEntry(1, 1000, tags, 0);
+      expect(withTags.tags).toBe(tags);
+
+      const noTags = buildCacheEntry(1, 1000, undefined, 0);
+      expect(noTags.tags).toBeUndefined();
+    });
+
+    it('defaults `now` to Date.now() when omitted', () => {
+      const before = Date.now();
+      const entry = buildCacheEntry('x', 1000, undefined);
+      const after = Date.now();
+
+      expect(entry.createdAt).toBeGreaterThanOrEqual(before);
+      expect(entry.createdAt).toBeLessThanOrEqual(after);
+      expect(entry.expiresAt).toBe(entry.createdAt + 1000);
+    });
+  });
+
+  describe('normalizeStoredEntry', () => {
+    it('migrates legacy ISO-Date-string createdAt/expiresAt to epoch ms', () => {
+      const now = Date.now();
+      const createdAtIso = new Date(now - 1000).toISOString();
+      const expiresAtIso = new Date(now + 60_000).toISOString();
+
+      // Legacy on-wire shape used string dates; launder through unknown to build
+      // the fixture without `any`.
+      const raw = {
+        data: { name: 'legacy' },
+        createdAt: createdAtIso,
+        expiresAt: expiresAtIso,
+        tags: ['t'],
+      } as unknown as CacheEntry<{ name: string }>;
+
+      const entry = normalizeStoredEntry(raw);
+
+      expect(entry.createdAt).toBe(Date.parse(createdAtIso));
+      expect(entry.expiresAt).toBe(Date.parse(expiresAtIso));
+      expect(entry.createdAt).toBeTypeOf('number');
+      expect(entry.expiresAt).toBeTypeOf('number');
+      expect(entry.data).toEqual({ name: 'legacy' });
+    });
+
+    it('falls back createdAt → Date.now() when the legacy string is unparseable', () => {
+      const before = Date.now();
+      const raw = {
+        data: 'x',
+        createdAt: 'not-a-date',
+        expiresAt: null,
+      } as unknown as CacheEntry<string>;
+
+      const entry = normalizeStoredEntry(raw);
+      const after = Date.now();
+
+      expect(entry.createdAt).toBeTypeOf('number');
+      expect(entry.createdAt).toBeGreaterThanOrEqual(before);
+      expect(entry.createdAt).toBeLessThanOrEqual(after);
+    });
+
+    it('falls back expiresAt → null when the legacy string is unparseable', () => {
+      const raw = {
+        data: 'x',
+        createdAt: 5_000_000,
+        expiresAt: 'garbage',
+      } as unknown as CacheEntry<string>;
+
+      const entry = normalizeStoredEntry(raw);
+
+      expect(entry.expiresAt).toBeNull();
+      // Numeric createdAt passes through untouched.
+      expect(entry.createdAt).toBe(5_000_000);
+    });
+
+    it('leaves already-numeric fields untouched', () => {
+      const entry: CacheEntry<string> = {
+        data: 'x',
+        createdAt: 1234,
+        expiresAt: 5678,
+        tags: undefined,
+      };
+      const out = normalizeStoredEntry(entry);
+
+      expect(out.createdAt).toBe(1234);
+      expect(out.expiresAt).toBe(5678);
+    });
+
+    it('leaves a null expiresAt as null', () => {
+      const entry: CacheEntry<number> = {
+        data: 1,
+        createdAt: 1,
+        expiresAt: null,
+      };
+      expect(normalizeStoredEntry(entry).expiresAt).toBeNull();
+    });
+
+    it('mutates in place and returns the same object reference', () => {
+      const raw = {
+        data: 'x',
+        createdAt: new Date(0).toISOString(),
+        expiresAt: null,
+      } as unknown as CacheEntry<string>;
+
+      const out = normalizeStoredEntry(raw);
+
+      expect(out).toBe(raw); // same identity (mutate-in-place)
+      expect(raw.createdAt).toBe(0); // the input object itself was mutated
+    });
+  });
+
+  describe('isCacheEntryExpired', () => {
+    const entry = (expiresAt: number | null): CacheEntry<string> => ({
+      data: 'x',
+      createdAt: 0,
+      expiresAt,
+    });
+
+    it('returns false when expiresAt is null (never expires)', () => {
+      expect(isCacheEntryExpired(entry(null), 1_000_000)).toBe(false);
+    });
+
+    it('returns true when expiresAt < now', () => {
+      expect(isCacheEntryExpired(entry(1000), 2000)).toBe(true);
+    });
+
+    it('returns false when expiresAt === now (boundary, not yet expired)', () => {
+      expect(isCacheEntryExpired(entry(1000), 1000)).toBe(false);
+    });
+
+    it('returns false when expiresAt > now', () => {
+      expect(isCacheEntryExpired(entry(5000), 1000)).toBe(false);
+    });
+  });
+
+  describe('round-trip', () => {
+    it('survives JSON serialize → parse → normalize equal to the numeric entry', () => {
+      const now = 1_700_000_000_000;
+      const original = buildCacheEntry({ id: 7, name: 'r' }, 30_000, ['a', 'b'], now);
+
+      const wire = JSON.stringify(original);
+      const parsed = JSON.parse(wire) as CacheEntry<{ id: number; name: string }>;
+      const restored = normalizeStoredEntry(parsed);
+
+      expect(restored).toEqual(original);
+      expect(restored.createdAt).toBe(now);
+      expect(restored.expiresAt).toBe(now + 30_000);
+      // The numeric round-trip must not have been re-interpreted as a string.
+      expect(restored.createdAt).toBeTypeOf('number');
+      expect(restored.expiresAt).toBeTypeOf('number');
+    });
+
+    it('migration runs correctly even when the entry is already expired', () => {
+      const now = Date.now();
+      const raw = {
+        data: 'old',
+        createdAt: new Date(now - 120_000).toISOString(),
+        expiresAt: new Date(now - 60_000).toISOString(),
+      } as unknown as CacheEntry<string>;
+
+      const entry = normalizeStoredEntry(raw);
+      expect(entry.expiresAt).toBeTypeOf('number');
+      // After migration the standard predicate correctly flags it expired.
+      expect(isCacheEntryExpired(entry, now)).toBe(true);
+    });
+  });
+});

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -152,6 +152,40 @@ describe('MemoryCacheStorage', () => {
 
       vi.useRealTimers();
     });
+
+    it('should re-sync getStats().size after expiry-on-read via get()', async () => {
+      // Regression guard: expiry-on-read now goes through the delegated
+      // MemoryTtlStore, which fires onEvict (tag cleanup) but does NOT touch
+      // stats.size. The store call must re-sync `stats.size = store.size` so
+      // getStats().size stays consistent once the expired entry is evicted.
+      vi.useFakeTimers();
+
+      await cache.set('key1', 'value', { ttlMs: 60_000 });
+      expect(cache.getStats().size).toBe(1);
+
+      vi.advanceTimersByTime(61 * 1000);
+
+      // Expiry-on-read deletes the entry and must reflect in size.
+      expect(await cache.get('key1')).toBeNull();
+      expect(cache.getStats().size).toBe(0);
+
+      vi.useRealTimers();
+    });
+
+    it('should re-sync getStats().size after expiry-on-read via has()', async () => {
+      // Same regression guard for the has() path (also expiry-deletes on read).
+      vi.useFakeTimers();
+
+      await cache.set('key1', 'value', { ttlMs: 60_000 });
+      expect(cache.getStats().size).toBe(1);
+
+      vi.advanceTimersByTime(61 * 1000);
+
+      expect(await cache.has('key1')).toBe(false);
+      expect(cache.getStats().size).toBe(0);
+
+      vi.useRealTimers();
+    });
   });
 
   describe('pattern deletion', () => {
@@ -203,6 +237,17 @@ describe('MemoryCacheStorage', () => {
     it('should return 0 for non-existent tag', async () => {
       const count = await cache.deleteByTag!('nonexistent');
       expect(count).toBe(0);
+    });
+
+    it('should drop the now-empty tag bucket from getTags() after deleteByTag', async () => {
+      // Regression guard: onEvict → removeFromTagIndex only removes the key from
+      // each tag's Set; the explicit final tagIndex.delete(tag) in deleteByTag is
+      // load-bearing to drop the emptied bucket so getTags() stays consistent.
+      expect(cache.getTags()).toContain('posts');
+
+      await cache.deleteByTag!('posts');
+
+      expect(cache.getTags()).not.toContain('posts');
     });
   });
 

--- a/tests/memory-ttl-store.test.ts
+++ b/tests/memory-ttl-store.test.ts
@@ -1,0 +1,301 @@
+import type { MemoryTtlStoreOptions } from 'hono-crud/internal';
+import { MemoryTtlStore } from 'hono-crud/internal';
+import { describe, expect, it, vi } from 'vitest';
+
+// Unit tests for the generic TTL Map store composed by the in-memory cache,
+// rate-limit, and idempotency backends. The store is synchronous and accepts an
+// explicit `now` argument on every time-sensitive method, so the tests drive
+// the clock through that argument instead of fake timers (the same `now`-arg
+// approach the spec's TEST PLAN calls out).
+
+// A simple value-with-expiry wrapper exercises the `isExpired(value, now)`
+// predicate the way the rate-limit/idempotency owners use it.
+interface Wrapper {
+  payload: string;
+  expiresAt: number;
+}
+
+const expiresByField = (value: Wrapper, now: number): boolean => now > value.expiresAt;
+
+function makeStore(
+  overrides: Partial<MemoryTtlStoreOptions<Wrapper>> = {},
+): MemoryTtlStore<Wrapper> {
+  return new MemoryTtlStore<Wrapper>({ isExpired: expiresByField, ...overrides });
+}
+
+const wrap = (payload: string, expiresAt = Number.POSITIVE_INFINITY): Wrapper => ({
+  payload,
+  expiresAt,
+});
+
+describe('MemoryTtlStore', () => {
+  describe('capacity eviction', () => {
+    it('evicts the oldest (first-inserted) entry when at maxEntries', () => {
+      const store = makeStore({ maxEntries: 2 });
+
+      store.set('key1', wrap('v1'));
+      store.set('key2', wrap('v2'));
+      store.set('key3', wrap('v3')); // at capacity → evict key1 (oldest)
+
+      expect(store.getKeys()).toEqual(['key2', 'key3']);
+      expect(store.size).toBe(2);
+      expect(store.get('key1')).toBeUndefined();
+    });
+
+    it('does not evict when overwriting an existing key at capacity', () => {
+      const store = makeStore({ maxEntries: 2 });
+
+      store.set('key1', wrap('v1'));
+      store.set('key2', wrap('v2'));
+      // Overwriting an existing key must not trip capacity eviction.
+      store.set('key1', wrap('v1-updated'));
+
+      expect(store.getKeys()).toEqual(['key1', 'key2']);
+      expect(store.get('key1')?.payload).toBe('v1-updated');
+    });
+
+    it('maxEntries <= 0 disables capacity eviction', () => {
+      const store = makeStore({ maxEntries: 0 });
+      for (let i = 0; i < 5; i++) store.set(`key${i}`, wrap(`v${i}`));
+      expect(store.size).toBe(5);
+      expect(store.getKeys()).toEqual(['key0', 'key1', 'key2', 'key3', 'key4']);
+    });
+  });
+
+  describe('refreshLruOnOverwrite', () => {
+    it('moves an overwritten key to the newest position when refresh=true', () => {
+      const store = makeStore({ maxEntries: 2 });
+
+      store.set('key1', wrap('v1'));
+      store.set('key2', wrap('v2'));
+      // Refresh key1 → it becomes the newest, so key2 is now the oldest.
+      store.set('key1', wrap('v1-refreshed'), /* refreshLruOnOverwrite */ true);
+      store.set('key3', wrap('v3')); // capacity → evict key2 (now oldest)
+
+      expect(store.getKeys()).toEqual(['key1', 'key3']);
+      expect(store.get('key1')?.payload).toBe('v1-refreshed');
+      expect(store.get('key2')).toBeUndefined();
+    });
+
+    it('does NOT change insertion order when refresh=false (default)', () => {
+      const store = makeStore({ maxEntries: 2 });
+
+      store.set('key1', wrap('v1'));
+      store.set('key2', wrap('v2'));
+      // Overwrite without refresh → key1 stays oldest.
+      store.set('key1', wrap('v1-updated'), /* refreshLruOnOverwrite */ false);
+      store.set('key3', wrap('v3')); // capacity → evict key1 (still oldest)
+
+      expect(store.getKeys()).toEqual(['key2', 'key3']);
+      expect(store.get('key1')).toBeUndefined();
+    });
+  });
+
+  describe('onEvict hook', () => {
+    it('fires on capacity eviction', () => {
+      const onEvict = vi.fn();
+      const store = makeStore({ maxEntries: 1, onEvict });
+
+      store.set('key1', wrap('v1'));
+      store.set('key2', wrap('v2')); // evicts key1
+
+      expect(onEvict).toHaveBeenCalledTimes(1);
+      expect(onEvict).toHaveBeenCalledWith('key1', expect.objectContaining({ payload: 'v1' }));
+    });
+
+    it('fires on expiry-on-read via get()', () => {
+      const onEvict = vi.fn();
+      const store = makeStore({ onEvict });
+
+      store.set('key1', wrap('v1', 1000));
+      expect(store.get('key1', 2000)).toBeUndefined(); // expired at now=2000
+
+      expect(onEvict).toHaveBeenCalledTimes(1);
+      expect(onEvict).toHaveBeenCalledWith('key1', expect.objectContaining({ payload: 'v1' }));
+    });
+
+    it('fires once per swept entry on cleanup()', () => {
+      const onEvict = vi.fn();
+      const store = makeStore({ onEvict });
+
+      store.set('a', wrap('a', 1000));
+      store.set('b', wrap('b', 5000));
+      store.set('c', wrap('c', 1000));
+
+      const removed = store.cleanup(2000); // a, c expired; b survives
+
+      expect(removed).toBe(2);
+      expect(onEvict).toHaveBeenCalledTimes(2);
+      expect(onEvict.mock.calls.map((c) => c[0]).sort()).toEqual(['a', 'c']);
+    });
+
+    it('fires on delete()', () => {
+      const onEvict = vi.fn();
+      const store = makeStore({ onEvict });
+
+      store.set('key1', wrap('v1'));
+      expect(store.delete('key1')).toBe(true);
+
+      expect(onEvict).toHaveBeenCalledTimes(1);
+      expect(onEvict).toHaveBeenCalledWith('key1', expect.objectContaining({ payload: 'v1' }));
+    });
+
+    it('fires with the OLD value on refresh-overwrite', () => {
+      const onEvict = vi.fn();
+      const store = makeStore({ onEvict });
+
+      store.set('key1', wrap('old'));
+      store.set('key1', wrap('new'), /* refreshLruOnOverwrite */ true);
+
+      expect(onEvict).toHaveBeenCalledTimes(1);
+      expect(onEvict).toHaveBeenCalledWith('key1', expect.objectContaining({ payload: 'old' }));
+      expect(store.get('key1')?.payload).toBe('new');
+    });
+
+    it('does NOT fire on clear()', () => {
+      const onEvict = vi.fn();
+      const store = makeStore({ onEvict });
+
+      store.set('key1', wrap('v1'));
+      store.set('key2', wrap('v2'));
+      store.clear();
+
+      expect(onEvict).not.toHaveBeenCalled();
+      expect(store.size).toBe(0);
+    });
+
+    it('does NOT fire delete() for a missing key', () => {
+      const onEvict = vi.fn();
+      const store = makeStore({ onEvict });
+
+      expect(store.delete('absent')).toBe(false);
+      expect(onEvict).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('peek', () => {
+    it('returns the raw value without an expiry check or delete', () => {
+      const onEvict = vi.fn();
+      const store = makeStore({ onEvict });
+
+      store.set('key1', wrap('v1', 1000));
+
+      // peek must not delete the entry even though it is "expired" relative to a
+      // later clock — it never runs isExpired.
+      const peeked = store.peek('key1');
+      expect(peeked?.payload).toBe('v1');
+      expect(store.size).toBe(1);
+      expect(onEvict).not.toHaveBeenCalled();
+
+      // get() at the same clock WOULD delete it — contrast with peek.
+      expect(store.get('key1', 2000)).toBeUndefined();
+      expect(store.size).toBe(0);
+    });
+
+    it('returns undefined for a missing key', () => {
+      const store = makeStore();
+      expect(store.peek('absent')).toBeUndefined();
+    });
+  });
+
+  describe('cleanup()', () => {
+    it('returns the exact removed count and leaves survivors', () => {
+      const store = makeStore();
+      store.set('a', wrap('a', 1000));
+      store.set('b', wrap('b', 2000));
+      store.set('c', wrap('c', 3000));
+      store.set('d', wrap('d')); // never expires (Infinity)
+
+      const removed = store.cleanup(2500); // a, b expired
+
+      expect(removed).toBe(2);
+      expect(store.size).toBe(2);
+      expect(store.getKeys()).toEqual(['c', 'd']);
+    });
+
+    it('returns 0 when nothing is expired', () => {
+      const store = makeStore();
+      store.set('a', wrap('a', 10_000));
+      expect(store.cleanup(5000)).toBe(0);
+      expect(store.size).toBe(1);
+    });
+  });
+
+  describe('maybeCleanup (lazy cleanup-on-access guard)', () => {
+    it('never sweeps when cleanupInterval <= 0', () => {
+      const onEvict = vi.fn();
+      const store = makeStore({ cleanupInterval: 0, onEvict });
+
+      store.set('a', wrap('a', 1000));
+      // Even far past expiry, the lazy guard is disabled.
+      store.maybeCleanup(1_000_000);
+
+      expect(store.size).toBe(1);
+      expect(onEvict).not.toHaveBeenCalled();
+    });
+
+    it('sweeps at most once per interval window', () => {
+      const store = makeStore({ cleanupInterval: 1000 });
+
+      store.set('a', wrap('a', 500));
+      store.set('b', wrap('b', 5000));
+
+      // First call past the interval since lastCleanup(=0): sweeps, removes 'a'.
+      store.maybeCleanup(1000);
+      expect(store.size).toBe(1);
+      expect(store.getKeys()).toEqual(['b']);
+
+      // Add another already-expired entry; a call inside the same window does
+      // NOT sweep again.
+      store.set('c', wrap('c', 100));
+      store.maybeCleanup(1500); // 1500 - 1000 < 1000 → no sweep
+      expect(store.getKeys()).toEqual(['b', 'c']);
+
+      // Once the next window opens, it sweeps again and removes 'c'.
+      store.maybeCleanup(2000); // 2000 - 1000 >= 1000 → sweep
+      expect(store.getKeys()).toEqual(['b']);
+    });
+  });
+
+  describe('expiry-on-read', () => {
+    it('get() returns undefined for an expired entry AND deletes it', () => {
+      const store = makeStore();
+      store.set('key1', wrap('v1', 1000));
+
+      expect(store.get('key1', 500)).toEqual(expect.objectContaining({ payload: 'v1' }));
+      expect(store.get('key1', 2000)).toBeUndefined(); // expired → deleted
+      expect(store.size).toBe(0);
+      // Subsequent peek confirms the entry is gone.
+      expect(store.peek('key1')).toBeUndefined();
+    });
+
+    it('has() returns false for an expired entry AND deletes it', () => {
+      const store = makeStore();
+      store.set('key1', wrap('v1', 1000));
+
+      expect(store.has('key1', 500)).toBe(true);
+      expect(store.has('key1', 2000)).toBe(false); // expired → deleted
+      expect(store.size).toBe(0);
+    });
+
+    it('get() returns undefined for a missing key', () => {
+      const store = makeStore();
+      expect(store.get('absent')).toBeUndefined();
+    });
+  });
+
+  describe('debug accessors', () => {
+    it('size, getKeys, and entries reflect live contents', () => {
+      const store = makeStore();
+      store.set('a', wrap('a'));
+      store.set('b', wrap('b'));
+
+      expect(store.size).toBe(2);
+      expect(store.getKeys()).toEqual(['a', 'b']);
+      expect([...store.entries()].map(([k, v]) => [k, v.payload])).toEqual([
+        ['a', 'a'],
+        ['b', 'b'],
+      ]);
+    });
+  });
+});

--- a/tests/relation-orchestrator.test.ts
+++ b/tests/relation-orchestrator.test.ts
@@ -1,0 +1,559 @@
+// Unit tests for the ORM-agnostic relation batch/single-item orchestrator
+// (`packages/core/src/relations/batch-loader.ts`), exercised through the
+// `hono-crud/internal` entrypoint with fake adapters. These cover batch
+// grouping/map-back, single-item parity, the §D.1 always-set-key drift surface,
+// and the exported single-relation primitives.
+//
+// (Spec §E names this file `relation-batch-loader.test.ts`; this work package's
+// scope names it `relation-orchestrator.test.ts` — same suite, kept here.)
+import type { MetaInput, RelationConfig, RelationsConfig } from 'hono-crud';
+import {
+  type FetchRelated,
+  type RelatedRecord,
+  type RelationLoaderAdapter,
+  type SyncFetchRelated,
+  type SyncRelationLoaderAdapter,
+  batchLoadRelations,
+  loadRelationsForItem,
+  loadRelationsForItemSync,
+  resolveRelationValueAsync,
+  resolveRelationValueSync,
+} from 'hono-crud/internal';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+// The orchestrator's generic returns `T` (the input item type). Typing item
+// fixtures as an open record lets the tests read the dynamically-added relation
+// keys (`posts`, `author`, …) off the result without `any` — the orchestrator's
+// own `T extends Record<string, unknown>` constraint is exactly this shape.
+type Row = Record<string, unknown>;
+
+// A minimal MetaInput whose only orchestrator-relevant content is
+// `model.relations`. The schema/primaryKeys are required by the type but unused
+// by the loader.
+function metaWith(relations: RelationsConfig): MetaInput {
+  return {
+    model: {
+      tableName: 'users',
+      schema: z.object({ id: z.string() }),
+      primaryKeys: ['id'],
+      relations,
+    },
+  };
+}
+
+// A fake fetchRelated that records every invocation's (keyField, values) and
+// returns canned records (filtered to those whose keyField is in `values`,
+// mirroring a real IN-list query). `handle` is an opaque sentinel string.
+function makeFakeFetch(records: RelatedRecord[]): {
+  fetch: FetchRelated<string> & SyncFetchRelated<string>;
+  calls: Array<{ handle: string; keyField: string; values: unknown[] }>;
+} {
+  const calls: Array<{ handle: string; keyField: string; values: unknown[] }> = [];
+  const fetch = (handle: string, keyField: string, values: unknown[]): RelatedRecord[] => {
+    calls.push({ handle, keyField, values });
+    return records.filter((r) => values.includes(r[keyField]));
+  };
+  return { fetch, calls };
+}
+
+function asyncAdapter(
+  fetch: FetchRelated<string>,
+  handle: string | null = 'HANDLE',
+): RelationLoaderAdapter<string> {
+  return { resolveRelation: () => handle, fetchRelated: fetch };
+}
+
+function syncAdapter(
+  fetch: SyncFetchRelated<string>,
+  handle: string | null = 'HANDLE',
+): SyncRelationLoaderAdapter<string> {
+  return { resolveRelation: () => handle, fetchRelated: fetch };
+}
+
+const hasMany = (overrides: Partial<RelationConfig> = {}): RelationConfig => ({
+  type: 'hasMany',
+  model: 'posts',
+  foreignKey: 'authorId',
+  ...overrides,
+});
+const hasOne = (overrides: Partial<RelationConfig> = {}): RelationConfig => ({
+  type: 'hasOne',
+  model: 'profiles',
+  foreignKey: 'userId',
+  ...overrides,
+});
+const belongsTo = (overrides: Partial<RelationConfig> = {}): RelationConfig => ({
+  type: 'belongsTo',
+  model: 'users',
+  foreignKey: 'authorId',
+  localKey: 'id',
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// batchLoadRelations
+// ---------------------------------------------------------------------------
+
+describe('batchLoadRelations', () => {
+  it('hasMany groups 1:N by foreign key', async () => {
+    const posts: RelatedRecord[] = [
+      { id: 'p1', authorId: 'u1' },
+      { id: 'p2', authorId: 'u1' },
+      { id: 'p3', authorId: 'u2' },
+    ];
+    const { fetch, calls } = makeFakeFetch(posts);
+    const items: Row[] = [{ id: 'u1' }, { id: 'u2' }];
+
+    const result = await batchLoadRelations(
+      items,
+      metaWith({ posts: hasMany() }),
+      asyncAdapter(fetch),
+      { relations: ['posts'] },
+    );
+
+    expect(result[0].posts).toEqual([
+      { id: 'p1', authorId: 'u1' },
+      { id: 'p2', authorId: 'u1' },
+    ]);
+    expect(result[1].posts).toEqual([{ id: 'p3', authorId: 'u2' }]);
+    // One fetch for the whole batch (N+1 avoidance), keyed on the foreign key.
+    expect(calls).toHaveLength(1);
+    expect(calls[0].keyField).toBe('authorId');
+    expect(calls[0].values).toEqual(['u1', 'u2']);
+  });
+
+  it('hasMany with no matches yields []', async () => {
+    const { fetch } = makeFakeFetch([]);
+    const items: Row[] = [{ id: 'u1' }];
+    const result = await batchLoadRelations(
+      items,
+      metaWith({ posts: hasMany() }),
+      asyncAdapter(fetch),
+      { relations: ['posts'] },
+    );
+    expect(result[0].posts).toEqual([]);
+  });
+
+  it('hasOne maps to records[0] || null', async () => {
+    const profiles: RelatedRecord[] = [
+      { id: 'pr1', userId: 'u1' },
+      { id: 'pr2', userId: 'u2' },
+    ];
+    const { fetch } = makeFakeFetch(profiles);
+    const items: Row[] = [{ id: 'u1' }, { id: 'u2' }, { id: 'u3' }];
+    const result = await batchLoadRelations(
+      items,
+      metaWith({ profile: hasOne() }),
+      asyncAdapter(fetch),
+      { relations: ['profile'] },
+    );
+
+    expect(result[0].profile).toEqual({ id: 'pr1', userId: 'u1' });
+    expect(result[1].profile).toEqual({ id: 'pr2', userId: 'u2' });
+    expect(result[2].profile).toBeNull(); // no match → null
+  });
+
+  it('belongsTo maps 1:1 by local key with last-writer-wins on duplicates', async () => {
+    // Two records share the same localKey ('id') → last one wins.
+    const authors: RelatedRecord[] = [
+      { id: 'a1', name: 'first' },
+      { id: 'a1', name: 'second' },
+    ];
+    const { fetch, calls } = makeFakeFetch(authors);
+    const items: Row[] = [{ id: 'post1', authorId: 'a1' }];
+
+    const result = await batchLoadRelations(
+      items,
+      metaWith({ author: belongsTo() }),
+      asyncAdapter(fetch),
+      { relations: ['author'] },
+    );
+
+    expect(result[0].author).toEqual({ id: 'a1', name: 'second' }); // last writer wins
+    expect(calls[0].keyField).toBe('id'); // belongsTo fetches by localKey
+    expect(calls[0].values).toEqual(['a1']);
+  });
+
+  it('belongsTo with null/undefined foreign values → all null, fetch NOT called', async () => {
+    const { fetch, calls } = makeFakeFetch([{ id: 'a1' }]);
+    const items: Row[] = [{ id: 'post1', authorId: null }, { id: 'post2' }];
+
+    const result = await batchLoadRelations(
+      items,
+      metaWith({ author: belongsTo() }),
+      asyncAdapter(fetch),
+      { relations: ['author'] },
+    );
+
+    expect(result[0].author).toBeNull();
+    expect(result[1].author).toBeNull();
+    expect(calls).toHaveLength(0); // empty foreignValues → no query
+  });
+
+  it('returns items unchanged for empty input', async () => {
+    const { fetch, calls } = makeFakeFetch([{ id: 'p1', authorId: 'u1' }]);
+    const result = await batchLoadRelations(
+      [],
+      metaWith({ posts: hasMany() }),
+      asyncAdapter(fetch),
+      { relations: ['posts'] },
+    );
+    expect(result).toEqual([]);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('de-dupes and filters null/undefined local values before fetching', async () => {
+    const { fetch, calls } = makeFakeFetch([]);
+    const items = [
+      { id: 'u1' },
+      { id: 'u1' }, // duplicate
+      { id: null }, // filtered
+      { id: undefined }, // filtered
+      { id: 'u2' },
+    ];
+
+    await batchLoadRelations(items, metaWith({ posts: hasMany() }), asyncAdapter(fetch), {
+      relations: ['posts'],
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].values).toEqual(['u1', 'u2']); // de-duped, non-null only
+  });
+
+  it('skips a relation whose resolveRelation returns null while loading the rest', async () => {
+    const posts: RelatedRecord[] = [{ id: 'p1', authorId: 'u1' }];
+    const { fetch } = makeFakeFetch(posts);
+    // Adapter resolves `null` for "profile" but a real handle for "posts".
+    const adapter: RelationLoaderAdapter<string> = {
+      resolveRelation: (config) => (config.type === 'hasOne' ? null : 'HANDLE'),
+      fetchRelated: fetch,
+    };
+
+    const items: Row[] = [{ id: 'u1' }];
+    const result = await batchLoadRelations(
+      items,
+      metaWith({ posts: hasMany(), profile: hasOne() }),
+      adapter,
+      { relations: ['posts', 'profile'] },
+    );
+
+    expect(result[0].posts).toEqual([{ id: 'p1', authorId: 'u1' }]);
+    expect('profile' in result[0]).toBe(false); // skipped → key not set
+  });
+
+  it('skips an unknown relation name (no config) without error', async () => {
+    const { fetch, calls } = makeFakeFetch([]);
+    const result = await batchLoadRelations(
+      [{ id: 'u1' }],
+      metaWith({ posts: hasMany() }),
+      asyncAdapter(fetch),
+      { relations: ['nonexistent'] },
+    );
+    expect('nonexistent' in result[0]).toBe(false);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('does not mutate the input items (clones)', async () => {
+    const { fetch } = makeFakeFetch([{ id: 'p1', authorId: 'u1' }]);
+    const items: Row[] = [{ id: 'u1' }];
+
+    const result = await batchLoadRelations(
+      items,
+      metaWith({ posts: hasMany() }),
+      asyncAdapter(fetch),
+      {
+        relations: ['posts'],
+      },
+    );
+
+    expect(items[0]).toEqual({ id: 'u1' }); // original untouched
+    expect('posts' in items[0]).toBe(false);
+    expect(result[0]).not.toBe(items[0]); // distinct clone
+  });
+
+  it('handles a combined belongsTo + hasMany + hasOne over the same item set', async () => {
+    const items: Row[] = [{ id: 'u1', orgId: 'o1' }];
+    // hasMany posts (by authorId), hasOne profile (by userId), belongsTo org (by id).
+    const records: RelatedRecord[] = [
+      { id: 'p1', authorId: 'u1' },
+      { id: 'pr1', userId: 'u1' },
+      { id: 'o1', name: 'Acme' },
+    ];
+    const { fetch } = makeFakeFetch(records);
+
+    const result = await batchLoadRelations(
+      items,
+      metaWith({
+        posts: hasMany(),
+        profile: hasOne(),
+        org: belongsTo({ model: 'orgs', foreignKey: 'orgId', localKey: 'id' }),
+      }),
+      asyncAdapter(fetch),
+      { relations: ['posts', 'profile', 'org'] },
+    );
+
+    expect(result[0].posts).toEqual([{ id: 'p1', authorId: 'u1' }]);
+    expect(result[0].profile).toEqual({ id: 'pr1', userId: 'u1' });
+    expect(result[0].org).toEqual({ id: 'o1', name: 'Acme' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadRelationsForItem (async single-item)
+// ---------------------------------------------------------------------------
+
+describe('loadRelationsForItem (async single)', () => {
+  it('matches batch output for a 1-item case', async () => {
+    const posts: RelatedRecord[] = [
+      { id: 'p1', authorId: 'u1' },
+      { id: 'p2', authorId: 'u1' },
+    ];
+    const { fetch } = makeFakeFetch(posts);
+    const item: Row = { id: 'u1' };
+
+    const single = await loadRelationsForItem(
+      item,
+      metaWith({ posts: hasMany() }),
+      asyncAdapter(fetch),
+      {
+        relations: ['posts'],
+      },
+    );
+    const { fetch: fetch2 } = makeFakeFetch(posts);
+    const [batched] = await batchLoadRelations(
+      [item],
+      metaWith({ posts: hasMany() }),
+      asyncAdapter(fetch2),
+      {
+        relations: ['posts'],
+      },
+    );
+
+    expect(single).toEqual(batched);
+  });
+
+  it('always sets the key on a null gate value (DRIFT #1): hasOne→null, hasMany→[], belongsTo→null', async () => {
+    const { fetch, calls } = makeFakeFetch([{ id: 'x' }]);
+    // hasOne/hasMany gate on item[localKey] (id); belongsTo gates on item[foreignKey] (authorId).
+    const item: Row = { id: null, authorId: null };
+
+    const result = await loadRelationsForItem(
+      item,
+      metaWith({ profile: hasOne(), posts: hasMany(), author: belongsTo() }),
+      asyncAdapter(fetch),
+      { relations: ['profile', 'posts', 'author'] },
+    );
+
+    expect(result.profile).toBeNull();
+    expect(result.posts).toEqual([]);
+    expect(result.author).toBeNull();
+    // All gates were null → no fetch issued.
+    expect(calls).toHaveLength(0);
+  });
+
+  it('belongsTo with null id but populated foreignKey still sets the key (DRIFT #1c)', async () => {
+    const authors: RelatedRecord[] = [{ id: 'a1', name: 'Author' }];
+    const { fetch, calls } = makeFakeFetch(authors);
+    // id is null (would have suppressed the key under the old memory guard) but
+    // belongsTo gates on foreignKey (authorId), which is populated.
+    const item: Row = { id: null, authorId: 'a1' };
+
+    const result = await loadRelationsForItem(
+      item,
+      metaWith({ author: belongsTo() }),
+      asyncAdapter(fetch),
+      {
+        relations: ['author'],
+      },
+    );
+
+    expect(result.author).toEqual({ id: 'a1', name: 'Author' });
+    expect(calls[0].keyField).toBe('id'); // belongsTo fetches by localKey
+    expect(calls[0].values).toEqual(['a1']); // gated on foreignKey value
+  });
+
+  it('returns the item unchanged when no relations requested', async () => {
+    const { fetch } = makeFakeFetch([]);
+    const item = { id: 'u1' };
+    const out = await loadRelationsForItem(
+      item,
+      metaWith({ posts: hasMany() }),
+      asyncAdapter(fetch),
+      {
+        relations: [],
+      },
+    );
+    expect(out).toBe(item); // early return, same reference
+  });
+
+  it('does not mutate the input item (clones) when relations load', async () => {
+    const { fetch } = makeFakeFetch([{ id: 'p1', authorId: 'u1' }]);
+    const item = { id: 'u1' };
+    const out = await loadRelationsForItem(
+      item,
+      metaWith({ posts: hasMany() }),
+      asyncAdapter(fetch),
+      {
+        relations: ['posts'],
+      },
+    );
+    expect('posts' in item).toBe(false);
+    expect(out).not.toBe(item);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadRelationsForItemSync (synchronous, memory)
+// ---------------------------------------------------------------------------
+
+describe('loadRelationsForItemSync', () => {
+  it('returns a plain (non-thenable) value — runs synchronously', () => {
+    const { fetch } = makeFakeFetch([{ id: 'p1', authorId: 'u1' }]);
+    const item: Row = { id: 'u1' };
+    const out = loadRelationsForItemSync(item, metaWith({ posts: hasMany() }), syncAdapter(fetch), {
+      relations: ['posts'],
+    });
+    // Not a Promise: no `.then`.
+    expect((out as { then?: unknown }).then).toBeUndefined();
+    expect(out.posts).toEqual([{ id: 'p1', authorId: 'u1' }]);
+  });
+
+  it('always sets the key on null gate values (DRIFT #1) just like the async path', () => {
+    const { fetch, calls } = makeFakeFetch([{ id: 'x' }]);
+    const item: Row = { id: null, authorId: null };
+
+    const result = loadRelationsForItemSync(
+      item,
+      metaWith({ profile: hasOne(), posts: hasMany(), author: belongsTo() }),
+      syncAdapter(fetch),
+      { relations: ['profile', 'posts', 'author'] },
+    );
+
+    expect(result.profile).toBeNull();
+    expect(result.posts).toEqual([]);
+    expect(result.author).toBeNull();
+    expect(calls).toHaveLength(0);
+  });
+
+  it('belongsTo with null id but populated foreignKey sets the key (memory DRIFT #1c)', () => {
+    const { fetch } = makeFakeFetch([{ id: 'a1', name: 'Author' }]);
+    const item: Row = { id: null, authorId: 'a1' };
+
+    const result = loadRelationsForItemSync(
+      item,
+      metaWith({ author: belongsTo() }),
+      syncAdapter(fetch),
+      {
+        relations: ['author'],
+      },
+    );
+
+    expect(result.author).toEqual({ id: 'a1', name: 'Author' });
+  });
+
+  it('skips a relation whose resolveRelation returns null', () => {
+    const { fetch } = makeFakeFetch([{ id: 'p1', authorId: 'u1' }]);
+    const adapter: SyncRelationLoaderAdapter<string> = {
+      resolveRelation: (config) => (config.type === 'hasOne' ? null : 'HANDLE'),
+      fetchRelated: fetch,
+    };
+    const item: Row = { id: 'u1' };
+    const result = loadRelationsForItemSync(
+      item,
+      metaWith({ posts: hasMany(), profile: hasOne() }),
+      adapter,
+      { relations: ['posts', 'profile'] },
+    );
+    expect(result.posts).toEqual([{ id: 'p1', authorId: 'u1' }]);
+    expect('profile' in result).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exported single-relation primitives
+// ---------------------------------------------------------------------------
+
+describe('resolveRelationValueAsync', () => {
+  it('hasMany: returns the records array; fetches by foreignKey gated on localKey', async () => {
+    const { fetch, calls } = makeFakeFetch([
+      { id: 'p1', authorId: 'u1' },
+      { id: 'p2', authorId: 'u1' },
+    ]);
+    const value = await resolveRelationValueAsync({ id: 'u1' }, hasMany(), 'HANDLE', fetch);
+
+    expect(value).toEqual([
+      { id: 'p1', authorId: 'u1' },
+      { id: 'p2', authorId: 'u1' },
+    ]);
+    expect(calls[0].keyField).toBe('authorId');
+    expect(calls[0].values).toEqual(['u1']);
+  });
+
+  it('hasOne: returns records[0] ?? null', async () => {
+    const { fetch } = makeFakeFetch([{ id: 'pr1', userId: 'u1' }]);
+    const value = await resolveRelationValueAsync({ id: 'u1' }, hasOne(), 'HANDLE', fetch);
+    expect(value).toEqual({ id: 'pr1', userId: 'u1' });
+
+    const { fetch: emptyFetch } = makeFakeFetch([]);
+    expect(
+      await resolveRelationValueAsync({ id: 'u9' }, hasOne(), 'HANDLE', emptyFetch),
+    ).toBeNull();
+  });
+
+  it('belongsTo: fetches by localKey gated on foreignKey, returns records[0] ?? null', async () => {
+    const { fetch, calls } = makeFakeFetch([{ id: 'a1', name: 'Author' }]);
+    const value = await resolveRelationValueAsync(
+      { id: 'post1', authorId: 'a1' },
+      belongsTo(),
+      'HANDLE',
+      fetch,
+    );
+
+    expect(value).toEqual({ id: 'a1', name: 'Author' });
+    expect(calls[0].keyField).toBe('id'); // localKey
+    expect(calls[0].values).toEqual(['a1']); // gated on foreignKey value
+  });
+
+  it('null gate value runs the reducer over an empty list (no fetch)', async () => {
+    const { fetch, calls } = makeFakeFetch([{ id: 'x' }]);
+
+    expect(await resolveRelationValueAsync({ id: null }, hasOne(), 'HANDLE', fetch)).toBeNull();
+    expect(await resolveRelationValueAsync({ id: null }, hasMany(), 'HANDLE', fetch)).toEqual([]);
+    expect(
+      await resolveRelationValueAsync({ authorId: null }, belongsTo(), 'HANDLE', fetch),
+    ).toBeNull();
+    expect(calls).toHaveLength(0); // gated → reducer over [] without fetching
+  });
+});
+
+describe('resolveRelationValueSync', () => {
+  it('returns the same shapes as the async primitive, synchronously', () => {
+    const { fetch: f1 } = makeFakeFetch([{ id: 'p1', authorId: 'u1' }]);
+    expect(resolveRelationValueSync({ id: 'u1' }, hasMany(), 'HANDLE', f1)).toEqual([
+      { id: 'p1', authorId: 'u1' },
+    ]);
+
+    const { fetch: f2 } = makeFakeFetch([{ id: 'pr1', userId: 'u1' }]);
+    expect(resolveRelationValueSync({ id: 'u1' }, hasOne(), 'HANDLE', f2)).toEqual({
+      id: 'pr1',
+      userId: 'u1',
+    });
+
+    const { fetch: f3 } = makeFakeFetch([{ id: 'a1' }]);
+    expect(resolveRelationValueSync({ authorId: 'a1' }, belongsTo(), 'HANDLE', f3)).toEqual({
+      id: 'a1',
+    });
+  });
+
+  it('null gate value → reducer over empty list, no fetch', () => {
+    const { fetch, calls } = makeFakeFetch([{ id: 'x' }]);
+    expect(resolveRelationValueSync({ id: null }, hasOne(), 'HANDLE', fetch)).toBeNull();
+    expect(resolveRelationValueSync({ id: null }, hasMany(), 'HANDLE', fetch)).toEqual([]);
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -25,7 +25,7 @@ import {
 } from 'hono-crud/storage';
 import type { StorageEnv } from 'hono-crud/storage/types';
 import { MemoryVersioningStorage, setVersioningStorage } from 'hono-crud/versioning';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('Storage Module', () => {
   describe('createStorageMiddleware', () => {
@@ -361,5 +361,62 @@ describe('Storage Module', () => {
       const logs = await globalStorage.query({});
       expect(logs.length).toBeGreaterThan(0);
     });
+  });
+});
+
+describe('MemoryRateLimitStorage fixed window', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not slide the fixed-window expiry when incrementing within the window', async () => {
+    // Direct guard for the §B.10 MUST-FIX: within-window increments mutate the
+    // live entry's count in place and must NOT re-set expiry. The entry must
+    // expire at `windowStart + windowMs`, never at `lastIncrement + windowMs`.
+    const storage = new MemoryRateLimitStorage({ cleanupInterval: 0 });
+    const windowMs = 60_000;
+
+    // Open the window at t=0 (windowStart=0, expiresAt=60_000).
+    const first = await storage.increment('user:fixed', windowMs);
+    expect(first.count).toBe(1);
+    expect(first.windowStart).toBe(0);
+
+    // Increment again at t=30_000 (still within the window). If the buggy
+    // sliding behavior were re-introduced, this would push expiry to 90_000.
+    vi.setSystemTime(30_000);
+    const second = await storage.increment('user:fixed', windowMs);
+    expect(second.count).toBe(2);
+    expect(second.windowStart).toBe(0); // window did NOT restart
+
+    // At t=61_000 the entry is past windowStart+windowMs (60_000) and must be
+    // gone — proving expiry stayed anchored to windowStart, not lastIncrement.
+    vi.setSystemTime(61_000);
+    expect(await storage.get('user:fixed')).toBeNull();
+  });
+
+  it('expires the fixed window via cleanup() at windowStart + windowMs', async () => {
+    // Companion guard using cleanup() rather than get(): the swept count proves
+    // the within-window increments did not extend the expiry past 60_000.
+    const storage = new MemoryRateLimitStorage({ cleanupInterval: 0 });
+    const windowMs = 60_000;
+
+    await storage.increment('user:fixed', windowMs); // windowStart=0
+    vi.setSystemTime(30_000);
+    await storage.increment('user:fixed', windowMs); // within window, no slide
+
+    // Just before windowStart+windowMs: still alive.
+    vi.setSystemTime(59_999);
+    expect(await storage.cleanup()).toBe(0);
+    expect(await storage.get('user:fixed')).not.toBeNull();
+
+    // Past windowStart+windowMs: swept.
+    vi.setSystemTime(60_001);
+    expect(await storage.cleanup()).toBe(1);
+    expect(storage.getSize()).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Themes 3–4 from the drift audit: the three places where the same non-trivial logic lived in multiple copies, each extracted to one home. Same process as #56 — inventoried, specced, the spec attacked by three adversarial design reviewers (all initially demanded revisions), then implemented per work package with adversarial review and a full gate.

### The three extractions

1. **`MemoryTtlStore<V>`** (core, internal via `hono-crud/internal`) — owns the edge-safety contract previously copy-pasted across the memory storages: lazy cleanup-on-access (no `setInterval`), expiry-on-read, insertion-order capacity eviction, count-returning `cleanup()`. Cache, rate-limit, and idempotency compose it:
   - cache: `onEvict` hook keeps the tag index consistent on every eviction path (previously fire-and-forget async); `refreshLruOnOverwrite` preserves its delete-then-reinsert LRU refresh
   - rate-limit: `peek()` serves the mutate-in-place increment paths that must not delete-on-expiry mid-operation
   - idempotency: entries + locks as two composed stores
   - **logging deliberately stays standalone** — the design review proved its newest-first `unshift`/`pop` structure is a different animal, not drift; forcing it in would have risked its exact-ordering tests
2. **Cache entry codec** (`packages/cache/src/entry.ts`) — `buildCacheEntry` / `normalizeStoredEntry` / `isCacheEntryExpired` shared by memory/redis/kv, with the single canonical legacy-Date migration guard. Wire-format compatible: entries already persisted in Redis/KV keep reading identically.
3. **Relation-batching orchestrator** (core, internal) — the ORM-agnostic control flow (unique-key collection, grouping, map-back, lookup-map dispatch over hasOne/hasMany/belongsTo) extracted from the near-verbatim drizzle/prisma copies and memory's third copy; each adapter now supplies only its query. Future N+1 fixes land once.

### Two deliberate behavior fixes (spec'd, not accidental)

- Single-item relation reads in memory/drizzle now **always set the relation key** (`null`/`[]` instead of absent), matching the batch path and prisma. This also fixes memory's belongsTo gating on the row's own `id` instead of the foreign key. No existing test asserted the old behavior; new tests assert the new one.
- Rate-limit's fixed window no longer **slides its stored expiry** on within-window increments — the window keeps its original `windowStart + windowMs` end. (Found by the design review while proving "identical behavior"; the old code refreshed expiry on every set.)

### Numbers

- Modified files: **−717/+358** — net −359 lines of duplicated logic
- Full existing suite (1007 tests) passes **without a single assertion change** — the pure-dedup tripwire (any non-spec'd behavioral failure = regression, not a test to edit) never fired
- 3 new test files (60+ tests): store eviction order/cleanup counts/onEvict semantics, codec round-trip + legacy migration, orchestrator with fake adapters including the null-key drift assertions
- Gate green: build, typecheck, unit, workers, examples typecheck, biome; local-consumer smoke verified separately
- Internal-only removals: memory's `loadRelation`, prisma's `loadPrismaRelation` (never publicly exported); all public constructor options and adapter loader signatures unchanged

One changeset, patch bumps across core and the six affected packages.