### PR TITLE
refactor: naming sweep — one name per role, docs match the code

### DIFF
--- a/.changeset/naming-sweep.md
+++ b/.changeset/naming-sweep.md
@@ -1,0 +1,24 @@
+---
+"hono-crud": patch
+"@hono-crud/idempotency": patch
+"@hono-crud/health": patch
+"@hono-crud/swagger": patch
+"@hono-crud/scalar": patch
+"@hono-crud/mcp": patch
+"@hono-crud/rate-limit": patch
+"@hono-crud/drizzle": patch
+---
+
+Naming + docs sweep (breaking, patch): one name per role across the whole library, and the docs now document the code that exists.
+
+- Middleware factories: `idempotency()` → `createIdempotencyMiddleware()`. (`multiTenant()`/`apiVersion()` keep their feature-named forms — each anchors an accessor family sharing its prefix; the doctrine in CLAUDE.md documents the rule and the exceptions.)
+- Surface packages are Hono-idiomatic factories you mount yourself: swagger's `setupSwaggerUI`/`setupReDoc`/`setupDocsIndex` (app mutators) become `swaggerUI()`/`redocUI()`/`docsIndex()` returning `MiddlewareHandler` with `SwaggerUIConfig`/`RedocUIConfig`/`DocsIndexConfig` (adopting scalar's `specUrl`/`pageTitle` vocabulary; `UIOptions` deleted); scalar's `setupScalar` is deleted (`app.get(path, scalarUI(config))`); health's `createHealthEndpoints`/`createHealthHandler` collapse into `createHealthRoutes(config): Hono` mounted via `app.route()`.
+- The word "Versioning" now means record history only: HTTP negotiation renames to `ApiVersioningConfig` (was `VersioningMiddlewareConfig`), `ApiVersionStrategy`, `ApiVersionTransformer`, `apiVersionedResponse()`.
+- Multi-tenant has one source-of-truth union: new exported `TenantIdSource` owned by the model-level `MultiTenantConfig`; the middleware config derives from it and renames to `MultiTenantMiddlewareConfig` (was `*Options`). Runtime defaults unchanged.
+- `CrudMcpOptions` → `CrudMcpConfig` per the now-documented Config-vs-Options rule.
+- Rate-limit key prefix unified: one exported `DEFAULT_RATE_LIMIT_KEY_PREFIX = 'rl'`; the KV and Redis storage prefixes no longer add their own divergent defaults ('rl:'/'ratelimit:'), so all backends build identical keys. In-flight rate-limit windows under old prefixes expire naturally.
+- Vestigial `RouterOptions.base`/`docs_url`/`redoc_url` deleted (UI paths live in the swagger/scalar packages; `openapi_url` stays).
+- One API-key hasher: the canonical `hashAPIKey` moves to `auth/hash.ts` and `defaultHashAPIKey` is now an alias of it — hashing is byte-identical, stored keys keep matching.
+- Sorting aliases removed from the functional config: `orderByFields`/`defaultOrderBy`/`defaultOrderDirection` and `SortingConfig.defaultDirection` are gone — canonical `sortFields`/`defaultSort`/`defaultOrder` only.
+- Drizzle's stale 5-verb `DrizzleAdapters` bundle in factory.ts is deleted; the 17-entry bundle in the package barrel is the only one, mirroring prisma and memory.
+- Docs: CLAUDE.md/AGENTS.md gain the naming doctrine and a corrected Drizzle Adapter Pattern section using the real type names (`DrizzleDatabaseConstraint`, `Database<Row>`, `QueryBuilder<Row>`, `cast<Row>()`); all docs/READMEs/examples migrated to the new names and call patterns.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,12 +9,49 @@
 - Prefer generics over `any` for flexible typing
 
 ### Drizzle Adapter Pattern
-The Drizzle adapter uses a two-tier type system:
-1. **Public interface** (`DrizzleDatabase`): Uses `unknown` returns to accept any Drizzle database
-2. **Internal interface** (`InternalDatabase`, `InternalQueryBuilder`): Uses specific method signatures
-3. **Casting function** (`toInternal()`): Safely converts public to internal type for method calls
-
+The Drizzle adapter uses a two-tier type system (packages/drizzle/src/helpers.ts):
+1. **Public constraint** (`DrizzleDatabaseConstraint`): structural bound with `unknown` members
+   (`select`/`insert`/`update`/`delete`/`transaction`), used as the `DB` generic bound on every
+   endpoint class — any Drizzle database satisfies it without coupling to drizzle-orm types.
+2. **Internal interfaces** (`Database<Row>`, `QueryBuilder<Row>`): typed method signatures used
+   inside the adapter; `Row` derives from the consumer's Zod schema (`ModelObject<M['model']>`),
+   never from a drizzle-orm type. `QueryBuilder<Row>` is `PromiseLike<Row[]>`.
+3. **Casting function** (`cast<Row>()`): the single sanctioned boundary `as`, converting an
+   unknown database instance to `Database<Row>` for internal method calls.
 This pattern avoids coupling to specific Drizzle versions while maintaining internal type safety.
+
+## Naming Doctrine
+
+1. `create<Feature>Middleware()` — app.use-style cross-cutting middleware factories.
+   **Documented exceptions (rename only with owner sign-off):** `multiTenant()`, `apiVersion()`,
+   and `apiVersionedResponse()` keep their feature-named forms. Each anchors a feature family
+   whose entire public surface shares the feature prefix (`apiVersion`/`getApiVersion`/
+   `getApiVersionConfig`/`ApiVersionEnv`/`CONTEXT_KEYS.apiVersion`; `multiTenant`/
+   `MultiTenantConfig`/`MultiTenantMiddlewareConfig`/`TenantEnv`), so a `create<Feature>Middleware`
+   spelling would break family symmetry for zero disambiguation gain. The old bare-noun
+   `idempotency` factory was renamed because its name collided with its package name and it
+   anchored no such accessor family.
+2. `with<Feature>()` — class mixins only.
+3. `<vendor>UI()` / `docsIndex()` — GET-mounted documentation-page factories returning
+   `MiddlewareHandler` (sanctioned family modeled on `scalarUI`; they are page handlers, not
+   cross-cutting middleware, hence not `create*Middleware`). **Family field vocabulary
+   (ScalarConfig is the source):** `specUrl` = location of the OpenAPI spec the page loads;
+   `pageTitle` = the HTML `<title>`; `<sibling>Path` (`docsPath`/`redocPath`/`scalarPath`) =
+   href of a sibling docs page rendered as a link.
+4. `create<Feature>Routes()` — router factories returning a mountable `Hono` when a feature
+   genuinely owns multiple routes (health).
+5. `*Config` = top-level setup bag of a middleware/factory; `*Options` = per-operation/per-call
+   leaf bag (and storage-adapter constructor bags).
+
+### Config vs Options naming
+- `*Config` — the top-level bag a middleware factory, route/router factory, or feature factory
+  accepts once at setup time (RateLimitConfig, IdempotencyConfig, HealthConfig, ScalarConfig,
+  ApiVersioningConfig, MultiTenantMiddlewareConfig, CrudMcpConfig, SwaggerUIConfig).
+- `*Options` — a leaf bag scoped to a single operation/call or sub-feature (ListOptions,
+  SearchOptions, ExportOptions, CacheSetOptions, ToolOptions, ResourceOptions), and
+  storage-adapter constructor bags (KVRateLimitStorageOptions).
+- Documented exceptions (legacy, rename only with owner sign-off): RouterOptions,
+  RegisterCrudOptions, CreateDrizzleCrudOptions, PerTenantOpenApiOptions.
 
 ## Edge Runtime Compatibility
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,12 +9,49 @@
 - Prefer generics over `any` for flexible typing
 
 ### Drizzle Adapter Pattern
-The Drizzle adapter uses a two-tier type system:
-1. **Public interface** (`DrizzleDatabase`): Uses `unknown` returns to accept any Drizzle database
-2. **Internal interface** (`InternalDatabase`, `InternalQueryBuilder`): Uses specific method signatures
-3. **Casting function** (`toInternal()`): Safely converts public to internal type for method calls
-
+The Drizzle adapter uses a two-tier type system (packages/drizzle/src/helpers.ts):
+1. **Public constraint** (`DrizzleDatabaseConstraint`): structural bound with `unknown` members
+   (`select`/`insert`/`update`/`delete`/`transaction`), used as the `DB` generic bound on every
+   endpoint class — any Drizzle database satisfies it without coupling to drizzle-orm types.
+2. **Internal interfaces** (`Database<Row>`, `QueryBuilder<Row>`): typed method signatures used
+   inside the adapter; `Row` derives from the consumer's Zod schema (`ModelObject<M['model']>`),
+   never from a drizzle-orm type. `QueryBuilder<Row>` is `PromiseLike<Row[]>`.
+3. **Casting function** (`cast<Row>()`): the single sanctioned boundary `as`, converting an
+   unknown database instance to `Database<Row>` for internal method calls.
 This pattern avoids coupling to specific Drizzle versions while maintaining internal type safety.
+
+## Naming Doctrine
+
+1. `create<Feature>Middleware()` — app.use-style cross-cutting middleware factories.
+   **Documented exceptions (rename only with owner sign-off):** `multiTenant()`, `apiVersion()`,
+   and `apiVersionedResponse()` keep their feature-named forms. Each anchors a feature family
+   whose entire public surface shares the feature prefix (`apiVersion`/`getApiVersion`/
+   `getApiVersionConfig`/`ApiVersionEnv`/`CONTEXT_KEYS.apiVersion`; `multiTenant`/
+   `MultiTenantConfig`/`MultiTenantMiddlewareConfig`/`TenantEnv`), so a `create<Feature>Middleware`
+   spelling would break family symmetry for zero disambiguation gain. The old bare-noun
+   `idempotency` factory was renamed because its name collided with its package name and it
+   anchored no such accessor family.
+2. `with<Feature>()` — class mixins only.
+3. `<vendor>UI()` / `docsIndex()` — GET-mounted documentation-page factories returning
+   `MiddlewareHandler` (sanctioned family modeled on `scalarUI`; they are page handlers, not
+   cross-cutting middleware, hence not `create*Middleware`). **Family field vocabulary
+   (ScalarConfig is the source):** `specUrl` = location of the OpenAPI spec the page loads;
+   `pageTitle` = the HTML `<title>`; `<sibling>Path` (`docsPath`/`redocPath`/`scalarPath`) =
+   href of a sibling docs page rendered as a link.
+4. `create<Feature>Routes()` — router factories returning a mountable `Hono` when a feature
+   genuinely owns multiple routes (health).
+5. `*Config` = top-level setup bag of a middleware/factory; `*Options` = per-operation/per-call
+   leaf bag (and storage-adapter constructor bags).
+
+### Config vs Options naming
+- `*Config` — the top-level bag a middleware factory, route/router factory, or feature factory
+  accepts once at setup time (RateLimitConfig, IdempotencyConfig, HealthConfig, ScalarConfig,
+  ApiVersioningConfig, MultiTenantMiddlewareConfig, CrudMcpConfig, SwaggerUIConfig).
+- `*Options` — a leaf bag scoped to a single operation/call or sub-feature (ListOptions,
+  SearchOptions, ExportOptions, CacheSetOptions, ToolOptions, ResourceOptions), and
+  storage-adapter constructor bags (KVRateLimitStorageOptions).
+- Documented exceptions (legacy, rename only with owner sign-off): RouterOptions,
+  RegisterCrudOptions, CreateDrizzleCrudOptions, PerTenantOpenApiOptions.
 
 ## Edge Runtime Compatibility
 

--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ Peer dependencies: `hono >= 4.0.0` and `zod >= 4.0.0` are required.
 | `@hono-crud/memory` | In-memory CRUD adapter (tests, demos) |
 | `@hono-crud/drizzle` | Drizzle ORM CRUD adapter |
 | `@hono-crud/prisma` | Prisma CRUD adapter |
-| `@hono-crud/swagger` | Swagger UI + ReDoc documentation endpoints |
-| `@hono-crud/scalar` | Scalar API reference documentation endpoint |
+| `@hono-crud/swagger` | Swagger UI + ReDoc documentation pages (`swaggerUI`, `redocUI`, `docsIndex`) |
+| `@hono-crud/scalar` | Scalar API reference documentation page (`scalarUI`) |
 | `@hono-crud/cache` | Caching mixins and storage backends |
 | `@hono-crud/rate-limit` | Rate limiting middleware and storage backends |
 | `@hono-crud/idempotency` | Idempotency middleware and storage backends |
-| `@hono-crud/health` | Health check endpoints |
+| `@hono-crud/health` | Health check routes (`createHealthRoutes`) |
 | `@hono-crud/mcp` | Expose your CRUD resources as Model Context Protocol (MCP) tools for AI agents |
 
 ## Quick Start
@@ -66,7 +66,7 @@ Peer dependencies: `hono >= 4.0.0` and `zod >= 4.0.0` are required.
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { fromHono, registerCrud, defineModel, defineMeta } from 'hono-crud';
-import { setupSwaggerUI } from '@hono-crud/swagger';
+import { swaggerUI } from '@hono-crud/swagger';
 import {
   MemoryCreateEndpoint,
   MemoryReadEndpoint,
@@ -137,7 +137,7 @@ app.doc('/openapi.json', {
   openapi: '3.1.0',
   info: { title: 'My API', version: '1.0.0' },
 });
-setupSwaggerUI(app, { docsPath: '/docs', specPath: '/openapi.json' });
+app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
 
 export default app;
 ```
@@ -460,8 +460,11 @@ These symbols also remain available from the `'hono-crud'` barrel for convenienc
 Idempotency and health checks ship as their own packages:
 
 ```typescript
-import { idempotency, MemoryIdempotencyStorage } from '@hono-crud/idempotency';
-import { createHealthEndpoints } from '@hono-crud/health';
+import { createIdempotencyMiddleware, MemoryIdempotencyStorage } from '@hono-crud/idempotency';
+import { createHealthRoutes } from '@hono-crud/health';
+
+app.use('/api/*', createIdempotencyMiddleware());
+app.route('/', createHealthRoutes());
 ```
 
 ## API Documentation
@@ -469,8 +472,8 @@ import { createHealthEndpoints } from '@hono-crud/health';
 `npm install @hono-crud/swagger @hono-crud/scalar`:
 
 ```typescript
-import { setupSwaggerUI, setupReDoc } from '@hono-crud/swagger';
-import { setupScalar } from '@hono-crud/scalar';
+import { swaggerUI, redocUI } from '@hono-crud/swagger';
+import { scalarUI } from '@hono-crud/scalar';
 
 // OpenAPI spec
 app.doc('/openapi.json', {
@@ -479,9 +482,9 @@ app.doc('/openapi.json', {
 });
 
 // Documentation UIs
-setupSwaggerUI(app, { docsPath: '/docs', specPath: '/openapi.json' });
-setupReDoc(app, { redocPath: '/redoc', specPath: '/openapi.json' });
-setupScalar(app, '/reference', { specUrl: '/openapi.json' });
+app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
+app.get('/redoc', redocUI({ specUrl: '/openapi.json' }));
+app.get('/reference', scalarUI({ specUrl: '/openapi.json' }));
 ```
 
 ## Examples

--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -570,7 +570,7 @@ Prevent duplicate operations via idempotency keys.
 
 ```typescript
 import {
-  idempotency,
+  createIdempotencyMiddleware,
   setIdempotencyStorage,
   MemoryIdempotencyStorage,
 } from '@hono-crud/idempotency';
@@ -578,7 +578,7 @@ import {
 setIdempotencyStorage(new MemoryIdempotencyStorage());
 
 // Apply to mutation endpoints
-app.use('/api/*', idempotency({
+app.use('/api/*', createIdempotencyMiddleware({
   headerName: 'Idempotency-Key',  // default
   ttl: 86400,                      // 24 hours (default)
 }));
@@ -656,15 +656,28 @@ instead, or `required: false` to continue without a tenant.
 
 **Model-level config:**
 
+Multi-tenancy is a two-stage pipeline. Stage 1 is the `multiTenant()`
+middleware above: it extracts the tenant ID from the request (header, path,
+query, JWT, or custom), enforces `required`/`validate`, and publishes the
+value to a context variable (`contextKey`, default `'tenantId'`). Stage 2 is
+the model-level config: with `source: 'context'` (the default) the data layer
+reads exactly what the middleware published, then filters every query by
+`field` and injects it on create.
+
 ```typescript
 const UserModel = defineModel({
   tableName: 'users',
   schema: UserSchema,
   primaryKeys: ['id'],
   multiTenant: {
-    tenantIdField: 'tenantId',
-    enforceOnCreate: true,
-    enforceOnRead: true,
+    field: 'tenantId',        // column that stores the tenant ID (default 'tenantId')
+    source: 'context',        // 'context' (default) | 'header' | 'path' | 'custom'
+    contextKey: 'tenantId',   // context var the data layer READS (middleware WRITES it)
+    headerName: 'X-Tenant-ID',// used when source is 'header'
+    pathParam: 'tenantId',    // used when source is 'path'
+    getTenantId: undefined,   // custom extractor when source is 'custom'
+    required: true,           // false = silently return no results when missing
+    errorMessage: 'Tenant ID is required',
   },
 });
 ```
@@ -676,9 +689,9 @@ const UserModel = defineModel({
 Liveness and readiness endpoints.
 
 ```typescript
-import { createHealthEndpoints } from '@hono-crud/health';
+import { createHealthRoutes } from '@hono-crud/health';
 
-createHealthEndpoints(app, {
+app.route('/', createHealthRoutes({
   version: '1.0.0',
   path: '/health',       // Liveness (always 200)
   readyPath: '/ready',   // Readiness (runs checks)
@@ -695,7 +708,7 @@ createHealthEndpoints(app, {
       timeout: 3000,     // Per-check timeout
     },
   ],
-});
+}));
 ```
 
 **Response:**
@@ -885,25 +898,42 @@ GET /users?page=2&per_page=50
 
 ## API Versioning
 
+Negotiate the API version per request and transform responses per version.
+Registration order matters: `apiVersion()` first, then `apiVersionedResponse()`,
+then your route handlers — `apiVersionedResponse()` wraps handlers via
+`await next()`, and middleware registered after a response-producing handler
+never runs.
+
 ```typescript
-import { apiVersion, getApiVersion, versionedResponse } from 'hono-crud';
+import { apiVersion, apiVersionedResponse, getApiVersion, getApiVersionConfig } from 'hono-crud';
 
 app.use('/api/*', apiVersion({
-  strategy: 'header',     // 'header' | 'path' | 'query'
-  headerName: 'API-Version',
-  defaultVersion: '1',
-  supported: ['1', '2'],
+  versions: [
+    { version: '1', responseTransformer: (data) => ({ id: data.id, name: data.name }) },
+    { version: '2' },
+  ],
+  defaultVersion: '2',        // falls back to the first entry when omitted
+  strategy: 'header',         // 'url' | 'header' | 'query' (default 'header')
+  headerName: 'Accept-Version', // default
+  queryParam: 'version',      // for strategy 'query' (default)
+  urlPattern: '/v{version}',  // for strategy 'url' (default)
+  extractVersion: undefined,  // custom extractor (overrides strategy)
+  addHeaders: true,           // adds version response headers (default)
 }));
 
-app.get('/api/users', (c) => {
-  const version = getApiVersion(c);
+// Rewrites response JSON through the active version's responseTransformer.
+app.use('/api/*', apiVersionedResponse());
 
-  return versionedResponse(c, userData, {
-    '1': (data) => ({ id: data.id, name: data.name }),
-    '2': (data) => ({ id: data.id, fullName: data.name, email: data.email }),
-  });
+app.get('/api/users/:id', (c) => {
+  const version = getApiVersion(c);          // e.g. '1'
+  const config = getApiVersionConfig(c);     // the matched ApiVersionConfig entry
+  return c.json(userData);                   // transformed on the way out for v1 clients
 });
 ```
+
+Each entry in `versions` is an `ApiVersionConfig` (`version`, optional
+`middleware`, `requestTransformer`, `responseTransformer`, `deprecated`,
+`sunset`).
 
 ---
 

--- a/docs/alternative-api-patterns.md
+++ b/docs/alternative-api-patterns.md
@@ -464,7 +464,7 @@ registerCrud(app, '/users', userEndpoints);
 // Built-in Memory adapter bundle
 import { MemoryAdapters } from '@hono-crud/memory';
 
-// Create custom adapter bundles for Drizzle or Prisma
+// Built-in Drizzle bundle (PrismaAdapters from @hono-crud/prisma works the same way)
 import { DrizzleAdapters } from '@hono-crud/drizzle';
 
 const endpoints = defineEndpoints(config, DrizzleAdapters);

--- a/docs/database-adapters.md
+++ b/docs/database-adapters.md
@@ -225,10 +225,10 @@ import {
   DrizzleReadEndpoint,
   DrizzleUpdateEndpoint,
   DrizzleDeleteEndpoint,
-  type DrizzleDatabase,
+  type DrizzleDatabaseConstraint,
 } from '@hono-crud/drizzle';
 
-const typedDb = db as unknown as DrizzleDatabase;
+const typedDb = db as unknown as DrizzleDatabaseConstraint;
 
 class UserList extends DrizzleListEndpoint {
   _meta = userMeta;

--- a/docs/hooks-and-approvals.md
+++ b/docs/hooks-and-approvals.md
@@ -1153,8 +1153,8 @@ LIMIT 50;
 
 An approved action could in principle be resumed multiple times if the
 resume call is idempotent at the HTTP layer. If your handler is non-
-idempotent (transfer money), wrap with the lib's existing `idempotency`
-middleware OR mark the action `consumed` after first resume. The minimal
+idempotent (transfer money), wrap with the lib's existing
+`createIdempotencyMiddleware` OR mark the action `consumed` after first resume. The minimal
 addition would be a 5th method on `ApprovalStorage`:
 
 ```ts

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -258,7 +258,7 @@ mcp-session-id: <id from the initialize response>
 
 ## Configuration reference
 
-### `createCrudMcp(app, options)` — `CrudMcpOptions`
+### `createCrudMcp(app, options)` — `CrudMcpConfig`
 
 | Option | Type | Default | Description |
 |---|---|---|---|

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -26,9 +26,12 @@ import { RedisRateLimitStorage, setRateLimitStorage } from '@hono-crud/rate-limi
 
 setRateLimitStorage(new RedisRateLimitStorage({
   client: redisClient,
-  prefix: 'rl:',
 }));
 ```
+
+The optional `prefix` adds extra namespacing on top of the keys the middleware
+produces; it defaults to `''` because keys are already namespaced by the
+middleware's `keyPrefix` (default `'rl'`).
 
 ### Context-scoped Storage
 

--- a/examples/drizzle/basic-crud.ts
+++ b/examples/drizzle/basic-crud.ts
@@ -21,7 +21,7 @@ import {
   DrizzleReadEndpoint,
   DrizzleUpdateEndpoint,
 } from '@hono-crud/drizzle';
-import { setupSwaggerUI } from '@hono-crud/swagger';
+import { swaggerUI } from '@hono-crud/swagger';
 import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 import { defineMeta, defineModel, fromHono, registerCrud } from 'hono-crud';
@@ -150,7 +150,7 @@ app.doc('/openapi.json', {
 });
 
 // Swagger UI
-setupSwaggerUI(app, { docsPath: '/docs', specPath: '/openapi.json' });
+app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
 
 // Health check
 app.get('/health', (c) => c.json({ status: 'ok', adapter: 'drizzle', database: 'postgresql' }));

--- a/examples/drizzle/batch-operations.ts
+++ b/examples/drizzle/batch-operations.ts
@@ -25,7 +25,7 @@ import {
   DrizzleRestoreEndpoint,
   DrizzleUpdateEndpoint,
 } from '@hono-crud/drizzle';
-import { setupSwaggerUI } from '@hono-crud/swagger';
+import { swaggerUI } from '@hono-crud/swagger';
 import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 import { defineMeta, defineModel, fromHono, registerCrud } from 'hono-crud';
@@ -193,7 +193,7 @@ app.doc('/openapi.json', {
   },
 });
 
-setupSwaggerUI(app, { docsPath: '/docs', specPath: '/openapi.json' });
+app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
 app.get('/health', (c) => c.json({ status: 'ok' }));
 
 // ============================================================================

--- a/examples/drizzle/comprehensive.ts
+++ b/examples/drizzle/comprehensive.ts
@@ -31,8 +31,8 @@ import {
   DrizzleUpdateEndpoint,
   DrizzleUpsertEndpoint,
 } from '@hono-crud/drizzle';
-import { setupScalar } from '@hono-crud/scalar';
-import { setupReDoc, setupSwaggerUI } from '@hono-crud/swagger';
+import { scalarUI } from '@hono-crud/scalar';
+import { redocUI, swaggerUI } from '@hono-crud/swagger';
 import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 import { defineMeta, defineModel, fromHono, registerCrud } from 'hono-crud';
@@ -510,9 +510,9 @@ This API demonstrates ALL hono-crud features:
   },
 });
 
-setupSwaggerUI(app, { docsPath: '/docs', specPath: '/openapi.json' });
-setupReDoc(app, { redocPath: '/redoc', specPath: '/openapi.json', title: 'Comprehensive API' });
-setupScalar(app, '/reference', { specUrl: '/openapi.json', theme: 'purple' });
+app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
+app.get('/redoc', redocUI({ specUrl: '/openapi.json', pageTitle: 'Comprehensive API' }));
+app.get('/reference', scalarUI({ specUrl: '/openapi.json', theme: 'purple' }));
 app.get('/health', (c) => c.json({ status: 'ok', adapter: 'drizzle', database: 'postgresql' }));
 
 // ============================================================================

--- a/examples/drizzle/d1-crud.ts
+++ b/examples/drizzle/d1-crud.ts
@@ -31,7 +31,7 @@
 
 import { KVCacheStorage } from '@hono-crud/cache';
 import { type DrizzleDatabaseConstraint, createDrizzleCrud } from '@hono-crud/drizzle';
-import { setupSwaggerUI } from '@hono-crud/swagger';
+import { swaggerUI } from '@hono-crud/swagger';
 import { drizzle } from 'drizzle-orm/d1';
 import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 import { Hono } from 'hono';
@@ -264,7 +264,7 @@ openApiApp.doc('/openapi.json', {
 });
 
 // Swagger UI
-setupSwaggerUI(openApiApp, { docsPath: '/docs', specPath: '/openapi.json' });
+openApiApp.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
 
 // Health check
 openApiApp.get('/health', (c) => c.json({ status: 'ok', adapter: 'drizzle', database: 'd1' }));

--- a/examples/drizzle/filtering.ts
+++ b/examples/drizzle/filtering.ts
@@ -25,7 +25,7 @@ import {
   type DrizzleDatabaseConstraint,
   DrizzleListEndpoint,
 } from '@hono-crud/drizzle';
-import { setupSwaggerUI } from '@hono-crud/swagger';
+import { swaggerUI } from '@hono-crud/swagger';
 import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 import { defineMeta, defineModel, fromHono, registerCrud } from 'hono-crud';
@@ -212,7 +212,7 @@ app.doc('/openapi.json', {
   },
 });
 
-setupSwaggerUI(app, { docsPath: '/docs', specPath: '/openapi.json' });
+app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
 app.get('/health', (c) => c.json({ status: 'ok' }));
 
 // ============================================================================

--- a/examples/drizzle/relations.ts
+++ b/examples/drizzle/relations.ts
@@ -17,7 +17,7 @@ import {
   DrizzleListEndpoint,
   DrizzleReadEndpoint,
 } from '@hono-crud/drizzle';
-import { setupSwaggerUI } from '@hono-crud/swagger';
+import { swaggerUI } from '@hono-crud/swagger';
 import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 import { defineMeta, defineModel, fromHono, registerCrud } from 'hono-crud';
@@ -338,7 +338,7 @@ app.doc('/openapi.json', {
   },
 });
 
-setupSwaggerUI(app, { docsPath: '/docs', specPath: '/openapi.json' });
+app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
 app.get('/health', (c) => c.json({ status: 'ok' }));
 
 // ============================================================================

--- a/examples/drizzle/soft-delete.ts
+++ b/examples/drizzle/soft-delete.ts
@@ -22,7 +22,7 @@ import {
   DrizzleRestoreEndpoint,
   DrizzleUpdateEndpoint,
 } from '@hono-crud/drizzle';
-import { setupSwaggerUI } from '@hono-crud/swagger';
+import { swaggerUI } from '@hono-crud/swagger';
 import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 import { defineMeta, defineModel, fromHono, registerCrud } from 'hono-crud';
@@ -182,7 +182,7 @@ app.doc('/openapi.json', {
   },
 });
 
-setupSwaggerUI(app, { docsPath: '/docs', specPath: '/openapi.json' });
+app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
 app.get('/health', (c) => c.json({ status: 'ok' }));
 
 // ============================================================================

--- a/examples/drizzle/upsert.ts
+++ b/examples/drizzle/upsert.ts
@@ -21,7 +21,7 @@ import {
   DrizzleListEndpoint,
   DrizzleUpsertEndpoint,
 } from '@hono-crud/drizzle';
-import { setupSwaggerUI } from '@hono-crud/swagger';
+import { swaggerUI } from '@hono-crud/swagger';
 import { serve } from '@hono/node-server';
 import { integer, numeric, pgEnum, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
 import { Hono } from 'hono';
@@ -238,7 +238,7 @@ app.doc('/openapi.json', {
   },
 });
 
-setupSwaggerUI(app, { docsPath: '/docs', specPath: '/openapi.json' });
+app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
 app.get('/health', (c) => c.json({ status: 'ok' }));
 
 // ============================================================================

--- a/examples/drizzle/with-drizzle-zod.ts
+++ b/examples/drizzle/with-drizzle-zod.ts
@@ -26,8 +26,8 @@ import {
   // drizzle-zod helpers
   createDrizzleSchemas,
 } from '@hono-crud/drizzle';
-import { setupScalar } from '@hono-crud/scalar';
-import { setupSwaggerUI } from '@hono-crud/swagger';
+import { scalarUI } from '@hono-crud/scalar';
+import { swaggerUI } from '@hono-crud/swagger';
 import { serve } from '@hono/node-server';
 import { createClient } from '@libsql/client';
 import { drizzle } from 'drizzle-orm/libsql';
@@ -232,12 +232,15 @@ export async function createApp() {
   });
 
   // Setup both Swagger UI and Scalar API Reference
-  setupSwaggerUI(app, { docsPath: '/docs', specPath: '/openapi.json' });
-  setupScalar(app, '/reference', {
-    specUrl: '/openapi.json',
-    theme: 'purple',
-    pageTitle: 'drizzle-zod Example API',
-  });
+  app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
+  app.get(
+    '/reference',
+    scalarUI({
+      specUrl: '/openapi.json',
+      theme: 'purple',
+      pageTitle: 'drizzle-zod Example API',
+    }),
+  );
 
   // Health check
   app.get('/health', (c) =>

--- a/examples/local-consumer/src/app.ts
+++ b/examples/local-consumer/src/app.ts
@@ -1,6 +1,6 @@
 import { MemoryCacheStorage } from '@hono-crud/cache';
-import { createHealthEndpoints } from '@hono-crud/health';
-import { MemoryIdempotencyStorage, idempotency } from '@hono-crud/idempotency';
+import { createHealthRoutes } from '@hono-crud/health';
+import { MemoryIdempotencyStorage, createIdempotencyMiddleware } from '@hono-crud/idempotency';
 import {
   MemoryAggregateEndpoint,
   MemoryBatchCreateEndpoint,
@@ -28,7 +28,7 @@ import {
   getStorage,
 } from '@hono-crud/memory';
 import { MemoryRateLimitStorage, createRateLimitMiddleware } from '@hono-crud/rate-limit';
-import { setupSwaggerUI } from '@hono-crud/swagger';
+import { swaggerUI } from '@hono-crud/swagger';
 import { type Context, Hono, type MiddlewareHandler } from 'hono';
 import {
   type AuthEnv,
@@ -521,7 +521,7 @@ export function createApp() {
       storage: rateLimitStorage,
     }),
   );
-  app.use('/idempotent/*', idempotency({ storage: idempotencyStorage }));
+  app.use('/idempotent/*', createIdempotencyMiddleware({ storage: idempotencyStorage }));
   app.use('/tenant/*', multiTenant<AppEnv>({ source: 'header', required: true }));
   app.use(
     '/versioned/*',
@@ -655,19 +655,22 @@ export function createApp() {
     return c.json({ userId, postId });
   });
 
-  createHealthEndpoints(app, {
-    path: '/live',
-    readyPath: '/ready',
-    version: 'local-consumer',
-    checks: [
-      { name: 'memory-users', check: async () => `${getStorage<User>('users').size} users` },
-      {
-        name: 'memory-cache',
-        check: async () => `${cacheStorage.getStats().size} cache entries`,
-        critical: false,
-      },
-    ],
-  });
+  app.route(
+    '/',
+    createHealthRoutes({
+      path: '/live',
+      readyPath: '/ready',
+      version: 'local-consumer',
+      checks: [
+        { name: 'memory-users', check: async () => `${getStorage<User>('users').size} users` },
+        {
+          name: 'memory-cache',
+          check: async () => `${cacheStorage.getStats().size} cache entries`,
+          critical: false,
+        },
+      ],
+    }),
+  );
 
   app.get('/health', (c) =>
     c.json({
@@ -714,7 +717,7 @@ export function createApp() {
     },
   });
 
-  setupSwaggerUI(app, { docsPath: '/docs', specPath: '/openapi.json' });
+  app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
 
   return app;
 }

--- a/examples/memory/alternative-apis.ts
+++ b/examples/memory/alternative-apis.ts
@@ -21,7 +21,7 @@ import {
   MemoryUpdateEndpoint,
   clearStorage,
 } from '@hono-crud/memory';
-import { setupSwaggerUI } from '@hono-crud/swagger';
+import { swaggerUI } from '@hono-crud/swagger';
 import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 import {
@@ -344,7 +344,7 @@ Choose the pattern that best fits your coding style and project requirements.
   },
 });
 
-setupSwaggerUI(app, { docsPath: '/docs', specPath: '/openapi.json' });
+app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
 
 // Health check
 app.get('/health', (c) => c.json({ status: 'ok' }));

--- a/examples/memory/basic-crud.ts
+++ b/examples/memory/basic-crud.ts
@@ -19,8 +19,8 @@ import {
   MemoryUpdateEndpoint,
   clearStorage,
 } from '@hono-crud/memory';
-import { setupScalar } from '@hono-crud/scalar';
-import { setupReDoc, setupSwaggerUI } from '@hono-crud/swagger';
+import { scalarUI } from '@hono-crud/scalar';
+import { redocUI, swaggerUI } from '@hono-crud/swagger';
 import { serve } from '@hono/node-server';
 import { type Env, Hono } from 'hono';
 import { defineMeta, defineModel, fromHono, registerCrud } from 'hono-crud';
@@ -142,9 +142,9 @@ app.doc('/openapi.json', {
 });
 
 // API Documentation UIs
-setupSwaggerUI(app, { docsPath: '/docs', specPath: '/openapi.json' });
-setupReDoc(app, { redocPath: '/redoc', specPath: '/openapi.json', title: 'User API' });
-setupScalar(app, '/reference', { specUrl: '/openapi.json', theme: 'default' });
+app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
+app.get('/redoc', redocUI({ specUrl: '/openapi.json', pageTitle: 'User API' }));
+app.get('/reference', scalarUI({ specUrl: '/openapi.json', theme: 'default' }));
 
 // Health check
 app.get('/health', (c) => c.json({ status: 'ok', adapter: 'memory' }));

--- a/examples/memory/batch-operations.ts
+++ b/examples/memory/batch-operations.ts
@@ -23,7 +23,7 @@ import {
   MemoryUpdateEndpoint,
   clearStorage,
 } from '@hono-crud/memory';
-import { setupSwaggerUI } from '@hono-crud/swagger';
+import { swaggerUI } from '@hono-crud/swagger';
 import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 import { defineMeta, defineModel, fromHono, registerCrud } from 'hono-crud';
@@ -195,7 +195,7 @@ app.doc('/openapi.json', {
 });
 
 // Swagger UI
-setupSwaggerUI(app, { docsPath: '/docs', specPath: '/openapi.json' });
+app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
 
 // Health check
 app.get('/health', (c) => c.json({ status: 'ok' }));

--- a/examples/memory/comprehensive.ts
+++ b/examples/memory/comprehensive.ts
@@ -29,7 +29,7 @@ import {
   clearStorage,
   getStorage,
 } from '@hono-crud/memory';
-import { setupReDoc, setupSwaggerUI } from '@hono-crud/swagger';
+import { redocUI, swaggerUI } from '@hono-crud/swagger';
 import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 import { defineMeta, defineModel, fromHono, registerCrud } from 'hono-crud';
@@ -592,8 +592,8 @@ This API demonstrates ALL hono-crud features with the Memory adapter:
   },
 });
 
-setupSwaggerUI(app, { docsPath: '/docs', specPath: '/openapi.json' });
-setupReDoc(app, { redocPath: '/redoc', specPath: '/openapi.json', title: 'Comprehensive API' });
+app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
+app.get('/redoc', redocUI({ specUrl: '/openapi.json', pageTitle: 'Comprehensive API' }));
 app.get('/health', (c) => c.json({ status: 'ok', adapter: 'memory' }));
 
 // ============================================================================

--- a/examples/memory/computed-fields.ts
+++ b/examples/memory/computed-fields.ts
@@ -22,7 +22,7 @@ import {
   clearStorage,
   getStorage,
 } from '@hono-crud/memory';
-import { setupSwaggerUI } from '@hono-crud/swagger';
+import { swaggerUI } from '@hono-crud/swagger';
 import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 import { type ComputedFieldsConfig, defineMeta, defineModel, fromHono } from 'hono-crud';
@@ -243,7 +243,7 @@ These fields appear in all responses but are not stored in the database.
 });
 
 // Swagger UI
-setupSwaggerUI(app, { docsPath: '/docs', specPath: '/openapi.json' });
+app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
 
 // ============================================================================
 // Add Sample Data

--- a/examples/memory/field-selection.ts
+++ b/examples/memory/field-selection.ts
@@ -21,7 +21,7 @@ import {
   clearStorage,
   getStorage,
 } from '@hono-crud/memory';
-import { setupSwaggerUI } from '@hono-crud/swagger';
+import { swaggerUI } from '@hono-crud/swagger';
 import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 import { type ComputedFieldsConfig, defineMeta, defineModel, fromHono } from 'hono-crud';
@@ -260,7 +260,7 @@ Use \`?fields=field1,field2,field3\` to select specific fields.
 });
 
 // Swagger UI
-setupSwaggerUI(app, { docsPath: '/docs', specPath: '/openapi.json' });
+app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
 
 // ============================================================================
 // Add Sample Data

--- a/examples/memory/rate-limiting.ts
+++ b/examples/memory/rate-limiting.ts
@@ -26,7 +26,7 @@ import {
   createRateLimitMiddleware,
   setRateLimitStorage,
 } from '@hono-crud/rate-limit';
-import { setupSwaggerUI } from '@hono-crud/swagger';
+import { swaggerUI } from '@hono-crud/swagger';
 import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 import { type AuthEnv, defineMeta, defineModel, fromHono, registerCrud } from 'hono-crud';
@@ -306,7 +306,7 @@ app.doc('/openapi.json', {
   },
 });
 
-setupSwaggerUI(app, { docsPath: '/docs', specPath: '/openapi.json' });
+app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
 
 // ============================================================================
 // Start Server

--- a/examples/memory/relations.ts
+++ b/examples/memory/relations.ts
@@ -16,7 +16,7 @@ import {
   clearStorage,
   getStorage,
 } from '@hono-crud/memory';
-import { setupSwaggerUI } from '@hono-crud/swagger';
+import { swaggerUI } from '@hono-crud/swagger';
 import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 import { defineMeta, defineModel, fromHono, registerCrud } from 'hono-crud';
@@ -327,7 +327,7 @@ app.doc('/openapi.json', {
 });
 
 // Swagger UI
-setupSwaggerUI(app, { docsPath: '/docs', specPath: '/openapi.json' });
+app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
 
 // Health check
 app.get('/health', (c) => c.json({ status: 'ok' }));

--- a/examples/memory/soft-delete.ts
+++ b/examples/memory/soft-delete.ts
@@ -19,7 +19,7 @@ import {
   MemoryUpdateEndpoint,
   clearStorage,
 } from '@hono-crud/memory';
-import { setupSwaggerUI } from '@hono-crud/swagger';
+import { swaggerUI } from '@hono-crud/swagger';
 import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 import { defineMeta, defineModel, fromHono, registerCrud } from 'hono-crud';
@@ -161,7 +161,7 @@ app.doc('/openapi.json', {
 });
 
 // Swagger UI
-setupSwaggerUI(app, { docsPath: '/docs', specPath: '/openapi.json' });
+app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
 
 // Health check
 app.get('/health', (c) => c.json({ status: 'ok' }));

--- a/examples/prisma/basic-crud.ts
+++ b/examples/prisma/basic-crud.ts
@@ -22,7 +22,7 @@ import {
   PrismaReadEndpoint,
   PrismaUpdateEndpoint,
 } from '@hono-crud/prisma';
-import { setupSwaggerUI } from '@hono-crud/swagger';
+import { swaggerUI } from '@hono-crud/swagger';
 import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 import { defineMeta, defineModel, fromHono, registerCrud } from 'hono-crud';
@@ -144,7 +144,7 @@ app.doc('/openapi.json', {
 });
 
 // Swagger UI
-setupSwaggerUI(app, { docsPath: '/docs', specPath: '/openapi.json' });
+app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
 
 // Health check
 app.get('/health', (c) => c.json({ status: 'ok', adapter: 'prisma', database: 'postgresql' }));

--- a/examples/prisma/batch-operations.ts
+++ b/examples/prisma/batch-operations.ts
@@ -26,7 +26,7 @@ import {
   PrismaRestoreEndpoint,
   PrismaUpdateEndpoint,
 } from '@hono-crud/prisma';
-import { setupSwaggerUI } from '@hono-crud/swagger';
+import { swaggerUI } from '@hono-crud/swagger';
 import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 import { defineMeta, defineModel, fromHono, registerCrud } from 'hono-crud';
@@ -192,7 +192,7 @@ app.doc('/openapi.json', {
   },
 });
 
-setupSwaggerUI(app, { docsPath: '/docs', specPath: '/openapi.json' });
+app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
 app.get('/health', (c) => c.json({ status: 'ok' }));
 
 // ============================================================================

--- a/examples/prisma/comprehensive.ts
+++ b/examples/prisma/comprehensive.ts
@@ -32,7 +32,7 @@ import {
   PrismaUpdateEndpoint,
   PrismaUpsertEndpoint,
 } from '@hono-crud/prisma';
-import { setupReDoc, setupSwaggerUI } from '@hono-crud/swagger';
+import { redocUI, swaggerUI } from '@hono-crud/swagger';
 import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 import { defineMeta, defineModel, fromHono, registerCrud } from 'hono-crud';
@@ -443,8 +443,8 @@ This API demonstrates ALL hono-crud features:
   },
 });
 
-setupSwaggerUI(app, { docsPath: '/docs', specPath: '/openapi.json' });
-setupReDoc(app, { redocPath: '/redoc', specPath: '/openapi.json', title: 'Comprehensive API' });
+app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
+app.get('/redoc', redocUI({ specUrl: '/openapi.json', pageTitle: 'Comprehensive API' }));
 app.get('/health', (c) => c.json({ status: 'ok', adapter: 'prisma', database: 'postgresql' }));
 
 // ============================================================================

--- a/examples/prisma/filtering.ts
+++ b/examples/prisma/filtering.ts
@@ -23,7 +23,7 @@
  */
 
 import { PrismaCreateEndpoint, PrismaListEndpoint } from '@hono-crud/prisma';
-import { setupSwaggerUI } from '@hono-crud/swagger';
+import { swaggerUI } from '@hono-crud/swagger';
 import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 import { defineMeta, defineModel, fromHono, registerCrud } from 'hono-crud';
@@ -202,7 +202,7 @@ app.doc('/openapi.json', {
   },
 });
 
-setupSwaggerUI(app, { docsPath: '/docs', specPath: '/openapi.json' });
+app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
 app.get('/health', (c) => c.json({ status: 'ok' }));
 
 // ============================================================================

--- a/examples/prisma/relations.ts
+++ b/examples/prisma/relations.ts
@@ -14,7 +14,7 @@
  */
 
 import { PrismaCreateEndpoint, PrismaListEndpoint, PrismaReadEndpoint } from '@hono-crud/prisma';
-import { setupSwaggerUI } from '@hono-crud/swagger';
+import { swaggerUI } from '@hono-crud/swagger';
 import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 import { defineMeta, defineModel, fromHono, registerCrud } from 'hono-crud';
@@ -291,7 +291,7 @@ app.doc('/openapi.json', {
   },
 });
 
-setupSwaggerUI(app, { docsPath: '/docs', specPath: '/openapi.json' });
+app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
 app.get('/health', (c) => c.json({ status: 'ok' }));
 
 // ============================================================================

--- a/examples/prisma/soft-delete.ts
+++ b/examples/prisma/soft-delete.ts
@@ -23,7 +23,7 @@ import {
   PrismaRestoreEndpoint,
   PrismaUpdateEndpoint,
 } from '@hono-crud/prisma';
-import { setupSwaggerUI } from '@hono-crud/swagger';
+import { swaggerUI } from '@hono-crud/swagger';
 import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 import { defineMeta, defineModel, fromHono, registerCrud } from 'hono-crud';
@@ -176,7 +176,7 @@ app.doc('/openapi.json', {
   },
 });
 
-setupSwaggerUI(app, { docsPath: '/docs', specPath: '/openapi.json' });
+app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
 app.get('/health', (c) => c.json({ status: 'ok' }));
 
 // ============================================================================

--- a/examples/prisma/upsert.ts
+++ b/examples/prisma/upsert.ts
@@ -22,7 +22,7 @@ import {
   PrismaListEndpoint,
   PrismaUpsertEndpoint,
 } from '@hono-crud/prisma';
-import { setupSwaggerUI } from '@hono-crud/swagger';
+import { swaggerUI } from '@hono-crud/swagger';
 import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 import { defineMeta, defineModel, fromHono } from 'hono-crud';
@@ -116,7 +116,7 @@ app.doc('/openapi.json', {
   },
 });
 
-setupSwaggerUI(app, { docsPath: '/docs', specPath: '/openapi.json' });
+app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
 app.get('/health', (c) => c.json({ status: 'ok' }));
 
 // ============================================================================

--- a/packages/cache/src/mixin.ts
+++ b/packages/cache/src/mixin.ts
@@ -70,7 +70,7 @@ export const cacheStorageRegistry = cacheStorageFeature.registry;
  * @example
  * ```ts
  * import { Redis } from '@upstash/redis';
- * import { RedisCacheStorage, setCacheStorage } from 'hono-crud/cache';
+ * import { RedisCacheStorage, setCacheStorage } from '@hono-crud/cache';
  *
  * setCacheStorage(new RedisCacheStorage({
  *   client: new Redis({ url: c.env.REDIS_URL }),

--- a/packages/cache/src/storage/cloudflare-kv.ts
+++ b/packages/cache/src/storage/cloudflare-kv.ts
@@ -39,7 +39,7 @@ export interface KVCacheStorageOptions {
  *
  * @example
  * ```ts
- * import { KVCacheStorage } from 'hono-crud/cache';
+ * import { KVCacheStorage } from '@hono-crud/cache';
  * import { createStorageMiddleware } from 'hono-crud';
  *
  * app.use('*', async (c, next) => {

--- a/packages/cache/src/storage/memory.ts
+++ b/packages/cache/src/storage/memory.ts
@@ -15,7 +15,7 @@ import type { CacheEntry, CacheSetOptions, CacheStats, CacheStorage } from '../t
  *
  * @example
  * ```ts
- * import { MemoryCacheStorage, setCacheStorage } from 'hono-crud/cache';
+ * import { MemoryCacheStorage, setCacheStorage } from '@hono-crud/cache';
  *
  * const cache = new MemoryCacheStorage();
  * setCacheStorage(cache);

--- a/packages/cache/src/storage/redis.ts
+++ b/packages/cache/src/storage/redis.ts
@@ -59,7 +59,7 @@ export interface RedisCacheStorageOptions {
  * @example
  * ```ts
  * import { Redis } from '@upstash/redis';
- * import { RedisCacheStorage, setCacheStorage } from 'hono-crud/cache';
+ * import { RedisCacheStorage, setCacheStorage } from '@hono-crud/cache';
  *
  * const cache = new RedisCacheStorage({
  *   client: new Redis({
@@ -73,7 +73,7 @@ export interface RedisCacheStorageOptions {
  * @example
  * ```ts
  * import Redis from 'ioredis';
- * import { RedisCacheStorage, setCacheStorage } from 'hono-crud/cache';
+ * import { RedisCacheStorage, setCacheStorage } from '@hono-crud/cache';
  *
  * const cache = new RedisCacheStorage({
  *   client: new Redis(c.env.REDIS_URL),

--- a/packages/core/src/api-version/index.ts
+++ b/packages/core/src/api-version/index.ts
@@ -1,8 +1,8 @@
-export { apiVersion, getApiVersion, getApiVersionConfig, versionedResponse } from './middleware';
+export { apiVersion, getApiVersion, getApiVersionConfig, apiVersionedResponse } from './middleware';
 export type {
-  VersionStrategy,
-  VersionTransformer,
+  ApiVersionStrategy,
+  ApiVersionTransformer,
   ApiVersionConfig,
-  VersioningMiddlewareConfig,
+  ApiVersioningConfig,
   ApiVersionEnv,
 } from './types';

--- a/packages/core/src/api-version/middleware.ts
+++ b/packages/core/src/api-version/middleware.ts
@@ -1,7 +1,7 @@
 import type { Context, MiddlewareHandler } from 'hono';
 import { CONTEXT_KEYS } from '../core/context-keys';
 import { ApiException } from '../core/exceptions';
-import type { ApiVersionConfig, VersioningMiddlewareConfig } from './types';
+import type { ApiVersionConfig, ApiVersioningConfig } from './types';
 
 /**
  * Extract version from the Accept-Version (or custom) header.
@@ -59,7 +59,7 @@ function extractFromUrl(ctx: Context, pattern: string): string | undefined {
  * }));
  * ```
  */
-export function apiVersion(config: VersioningMiddlewareConfig): MiddlewareHandler {
+export function apiVersion(config: ApiVersioningConfig): MiddlewareHandler {
   const {
     versions,
     strategy = 'header',
@@ -143,16 +143,18 @@ export function getApiVersionConfig(ctx: Context): ApiVersionConfig | undefined 
 
 /**
  * Middleware that transforms response JSON using the active version's responseTransformer.
- * Apply AFTER your route handlers.
+ * Register it BEFORE your route handlers (and after apiVersion()) — like all Hono
+ * middleware it wraps the handler via `await next()` and rewrites the response on the
+ * way out. Middleware registered after a response-producing handler never runs.
  *
  * @example
  * ```ts
  * app.use('*', apiVersion({ ... }));
+ * app.use('*', apiVersionedResponse());
  * app.get('/users/:id', handler);
- * app.use('*', versionedResponse());
  * ```
  */
-export function versionedResponse(): MiddlewareHandler {
+export function apiVersionedResponse(): MiddlewareHandler {
   return async (ctx, next) => {
     await next();
 

--- a/packages/core/src/api-version/types.ts
+++ b/packages/core/src/api-version/types.ts
@@ -3,16 +3,17 @@ import type { Context, Env, MiddlewareHandler } from 'hono';
 /**
  * Strategy for extracting the API version from requests.
  */
-export type VersionStrategy = 'url' | 'header' | 'query';
+export type ApiVersionStrategy = 'url' | 'header' | 'query';
 
 /**
  * A version transformer function that converts request/response data
  * between API versions.
  */
-export type VersionTransformer = (data: Record<string, unknown>) => Record<string, unknown>;
+export type ApiVersionTransformer = (data: Record<string, unknown>) => Record<string, unknown>;
 
 /**
- * Configuration for a single API version.
+ * One version entry consumed by apiVersion() via {@link ApiVersioningConfig}.versions
+ * — not the record-history config in core/types.
  */
 export interface ApiVersionConfig {
   /** Version identifier (e.g. '1', '2', '2024-01-15') */
@@ -20,9 +21,9 @@ export interface ApiVersionConfig {
   /** Optional middleware to apply for this version */
   middleware?: MiddlewareHandler[];
   /** Transform incoming request body from this version to latest */
-  requestTransformer?: VersionTransformer;
+  requestTransformer?: ApiVersionTransformer;
   /** Transform outgoing response data from latest to this version */
-  responseTransformer?: VersionTransformer;
+  responseTransformer?: ApiVersionTransformer;
   /** ISO date string when this version was deprecated */
   deprecated?: string;
   /** ISO date string when this version will be removed */
@@ -30,15 +31,18 @@ export interface ApiVersionConfig {
 }
 
 /**
- * Configuration for the API versioning middleware.
+ * Top-level bag for the apiVersion() middleware.
+ * NOT to be confused with {@link ApiVersionConfig}, which describes ONE version entry
+ * inside `versions`. (Unrelated to the record-history feature's config in core/types,
+ * which governs stored record versions, not HTTP API negotiation.)
  */
-export interface VersioningMiddlewareConfig {
+export interface ApiVersioningConfig {
   /** Available API versions. First is treated as default if no defaultVersion specified. */
   versions: ApiVersionConfig[];
   /** Default version when none is specified by client */
   defaultVersion?: string;
   /** Version extraction strategy. @default 'header' */
-  strategy?: VersionStrategy;
+  strategy?: ApiVersionStrategy;
   /** Header name for header strategy. @default 'Accept-Version' */
   headerName?: string;
   /** Query parameter name for query strategy. @default 'version' */

--- a/packages/core/src/auth/hash.ts
+++ b/packages/core/src/auth/hash.ts
@@ -1,0 +1,26 @@
+// ============================================================================
+// API Key Hashing
+// ============================================================================
+
+/**
+ * Hashes an API key using SHA-256.
+ * Never store raw API keys - always store the hash.
+ *
+ * @param key - The raw API key
+ * @returns The SHA-256 hash as a hex string
+ *
+ * @example
+ * ```ts
+ * const hash = await hashAPIKey('sk_abc123...');
+ * // Store `hash` in your database
+ * ```
+ */
+export async function hashAPIKey(key: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(key);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = new Uint8Array(hashBuffer);
+  return Array.from(hashArray)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -113,10 +113,10 @@ export type { AuthEndpointMethods } from './endpoint';
 // Storage Exports
 // ============================================================================
 
+export { hashAPIKey } from './hash';
 export {
   MemoryAPIKeyStorage,
   generateAPIKey,
-  hashAPIKey,
   isValidAPIKeyFormat,
   getAPIKeyStorage,
   setAPIKeyStorage,

--- a/packages/core/src/auth/middleware/api-key.ts
+++ b/packages/core/src/auth/middleware/api-key.ts
@@ -2,6 +2,7 @@ import type { Context, MiddlewareHandler } from 'hono';
 import { CONTEXT_KEYS } from '../../core/context-keys';
 import { ConfigurationException, UnauthorizedException } from '../../core/exceptions';
 import { resolveAPIKeyStorage } from '../../storage/helpers';
+import { hashAPIKey } from '../hash';
 import type { APIKeyConfig, APIKeyEntry, APIKeyLookupResult, AuthEnv, AuthUser } from '../types';
 import { validateAPIKeyEntry } from '../validators/api-key';
 
@@ -10,17 +11,10 @@ import { validateAPIKeyEntry } from '../validators/api-key';
 // ============================================================================
 
 /**
- * Default function to hash an API key using SHA-256.
+ * Alias of {@link hashAPIKey}; the default `hashKey` used by
+ * createAPIKeyMiddleware/validateAPIKey.
  */
-export async function defaultHashAPIKey(key: string): Promise<string> {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(key);
-  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
-  const hashArray = new Uint8Array(hashBuffer);
-  return Array.from(hashArray)
-    .map((b) => b.toString(16).padStart(2, '0'))
-    .join('');
-}
+export const defaultHashAPIKey = hashAPIKey;
 
 /**
  * Default function to extract user info from API key entry.

--- a/packages/core/src/auth/storage/memory.ts
+++ b/packages/core/src/auth/storage/memory.ts
@@ -1,5 +1,6 @@
 import { CONTEXT_KEYS } from '../../core/context-keys';
 import { createStorageFeature } from '../../storage/feature';
+import { hashAPIKey } from '../hash';
 import type { APIKeyEntry, APIKeyLookupResult, APIKeyStorage } from '../types';
 
 // ============================================================================
@@ -190,29 +191,6 @@ export function generateAPIKey(prefix = 'sk', length = 32): string {
   }
 
   return `${prefix}_${result}`;
-}
-
-/**
- * Hashes an API key using SHA-256.
- * Never store raw API keys - always store the hash.
- *
- * @param key - The raw API key
- * @returns The SHA-256 hash as a hex string
- *
- * @example
- * ```ts
- * const hash = await hashAPIKey('sk_abc123...');
- * // Store `hash` in your database
- * ```
- */
-export async function hashAPIKey(key: string): Promise<string> {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(key);
-  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
-  const hashArray = new Uint8Array(hashBuffer);
-  return Array.from(hashArray)
-    .map((b) => b.toString(16).padStart(2, '0'))
-    .join('');
 }
 
 /**

--- a/packages/core/src/builder/index.ts
+++ b/packages/core/src/builder/index.ts
@@ -6,7 +6,7 @@
  * @example
  * ```ts
  * import { crud } from 'hono-crud';
- * import { MemoryListEndpoint, MemoryCreateEndpoint } from 'hono-crud/adapters/memory';
+ * import { MemoryListEndpoint, MemoryCreateEndpoint } from '@hono-crud/memory';
  *
  * const UserList = crud(userMeta).list()
  *   .tags('Users')

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -5,7 +5,8 @@
  *
  * @example
  * ```ts
- * import { defineEndpoints, MemoryAdapters } from 'hono-crud';
+ * import { defineEndpoints } from 'hono-crud';
+ * import { MemoryAdapters } from '@hono-crud/memory';
  *
  * const userEndpoints = defineEndpoints({
  *   meta: userMeta,
@@ -135,8 +136,6 @@ interface SortingConfig {
   default?: string;
   /** Default sort direction */
   defaultOrder?: SortDirection;
-  /** Backward-compatible alias for defaultOrder */
-  defaultDirection?: SortDirection;
 }
 
 /**
@@ -750,7 +749,7 @@ export function defineEndpoints<M extends MetaInput, E extends Env = Env>(
       defaultSort: cfg.sorting?.default
         ? {
             field: cfg.sorting.default,
-            order: cfg.sorting.defaultOrder ?? cfg.sorting.defaultDirection ?? 'asc',
+            order: cfg.sorting.defaultOrder ?? 'asc',
           }
         : undefined,
       defaultPerPage: cfg.pagination?.defaultPerPage,

--- a/packages/core/src/core/openapi.ts
+++ b/packages/core/src/core/openapi.ts
@@ -18,9 +18,6 @@ export interface OpenAPIConfig {
 }
 
 export interface RouterOptions {
-  base?: string;
-  docs_url?: string;
-  redoc_url?: string;
   openapi_url?: string;
 }
 
@@ -146,8 +143,6 @@ export class HonoOpenAPIHandler<E extends Env = Env> {
   constructor(app: OpenAPIHono<E>, options: RouterOptions = {}) {
     this.app = app;
     this.options = {
-      docs_url: '/docs',
-      redoc_url: '/redoc',
       openapi_url: '/openapi.json',
       ...options,
     };

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -511,7 +511,9 @@ export interface VersionHistoryEntry<T = Record<string, unknown>> {
 }
 
 /**
- * Versioning configuration for a model.
+ * Versioning configuration for a model (stored record-history versions).
+ * HTTP API version negotiation is configured separately via `ApiVersioningConfig`
+ * (api-version).
  */
 export interface VersioningConfig {
   /** Enable versioning for this model */
@@ -681,6 +683,13 @@ export type ComputedFieldsConfig<T = Record<string, unknown>> = Record<
 // ============================================================================
 
 /**
+ * Every recognized tenant-ID source across both pipeline stages.
+ * Single source of truth: the middleware and the model layer each derive their
+ * legal subset via Exclude<> below, so the two sides cannot drift.
+ */
+export type TenantIdSource = 'header' | 'context' | 'path' | 'query' | 'jwt' | 'custom';
+
+/**
  * Configuration for multi-tenant behavior.
  * When enabled, all queries are automatically filtered by tenant ID,
  * and tenant ID is automatically injected on create operations.
@@ -693,14 +702,18 @@ export interface MultiTenantConfig {
   field?: string;
 
   /**
-   * How to retrieve the tenant ID from the request context.
+   * Where the DATA LAYER reads the tenant ID.
    * - 'header': From request header (specify headerName)
    * - 'context': From Hono context variable (c.get('tenantId'))
    * - 'path': From URL path parameter
    * - 'custom': Use a custom function
+   *
+   * 'query'/'jwt' are excluded: raw-HTTP extraction belongs to the multiTenant()
+   * middleware, which validates and publishes to context — set source 'context'
+   * (the default) to consume it.
    * @default 'context'
    */
-  source?: 'header' | 'context' | 'path' | 'custom';
+  source?: Exclude<TenantIdSource, 'query' | 'jwt'>;
 
   /**
    * Header name when source is 'header'.
@@ -709,7 +722,8 @@ export interface MultiTenantConfig {
   headerName?: string;
 
   /**
-   * Context variable name when source is 'context'.
+   * Context variable the data layer READS when source is 'context'
+   * (the middleware's contextKey is where it WRITES).
    * @default 'tenantId'
    */
   contextKey?: string;
@@ -1221,7 +1235,7 @@ export interface NormalizedSoftDeleteConfig {
 export interface NormalizedMultiTenantConfig {
   enabled: boolean;
   field: string;
-  source: 'header' | 'context' | 'path' | 'custom';
+  source: Exclude<TenantIdSource, 'query' | 'jwt'>;
   headerName: string;
   contextKey: string;
   pathParam: string;

--- a/packages/core/src/functional/index.ts
+++ b/packages/core/src/functional/index.ts
@@ -6,7 +6,7 @@
  * @example
  * ```ts
  * import { createCreate, createList } from 'hono-crud';
- * import { MemoryCreateEndpoint, MemoryListEndpoint } from 'hono-crud/adapters/memory';
+ * import { MemoryCreateEndpoint, MemoryListEndpoint } from '@hono-crud/memory';
  *
  * const UserCreate = createCreate({
  *   meta: userMeta,
@@ -29,7 +29,6 @@ import type {
   HookMode,
   MetaInput,
   OpenAPIRouteSchema,
-  SortDirection,
   SortSpec,
 } from '../core/types';
 import type { ModelObject } from '../endpoints/types';
@@ -71,10 +70,7 @@ export interface ListConfig<M extends MetaInput, E extends Env = Env> {
   searchFields?: string[];
   searchFieldName?: string;
   sortFields?: string[];
-  orderByFields?: string[];
   defaultSort?: SortSpec;
-  defaultOrderBy?: string;
-  defaultOrderDirection?: SortDirection;
   defaultPerPage?: number;
   maxPerPage?: number;
   allowedIncludes?: string[];
@@ -185,12 +181,6 @@ export function createList<
   E extends Env = Env,
   B extends abstract new () => unknown = abstract new () => unknown,
 >(config: ListConfig<M, E>, BaseClass: B): GeneratedClass<B> {
-  const defaultSort =
-    config.defaultSort ??
-    (config.defaultOrderBy
-      ? { field: config.defaultOrderBy, order: config.defaultOrderDirection ?? 'asc' }
-      : undefined);
-
   return generateEndpointClass(BaseClass, {
     meta: config.meta,
     schema: config.schema,
@@ -201,8 +191,8 @@ export function createList<
     filterConfig: config.filterConfig,
     searchFields: config.searchFields,
     searchFieldName: config.searchFieldName,
-    sortFields: config.sortFields ?? config.orderByFields,
-    defaultSort,
+    sortFields: config.sortFields,
+    defaultSort: config.defaultSort,
     defaultPerPage: config.defaultPerPage,
     maxPerPage: config.maxPerPage,
     allowedIncludes: config.allowedIncludes,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -96,7 +96,7 @@ export { getMultiTenantConfig, extractTenantId } from './multi-tenant/config';
 export { parseSearchMode } from './endpoints/search-utils';
 export { multiTenant } from './multi-tenant';
 export type {
-  MultiTenantMiddlewareOptions,
+  MultiTenantMiddlewareConfig,
   TenantEnv,
 } from './multi-tenant';
 export type {
@@ -113,6 +113,7 @@ export type {
   IdStrategy,
   SoftDeleteConfig,
   NormalizedSoftDeleteConfig,
+  TenantIdSource,
   MultiTenantConfig,
   NormalizedMultiTenantConfig,
   RelationType,
@@ -546,13 +547,13 @@ export {
   apiVersion,
   getApiVersion,
   getApiVersionConfig,
-  versionedResponse,
+  apiVersionedResponse,
 } from './api-version/index';
 export type {
-  VersionStrategy,
-  VersionTransformer,
+  ApiVersionStrategy,
+  ApiVersionTransformer,
   ApiVersionConfig,
-  VersioningMiddlewareConfig,
+  ApiVersioningConfig,
   ApiVersionEnv,
 } from './api-version/index';
 

--- a/packages/core/src/multi-tenant/index.ts
+++ b/packages/core/src/multi-tenant/index.ts
@@ -1,34 +1,28 @@
 import type { Context, Env, MiddlewareHandler } from 'hono';
 import { CONTEXT_KEYS } from '../core/context-keys';
 import { ApiException } from '../core/exceptions';
+import type { MultiTenantConfig, TenantIdSource } from '../core/types';
 import { setContextVar } from '../utils/context';
 
 /**
- * Options for the multi-tenant middleware.
+ * Config for the multi-tenant middleware.
  */
-export interface MultiTenantMiddlewareOptions {
+export interface MultiTenantMiddlewareConfig
+  extends Pick<MultiTenantConfig, 'headerName' | 'pathParam'> {
   /**
-   * How to extract the tenant ID from the request.
+   * Where the middleware extracts the tenant ID from the REQUEST.
    * - 'header': From request header
    * - 'path': From URL path parameter
    * - 'query': From query string parameter
    * - 'jwt': From JWT claims (requires JWT middleware to run first)
    * - 'custom': Use a custom extraction function
+   *
+   * 'context' is excluded: the middleware is the context WRITER — a 'context'
+   * source would read a key nothing wrote. Model-side consumption of the
+   * published value is MultiTenantConfig.source 'context'.
    * @default 'header'
    */
-  source?: 'header' | 'path' | 'query' | 'jwt' | 'custom';
-
-  /**
-   * Header name when source is 'header'.
-   * @default 'X-Tenant-ID'
-   */
-  headerName?: string;
-
-  /**
-   * Path parameter name when source is 'path'.
-   * @default 'tenantId'
-   */
-  pathParam?: string;
+  source?: Exclude<TenantIdSource, 'context'>;
 
   /**
    * Query parameter name when source is 'query'.
@@ -49,7 +43,8 @@ export interface MultiTenantMiddlewareOptions {
   extractor?: <E extends Env>(ctx: Context<E>) => string | undefined | Promise<string | undefined>;
 
   /**
-   * The key to store the tenant ID in context.
+   * Context variable to WRITE the tenant ID to (the model side reads it back
+   * via MultiTenantConfig.contextKey).
    * Access via ctx.get('tenantId') or your custom key.
    * @default 'tenantId'
    */
@@ -127,7 +122,7 @@ export interface MultiTenantMiddlewareOptions {
  * ```
  */
 export function multiTenant<E extends Env = Env>(
-  options: MultiTenantMiddlewareOptions = {},
+  options: MultiTenantMiddlewareConfig = {},
 ): MiddlewareHandler<E> {
   const {
     source = 'header',
@@ -159,7 +154,7 @@ export function multiTenant<E extends Env = Env>(
    * O(1) lookup instead of switch statement.
    */
   const extractors: Record<
-    'header' | 'path' | 'query' | 'jwt' | 'custom',
+    Exclude<TenantIdSource, 'context'>,
     (ctx: Context<E>) => string | undefined | Promise<string | undefined>
   > = {
     header: (ctx) => ctx.req.header(headerName),

--- a/packages/drizzle/README.md
+++ b/packages/drizzle/README.md
@@ -16,7 +16,7 @@ import {
   DrizzleCreateEndpoint,
   DrizzleReadEndpoint,
   DrizzleListEndpoint,
-  type DrizzleDatabase,
+  type DrizzleDatabaseConstraint,
 } from '@hono-crud/drizzle';
 
 const app = fromHono(new Hono());
@@ -27,4 +27,4 @@ registerCrud(app, '/users', {
 });
 ```
 
-Exports `DrizzleAdapters`, the `Drizzle*Endpoint` classes, `createDrizzleCrud`, `createDrizzleSchemas`, and the `DrizzleDatabase` type.
+Exports `DrizzleAdapters` (the 17-entry adapter bundle), the `Drizzle*Endpoint` classes, `createDrizzleCrud`, `createDrizzleSchemas`, and the `DrizzleDatabaseConstraint` type.

--- a/packages/drizzle/src/factory.ts
+++ b/packages/drizzle/src/factory.ts
@@ -1,6 +1,5 @@
 import type { Env } from 'hono';
 import type { MetaInput } from 'hono-crud/internal';
-import type { AdapterBundle } from 'hono-crud/internal';
 import {
   DrizzleBatchUpsertEndpoint,
   DrizzleSearchEndpoint,
@@ -77,7 +76,7 @@ export interface CreateDrizzleCrudOptions {
  *
  * @example
  * ```ts
- * import { createDrizzleCrud } from 'hono-crud/adapters/drizzle';
+ * import { createDrizzleCrud } from '@hono-crud/drizzle';
  *
  * const projectMeta = defineMeta({ model: ProjectModel, fields: projectSchemas.insert });
  * const Project = createDrizzleCrud(db, projectMeta, { dialect: 'pg' });
@@ -161,39 +160,3 @@ export function createDrizzleCrud<M extends MetaInput, E extends Env = Env>(
     },
   } as DrizzleCrudClasses<M, E>;
 }
-
-// ============================================================================
-// Drizzle Adapters Bundle (for Config-based API)
-// ============================================================================
-
-/**
- * Drizzle adapter bundle for use with defineEndpoints.
- *
- * Note: When using DrizzleAdapters with defineEndpoints, you need to provide
- * your own base classes that extend the Drizzle endpoint classes and include
- * the `db` property. The config-based API cannot inject the database instance.
- *
- * @example
- * ```ts
- * import { defineEndpoints } from 'hono-crud';
- * import { DrizzleAdapters } from 'hono-crud/adapters/drizzle';
- *
- * // Create custom adapters with db injected
- * const MyDrizzleAdapters = {
- *   CreateEndpoint: class extends DrizzleCreateEndpoint { db = myDb; },
- *   ListEndpoint: class extends DrizzleListEndpoint { db = myDb; },
- *   ReadEndpoint: class extends DrizzleReadEndpoint { db = myDb; },
- *   UpdateEndpoint: class extends DrizzleUpdateEndpoint { db = myDb; },
- *   DeleteEndpoint: class extends DrizzleDeleteEndpoint { db = myDb; },
- * };
- *
- * const userEndpoints = defineEndpoints({ meta: userMeta, ... }, MyDrizzleAdapters);
- * ```
- */
-export const DrizzleAdapters: AdapterBundle = {
-  CreateEndpoint: DrizzleCreateEndpoint,
-  ListEndpoint: DrizzleListEndpoint,
-  ReadEndpoint: DrizzleReadEndpoint,
-  UpdateEndpoint: DrizzleUpdateEndpoint,
-  DeleteEndpoint: DrizzleDeleteEndpoint,
-};

--- a/packages/drizzle/src/helpers.ts
+++ b/packages/drizzle/src/helpers.ts
@@ -185,7 +185,7 @@ export type DrizzleDialect = (typeof DRIZZLE_DIALECTS)[number];
  *
  * @example
  * ```ts
- * import { DrizzleEnv } from 'hono-crud/adapters/drizzle';
+ * import { DrizzleEnv } from '@hono-crud/drizzle';
  *
  * type AppEnv = DrizzleEnv<typeof db>;
  *

--- a/packages/drizzle/src/index.ts
+++ b/packages/drizzle/src/index.ts
@@ -61,7 +61,7 @@ import {
 /**
  * Drizzle adapter bundle for use with `defineEndpoints`.
  *
- * Populates the 11 verbs Drizzle implements natively plus a stub
+ * Populates the 16 verbs Drizzle implements natively plus a stub
  * `CloneEndpoint` (throws on request — subclass to implement).
  *
  * @example

--- a/packages/drizzle/src/schema-utils.ts
+++ b/packages/drizzle/src/schema-utils.ts
@@ -10,7 +10,7 @@
  * @example
  * ```ts
  * import { pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
- * import { createDrizzleSchemas } from 'hono-crud/adapters/drizzle';
+ * import { createDrizzleSchemas } from '@hono-crud/drizzle';
  *
  * const users = pgTable('users', {
  *   id: uuid('id').primaryKey().defaultRandom(),
@@ -86,7 +86,7 @@ async function ensureDrizzleZod(): Promise<typeof _drizzleZod> {
  * @example
  * ```ts
  * import { users } from './schema';
- * import { createSelectSchema } from 'hono-crud/adapters/drizzle';
+ * import { createSelectSchema } from '@hono-crud/drizzle';
  *
  * const UserSchema = await createSelectSchema(users);
  * type User = z.infer<typeof UserSchema>;
@@ -111,7 +111,7 @@ export async function createSelectSchema<T extends DrizzleTable>(
  * @example
  * ```ts
  * import { users } from './schema';
- * import { createInsertSchema } from 'hono-crud/adapters/drizzle';
+ * import { createInsertSchema } from '@hono-crud/drizzle';
  *
  * const CreateUserSchema = await createInsertSchema(users);
  * type CreateUser = z.infer<typeof CreateUserSchema>;
@@ -139,7 +139,7 @@ export async function createInsertSchema<T extends DrizzleTable>(
  * @example
  * ```ts
  * import { users } from './schema';
- * import { createUpdateSchema } from 'hono-crud/adapters/drizzle';
+ * import { createUpdateSchema } from '@hono-crud/drizzle';
  *
  * const UpdateUserSchema = await createUpdateSchema(users);
  * type UpdateUser = z.infer<typeof UpdateUserSchema>;
@@ -194,7 +194,7 @@ export interface DrizzleSchemas {
  * @example
  * ```ts
  * import { pgTable, text, uuid } from 'drizzle-orm/pg-core';
- * import { createDrizzleSchemas, defineModel, defineMeta } from 'hono-crud/adapters/drizzle';
+ * import { createDrizzleSchemas, defineModel, defineMeta } from '@hono-crud/drizzle';
  * import { z } from 'zod';
  *
  * const users = pgTable('users', {

--- a/packages/health/README.md
+++ b/packages/health/README.md
@@ -1,6 +1,6 @@
 # @hono-crud/health
 
-Health check endpoints for [hono-crud](https://github.com/kshdotdev/hono-crud).
+Health check routes for [hono-crud](https://github.com/kshdotdev/hono-crud).
 
 ## Install
 
@@ -11,11 +11,11 @@ npm install @hono-crud/health hono-crud hono
 ## Usage
 
 ```ts
-import { createHealthEndpoints } from '@hono-crud/health';
+import { createHealthRoutes } from '@hono-crud/health';
 
-createHealthEndpoints(app, {
+app.route('/', createHealthRoutes({
   path: '/health',
-});
+}));
 ```
 
-Exports `createHealthEndpoints` for registering liveness / readiness routes.
+Exports `createHealthRoutes`, a router factory returning a mountable `Hono` that owns the liveness (`path`, default `/health`) and readiness (`readyPath`, default `/ready`) routes.

--- a/packages/health/src/endpoint.ts
+++ b/packages/health/src/endpoint.ts
@@ -60,16 +60,19 @@ async function runAllChecks(
 }
 
 /**
- * Create health check endpoints and register them on a Hono app.
+ * Create a mountable Hono sub-app that owns the health routes:
+ * liveness (`path`, default `/health`, always 200) and readiness
+ * (`readyPath`, default `/ready`, 200 or 503 based on the configured checks).
+ * Paths are relative to wherever the sub-app is mounted.
  *
  * @example
  * ```ts
  * import { Hono } from 'hono';
- * import { createHealthEndpoints } from 'hono-crud';
+ * import { createHealthRoutes } from '@hono-crud/health';
  *
  * const app = new Hono();
  *
- * createHealthEndpoints(app, {
+ * app.route('/', createHealthRoutes({
  *   version: '1.0.0',
  *   checks: [
  *     {
@@ -82,13 +85,10 @@ async function runAllChecks(
  *       critical: false, // degraded, not unhealthy
  *     },
  *   ],
- * });
+ * }));
  * ```
  */
-export function createHealthEndpoints<E extends Env = Env>(
-  app: Hono<E>,
-  config: HealthConfig = {},
-): void {
+export function createHealthRoutes<E extends Env = Env>(config: HealthConfig = {}): Hono<E> {
   const {
     checks = [],
     version,
@@ -97,6 +97,8 @@ export function createHealthEndpoints<E extends Env = Env>(
     defaultTimeout = 5000,
     verbose = true,
   } = config;
+
+  const app = new Hono<E>();
 
   // Liveness — always 200 if process is running
   app.get(path, (c) => {
@@ -129,14 +131,6 @@ export function createHealthEndpoints<E extends Env = Env>(
     const statusCode = status === 'unhealthy' ? 503 : 200;
     return c.json(response, statusCode);
   });
-}
 
-/**
- * Create a standalone health check handler (no app registration).
- * Useful for composing into existing routers.
- */
-export function createHealthHandler(config: HealthConfig = {}) {
-  const app = new Hono();
-  createHealthEndpoints(app, config);
   return app;
 }

--- a/packages/health/src/index.ts
+++ b/packages/health/src/index.ts
@@ -1,4 +1,4 @@
-export { createHealthEndpoints, createHealthHandler } from './endpoint';
+export { createHealthRoutes } from './endpoint';
 export type {
   HealthCheck,
   HealthCheckFn,

--- a/packages/idempotency/README.md
+++ b/packages/idempotency/README.md
@@ -12,7 +12,7 @@ npm install @hono-crud/idempotency hono-crud hono
 
 ```ts
 import {
-  idempotency,
+  createIdempotencyMiddleware,
   setIdempotencyStorage,
   MemoryIdempotencyStorage,
 } from '@hono-crud/idempotency';
@@ -20,7 +20,7 @@ import {
 setIdempotencyStorage(new MemoryIdempotencyStorage());
 
 // Replays the original response for repeated requests carrying the same Idempotency-Key.
-app.use('/api/*', idempotency());
+app.use('/api/*', createIdempotencyMiddleware());
 ```
 
-Exports `idempotency`, `setIdempotencyStorage`, and `MemoryIdempotencyStorage`.
+Exports `createIdempotencyMiddleware`, `setIdempotencyStorage`, and `MemoryIdempotencyStorage`.

--- a/packages/idempotency/src/index.ts
+++ b/packages/idempotency/src/index.ts
@@ -1,5 +1,5 @@
 export {
-  idempotency,
+  createIdempotencyMiddleware,
   setIdempotencyStorage,
   getIdempotencyStorage,
   getIdempotencyStorageRequired,

--- a/packages/idempotency/src/middleware.ts
+++ b/packages/idempotency/src/middleware.ts
@@ -34,7 +34,7 @@ export const idempotencyStorageRegistry = idempotencyStorageFeature.registry;
  *
  * @example
  * ```ts
- * import { setIdempotencyStorage, MemoryIdempotencyStorage } from 'hono-crud';
+ * import { setIdempotencyStorage, MemoryIdempotencyStorage } from '@hono-crud/idempotency';
  *
  * setIdempotencyStorage(new MemoryIdempotencyStorage());
  * ```
@@ -72,7 +72,7 @@ export function resolveIdempotencyStorage<E extends Env>(
 // ============================================================================
 
 /**
- * Idempotency middleware for safe request retries.
+ * Creates idempotency middleware for safe request retries.
  *
  * When a client sends an `Idempotency-Key` header on a mutating request,
  * the server stores the response and replays it for duplicate keys.
@@ -80,26 +80,33 @@ export function resolveIdempotencyStorage<E extends Env>(
  * @example
  * ```ts
  * import { Hono } from 'hono';
- * import { idempotency } from 'hono-crud';
+ * import {
+ *   createIdempotencyMiddleware,
+ *   MemoryIdempotencyStorage,
+ * } from '@hono-crud/idempotency';
  *
  * const app = new Hono();
- * app.use('/api/*', idempotency({ storage: new MemoryIdempotencyStorage() }));
+ * app.use('/api/*', createIdempotencyMiddleware({
+ *   storage: new MemoryIdempotencyStorage(),
+ * }));
  *
  * // Or with configuration:
- * app.use('/api/*', idempotency({
+ * app.use('/api/*', createIdempotencyMiddleware({
  *   ttl: 3600,              // 1 hour
  *   enforcedMethods: ['POST', 'PUT'],
  *   required: true,         // Require the header
  * }));
  * ```
  */
-export function idempotency(config?: IdempotencyConfig): MiddlewareHandler {
-  const headerName = config?.headerName ?? 'Idempotency-Key';
-  const ttlSeconds = config?.ttl ?? 86400;
+export function createIdempotencyMiddleware<E extends Env = Env>(
+  config: IdempotencyConfig = {},
+): MiddlewareHandler<E> {
+  const headerName = config.headerName ?? 'Idempotency-Key';
+  const ttlSeconds = config.ttl ?? 86400;
   const ttlMs = ttlSeconds * 1000;
-  const enforcedMethods = (config?.enforcedMethods ?? ['POST']).map((m) => m.toUpperCase());
-  const required = config?.required ?? false;
-  const lockTimeoutMs = (config?.lockTimeout ?? 60) * 1000;
+  const enforcedMethods = (config.enforcedMethods ?? ['POST']).map((m) => m.toUpperCase());
+  const required = config.required ?? false;
+  const lockTimeoutMs = (config.lockTimeout ?? 60) * 1000;
 
   return async (ctx, next) => {
     const method = ctx.req.method.toUpperCase();
@@ -126,7 +133,7 @@ export function idempotency(config?: IdempotencyConfig): MiddlewareHandler {
     }
 
     // Resolve storage (explicit config.storage > context > global, single tier)
-    const storage = resolveIdempotencyStorage(ctx, config?.storage);
+    const storage = resolveIdempotencyStorage(ctx, config.storage);
     if (!storage) {
       // No storage configured, pass through
       return next();

--- a/packages/idempotency/src/storage/memory.ts
+++ b/packages/idempotency/src/storage/memory.ts
@@ -9,7 +9,7 @@ import type { IdempotencyEntry, IdempotencyStorage } from '../types';
  *
  * @example
  * ```ts
- * import { MemoryIdempotencyStorage, setIdempotencyStorage } from 'hono-crud';
+ * import { MemoryIdempotencyStorage, setIdempotencyStorage } from '@hono-crud/idempotency';
  *
  * setIdempotencyStorage(new MemoryIdempotencyStorage());
  * ```

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -2,7 +2,7 @@ export { CrudMcpServer, createCrudMcp } from './server';
 export type {
   AutoOptions,
   Awaitable,
-  CrudMcpOptions,
+  CrudMcpConfig,
   Identity,
   McpAuthOptions,
   MiddlewareAuthOptions,

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -8,7 +8,7 @@ import {
 } from 'hono-crud/internal';
 import { type ResolvedAuth, resolveAuth } from './auth';
 import { registerResourceTools } from './tools';
-import type { AutoOptions, CrudMcpOptions, ResourceEndpoints, ResourceOptions } from './types';
+import type { AutoOptions, CrudMcpConfig, ResourceEndpoints, ResourceOptions } from './types';
 
 function normalizePath(path: string): string {
   return path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path;
@@ -31,7 +31,7 @@ export class CrudMcpServer {
   constructor(
     // biome-ignore lint/suspicious/noExplicitAny: re-dispatch targets any Hono app.
     private readonly app: Hono<any, any, any>,
-    private readonly options: CrudMcpOptions,
+    private readonly options: CrudMcpConfig,
   ) {
     this.server = new McpServer(
       { name: options.name, version: options.version },
@@ -112,7 +112,7 @@ export class CrudMcpServer {
 export function createCrudMcp(
   // biome-ignore lint/suspicious/noExplicitAny: re-dispatch targets any Hono app.
   app: Hono<any, any, any>,
-  options: CrudMcpOptions,
+  options: CrudMcpConfig,
 ): CrudMcpServer {
   return new CrudMcpServer(app, options);
 }

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -11,7 +11,7 @@ import {
 } from './dispatch';
 import { buildInputShape, extractRequestPlan } from './schema';
 import {
-  type CrudMcpOptions,
+  type CrudMcpConfig,
   type EndpointInstance,
   OPERATIONS,
   type ResourceEndpoints,
@@ -68,7 +68,7 @@ export function registerResourceTools(
   app: Hono<any, any, any>,
   basePath: string,
   endpoints: ResourceEndpoints,
-  options: CrudMcpOptions,
+  options: CrudMcpConfig,
   resourceOptions: ResourceOptions = {},
 ): string[] {
   const normalizedPath = basePath.endsWith('/') ? basePath.slice(0, -1) : basePath;

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -53,7 +53,7 @@ export interface ResourceOptions {
   tools?: Partial<Record<OperationName, ToolOptions>>;
 }
 
-/** Context handed to a custom {@link CrudMcpOptions.naming} strategy. */
+/** Context handed to a custom {@link CrudMcpConfig.naming} strategy. */
 export interface NamingContext {
   resource: string;
   operation: OperationName;
@@ -112,8 +112,8 @@ export interface OAuthAuthOptions {
 
 export type McpAuthOptions = VerifierAuthOptions | MiddlewareAuthOptions | OAuthAuthOptions;
 
-/** Options for {@link createCrudMcp}. */
-export interface CrudMcpOptions {
+/** Config for {@link createCrudMcp}. */
+export interface CrudMcpConfig {
   /** MCP server name advertised to clients. */
   name: string;
   /** MCP server version advertised to clients. */

--- a/packages/rate-limit/src/index.ts
+++ b/packages/rate-limit/src/index.ts
@@ -31,6 +31,7 @@ export {
 
 // Middleware
 export {
+  DEFAULT_RATE_LIMIT_KEY_PREFIX,
   createRateLimitMiddleware,
   setRateLimitStorage,
   getRateLimitStorage,

--- a/packages/rate-limit/src/middleware.ts
+++ b/packages/rate-limit/src/middleware.ts
@@ -34,7 +34,7 @@ export const rateLimitStorageRegistry = rateLimitStorageFeature.registry;
  *
  * @example
  * ```ts
- * import { setRateLimitStorage, MemoryRateLimitStorage } from 'hono-crud';
+ * import { setRateLimitStorage, MemoryRateLimitStorage } from '@hono-crud/rate-limit';
  *
  * setRateLimitStorage(new MemoryRateLimitStorage());
  * ```
@@ -218,6 +218,15 @@ async function checkSlidingWindow(
 // ============================================================================
 
 /**
+ * Default prefix the middleware prepends to every generated rate-limit key
+ * (joined with `':'` by `generateKey`), yielding keys shaped
+ * `rl:<path>:<clientKey>`. Storage adapters add no prefix of their own by
+ * default, so this is the single source of key namespacing. Override per
+ * middleware via {@link RateLimitConfig.keyPrefix}.
+ */
+export const DEFAULT_RATE_LIMIT_KEY_PREFIX = 'rl';
+
+/**
  * Creates rate limit middleware.
  *
  * @example
@@ -227,7 +236,7 @@ async function checkSlidingWindow(
  *   createRateLimitMiddleware,
  *   setRateLimitStorage,
  *   MemoryRateLimitStorage,
- * } from 'hono-crud';
+ * } from '@hono-crud/rate-limit';
  *
  * // Setup storage (do this once at startup)
  * setRateLimitStorage(new MemoryRateLimitStorage());
@@ -273,7 +282,7 @@ export function createRateLimitMiddleware<E extends Env = Env>(
   const windowSeconds = config.windowSeconds ?? 60;
   const algorithm = config.algorithm ?? 'sliding-window';
   const keyStrategy = config.keyStrategy ?? 'ip';
-  const keyPrefix = config.keyPrefix ?? 'rl';
+  const keyPrefix = config.keyPrefix ?? DEFAULT_RATE_LIMIT_KEY_PREFIX;
   const skipPaths = config.skipPaths ?? [];
   const includeHeaders = config.includeHeaders ?? true;
   const errorMessage = config.errorMessage ?? 'Too many requests';

--- a/packages/rate-limit/src/storage/cloudflare-kv.ts
+++ b/packages/rate-limit/src/storage/cloudflare-kv.ts
@@ -12,7 +12,11 @@ import type {
 export interface KVRateLimitStorageOptions {
   /** KV namespace binding. */
   kv: KVNamespace;
-  /** Key prefix for all rate limit entries. @default 'rl:' */
+  /**
+   * Extra namespace prefix prepended to every key. Default `''` — keys are
+   * already namespaced by the middleware's `keyPrefix` (default `'rl'`).
+   * @default ''
+   */
   prefix?: string;
   /**
    * Whether KV read/write failures should allow the request to continue.
@@ -45,7 +49,8 @@ export interface KVRateLimitStorageOptions {
  *
  * @example
  * ```ts
- * import { KVRateLimitStorage, createStorageMiddleware } from 'hono-crud';
+ * import { KVRateLimitStorage } from '@hono-crud/rate-limit';
+ * import { createStorageMiddleware } from 'hono-crud';
  *
  * app.use('*', async (c, next) => {
  *   const rateLimitStorage = new KVRateLimitStorage({ kv: c.env.RATE_LIMIT_KV });
@@ -61,7 +66,7 @@ export class KVRateLimitStorage implements RateLimitStorage {
 
   constructor(options: KVRateLimitStorageOptions) {
     this.kv = options.kv;
-    this.prefix = options.prefix ?? 'rl:';
+    this.prefix = options.prefix ?? '';
     this.failOpen = options.failOpen ?? true;
     this.onError = options.onError;
   }

--- a/packages/rate-limit/src/storage/memory.ts
+++ b/packages/rate-limit/src/storage/memory.ts
@@ -47,7 +47,7 @@ interface RateLimitWrapper {
  *
  * @example
  * ```ts
- * import { MemoryRateLimitStorage, setRateLimitStorage } from 'hono-crud';
+ * import { MemoryRateLimitStorage, setRateLimitStorage } from '@hono-crud/rate-limit';
  *
  * const storage = new MemoryRateLimitStorage();
  * setRateLimitStorage(storage);

--- a/packages/rate-limit/src/storage/redis.ts
+++ b/packages/rate-limit/src/storage/redis.ts
@@ -44,7 +44,11 @@ export interface RedisRateLimitClient {
 export interface RedisRateLimitStorageOptions {
   /** Redis client instance */
   client: RedisRateLimitClient;
-  /** Key prefix for all rate limit entries @default 'ratelimit:' */
+  /**
+   * Extra namespace prefix prepended to every key. Default `''` — keys are
+   * already namespaced by the middleware's `keyPrefix` (default `'rl'`).
+   * @default ''
+   */
   prefix?: string;
 }
 
@@ -99,7 +103,7 @@ return cjson.encode({timestamps = timestamps})
  * @example
  * ```ts
  * import { Redis } from '@upstash/redis';
- * import { RedisRateLimitStorage, setRateLimitStorage } from 'hono-crud';
+ * import { RedisRateLimitStorage, setRateLimitStorage } from '@hono-crud/rate-limit';
  *
  * const storage = new RedisRateLimitStorage({
  *   client: new Redis({
@@ -113,7 +117,7 @@ return cjson.encode({timestamps = timestamps})
  * @example
  * ```ts
  * import Redis from 'ioredis';
- * import { RedisRateLimitStorage, setRateLimitStorage } from 'hono-crud';
+ * import { RedisRateLimitStorage, setRateLimitStorage } from '@hono-crud/rate-limit';
  *
  * const storage = new RedisRateLimitStorage({
  *   client: new Redis(c.env.REDIS_URL),
@@ -128,7 +132,7 @@ export class RedisRateLimitStorage implements RateLimitStorage {
 
   constructor(options: RedisRateLimitStorageOptions) {
     this.client = options.client;
-    this.prefix = options.prefix ?? 'ratelimit:';
+    this.prefix = options.prefix ?? '';
   }
 
   /**

--- a/packages/rate-limit/src/types.ts
+++ b/packages/rate-limit/src/types.ts
@@ -142,8 +142,10 @@ export interface RateLimitConfig<E extends Env = Env> {
 
   /**
    * Prefix for storage keys.
-   * Useful for namespacing different rate limiters.
-   * @default 'rl'
+   * Useful for namespacing different rate limiters. This is the single source
+   * of key namespacing — storage adapters add no prefix of their own by
+   * default, so persisted keys are `<keyPrefix>:<path>:<clientKey>`.
+   * @default 'rl' (`DEFAULT_RATE_LIMIT_KEY_PREFIX`)
    */
   keyPrefix?: string;
 
@@ -210,7 +212,7 @@ export interface RateLimitConfig<E extends Env = Env> {
  *
  * @example
  * ```ts
- * import type { RateLimitEnv } from 'hono-crud';
+ * import type { RateLimitEnv } from '@hono-crud/rate-limit';
  *
  * type AppEnv = RateLimitEnv & {
  *   Variables: {

--- a/packages/scalar/README.md
+++ b/packages/scalar/README.md
@@ -11,13 +11,13 @@ npm install @hono-crud/scalar hono-crud hono
 ## Usage
 
 ```ts
-import { setupScalar } from '@hono-crud/scalar';
+import { scalarUI } from '@hono-crud/scalar';
 
 // app exposes its OpenAPI spec at /openapi.json
-setupScalar(app, '/scalar', {
+app.get('/reference', scalarUI({
   specUrl: '/openapi.json',
   pageTitle: 'My API',
-});
+}));
 ```
 
-Exports `setupScalar`, `scalarUI`, and the `ScalarConfig` / `ScalarTheme` types.
+Exports `scalarUI` and the `ScalarConfig` / `ScalarTheme` types.

--- a/packages/scalar/src/index.ts
+++ b/packages/scalar/src/index.ts
@@ -1,6 +1,6 @@
 import { apiReference } from '@scalar/hono-api-reference';
 import type { ApiReferenceConfiguration } from '@scalar/hono-api-reference';
-import type { Env, Hono, MiddlewareHandler } from 'hono';
+import type { MiddlewareHandler } from 'hono';
 
 /**
  * Available Scalar themes.
@@ -77,7 +77,7 @@ export interface ScalarConfig {
  * @example
  * ```ts
  * import { Hono } from 'hono';
- * import { scalarUI } from 'hono-crud';
+ * import { scalarUI } from '@hono-crud/scalar';
  *
  * const app = new Hono();
  *
@@ -143,32 +143,4 @@ export function scalarUI(config: ScalarConfig = {}): MiddlewareHandler {
   }
 
   return apiReference(scalarConfig);
-}
-
-/**
- * Sets up Scalar API Reference endpoint on a Hono app.
- *
- * @param app - Hono app instance
- * @param path - Path to serve the API reference (default: '/reference')
- * @param config - Scalar configuration options
- *
- * @example
- * ```ts
- * import { Hono } from 'hono';
- * import { setupScalar } from 'hono-crud';
- *
- * const app = new Hono();
- *
- * setupScalar(app, '/reference', {
- *   specUrl: '/openapi.json',
- *   theme: 'moon',
- * });
- * ```
- */
-export function setupScalar<E extends Env>(
-  app: Hono<E>,
-  path = '/reference',
-  config: ScalarConfig = {},
-): void {
-  app.get(path, scalarUI(config));
 }

--- a/packages/swagger/README.md
+++ b/packages/swagger/README.md
@@ -1,6 +1,6 @@
 # @hono-crud/swagger
 
-Swagger UI and ReDoc documentation endpoints for [hono-crud](https://github.com/kshdotdev/hono-crud).
+Swagger UI and ReDoc documentation pages for [hono-crud](https://github.com/kshdotdev/hono-crud).
 
 ## Install
 
@@ -11,11 +11,16 @@ npm install @hono-crud/swagger hono-crud hono
 ## Usage
 
 ```ts
-import { setupSwaggerUI, setupReDoc } from '@hono-crud/swagger';
+import { swaggerUI, redocUI, docsIndex } from '@hono-crud/swagger';
 
 // app exposes its OpenAPI spec at /openapi.json
-setupSwaggerUI(app, { docsPath: '/docs', specPath: '/openapi.json' });
-setupReDoc(app, { docsPath: '/redoc', specPath: '/openapi.json' });
+app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
+app.get('/redoc', redocUI({ specUrl: '/openapi.json', pageTitle: 'My API' }));
+
+// Optional landing page linking to all docs UIs
+app.get('/', docsIndex({ docsPath: '/docs', redocPath: '/redoc', scalarPath: '/reference' }));
 ```
 
-Exports `setupSwaggerUI`, `setupReDoc`, `setupDocsIndex`, and the `UIOptions` type. For the Scalar API reference UI, use `@hono-crud/scalar`.
+Each factory returns a `MiddlewareHandler` you mount with `app.get(path, ...)`.
+
+Exports `swaggerUI`, `redocUI`, `docsIndex`, and the `SwaggerUIConfig` / `RedocUIConfig` / `DocsIndexConfig` types. All configs accept `specUrl` (default `/openapi.json`); `redocUI` and `docsIndex` also accept `pageTitle`. For the Scalar API reference UI, use `@hono-crud/scalar`.

--- a/packages/swagger/src/index.ts
+++ b/packages/swagger/src/index.ts
@@ -1,49 +1,70 @@
-import { swaggerUI } from '@hono/swagger-ui';
-import type { Env, Hono } from 'hono';
+import { swaggerUI as honoSwaggerUI } from '@hono/swagger-ui';
+import type { MiddlewareHandler } from 'hono';
 
-export interface UIOptions {
+/**
+ * Config for the Swagger UI page middleware.
+ */
+export interface SwaggerUIConfig {
   /**
-   * Path to serve Swagger UI (default: '/docs')
+   * URL to the OpenAPI spec file.
+   * @default '/openapi.json'
    */
-  docsPath?: string;
-  /**
-   * Path to serve ReDoc (default: '/redoc')
-   */
-  redocPath?: string;
-  /**
-   * Path to serve Scalar (default: '/reference')
-   */
-  scalarPath?: string;
-  /**
-   * Path to the OpenAPI JSON spec (default: '/openapi.json')
-   */
-  specPath?: string;
-  /**
-   * Page title for the documentation
-   */
-  title?: string;
+  specUrl?: string;
 }
 
 /**
- * Sets up Swagger UI endpoint.
+ * Creates a Swagger UI documentation-page middleware.
+ *
+ * @example
+ * ```ts
+ * import { Hono } from 'hono';
+ * import { swaggerUI } from '@hono-crud/swagger';
+ *
+ * const app = new Hono();
+ *
+ * app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
+ * ```
  */
-export function setupSwaggerUI<E extends Env>(app: Hono<E>, options: UIOptions = {}): void {
-  const { docsPath = '/docs', specPath = '/openapi.json' } = options;
-
-  app.get(docsPath, swaggerUI({ url: specPath }));
+export function swaggerUI(config: SwaggerUIConfig = {}): MiddlewareHandler {
+  return honoSwaggerUI({ url: config.specUrl ?? '/openapi.json' });
 }
 
 /**
- * Sets up ReDoc endpoint using CDN.
+ * Config for the ReDoc page middleware.
  */
-export function setupReDoc<E extends Env>(app: Hono<E>, options: UIOptions = {}): void {
-  const { redocPath = '/redoc', specPath = '/openapi.json', title = 'API Documentation' } = options;
+export interface RedocUIConfig {
+  /**
+   * URL to the OpenAPI spec file.
+   * @default '/openapi.json'
+   */
+  specUrl?: string;
+  /**
+   * Page title for the documentation.
+   * @default 'API Documentation'
+   */
+  pageTitle?: string;
+}
 
-  app.get(redocPath, (c) => {
-    const html = `<!DOCTYPE html>
+/**
+ * Creates a ReDoc documentation-page middleware (rendered via CDN bundle).
+ *
+ * @example
+ * ```ts
+ * import { Hono } from 'hono';
+ * import { redocUI } from '@hono-crud/swagger';
+ *
+ * const app = new Hono();
+ *
+ * app.get('/redoc', redocUI({ specUrl: '/openapi.json', pageTitle: 'My API' }));
+ * ```
+ */
+export function redocUI(config: RedocUIConfig = {}): MiddlewareHandler {
+  const { specUrl = '/openapi.json', pageTitle = 'API Documentation' } = config;
+
+  const html = `<!DOCTYPE html>
 <html>
   <head>
-    <title>${title}</title>
+    <title>${pageTitle}</title>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
@@ -52,35 +73,74 @@ export function setupReDoc<E extends Env>(app: Hono<E>, options: UIOptions = {})
     </style>
   </head>
   <body>
-    <redoc spec-url='${specPath}'></redoc>
+    <redoc spec-url='${specUrl}'></redoc>
     <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
   </body>
 </html>`;
-    return c.html(html);
-  });
+
+  return async (c) => c.html(html);
 }
 
 /**
- * Returns a simple HTML page listing available documentation endpoints.
+ * Config for the documentation landing page. Path fields are LINK HREFS rendered
+ * into the page — not route registrations (the page itself is mounted wherever
+ * the `app.get` call site puts it).
  */
-export function setupDocsIndex<E extends Env>(
-  app: Hono<E>,
-  options: UIOptions & { indexPath?: string } = {},
-): void {
+export interface DocsIndexConfig {
+  /**
+   * Href of the Swagger UI page link.
+   * @default '/docs'
+   */
+  docsPath?: string;
+  /**
+   * Href of the ReDoc page link.
+   * @default '/redoc'
+   */
+  redocPath?: string;
+  /**
+   * Href of the Scalar page link.
+   * @default '/reference'
+   */
+  scalarPath?: string;
+  /**
+   * URL to the OpenAPI spec file.
+   * @default '/openapi.json'
+   */
+  specUrl?: string;
+  /**
+   * Page title for the landing page.
+   * @default 'API Documentation'
+   */
+  pageTitle?: string;
+}
+
+/**
+ * Creates a middleware serving a simple HTML landing page that links to the
+ * available documentation endpoints.
+ *
+ * @example
+ * ```ts
+ * import { Hono } from 'hono';
+ * import { docsIndex } from '@hono-crud/swagger';
+ *
+ * const app = new Hono();
+ *
+ * app.get('/', docsIndex({ pageTitle: 'My API' }));
+ * ```
+ */
+export function docsIndex(config: DocsIndexConfig = {}): MiddlewareHandler {
   const {
-    indexPath = '/',
     docsPath = '/docs',
     redocPath = '/redoc',
     scalarPath = '/reference',
-    specPath = '/openapi.json',
-    title = 'API Documentation',
-  } = options;
+    specUrl = '/openapi.json',
+    pageTitle = 'API Documentation',
+  } = config;
 
-  app.get(indexPath, (c) => {
-    const html = `<!DOCTYPE html>
+  const html = `<!DOCTYPE html>
 <html>
   <head>
-    <title>${title}</title>
+    <title>${pageTitle}</title>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
@@ -119,7 +179,7 @@ export function setupDocsIndex<E extends Env>(
     </style>
   </head>
   <body>
-    <h1>${title}</h1>
+    <h1>${pageTitle}</h1>
 
     <div class="card">
       <h2>Swagger UI</h2>
@@ -142,10 +202,10 @@ export function setupDocsIndex<E extends Env>(
     <div class="card json">
       <h2>OpenAPI Spec</h2>
       <p>Raw OpenAPI 3.1 JSON specification.</p>
-      <a href="${specPath}">View JSON &rarr;</a>
+      <a href="${specUrl}">View JSON &rarr;</a>
     </div>
   </body>
 </html>`;
-    return c.html(html);
-  });
+
+  return async (c) => c.html(html);
 }

--- a/scripts/test-pg-transactions.ts
+++ b/scripts/test-pg-transactions.ts
@@ -16,7 +16,7 @@ import pg from 'pg';
 import { z } from 'zod';
 import {
   DrizzleCreateEndpoint,
-  type DrizzleDatabase,
+  type DrizzleDatabaseConstraint,
   DrizzleDeleteEndpoint,
   DrizzleUpdateEndpoint,
 } from '../src/adapters/drizzle/index.js';
@@ -69,13 +69,13 @@ const UserModel = defineModel({
 
 class UserCreateWithTx extends DrizzleCreateEndpoint {
   _meta = { model: UserModel };
-  db = db as unknown as DrizzleDatabase;
+  db = db as unknown as DrizzleDatabaseConstraint;
   protected useTransaction = true;
 }
 
 class UserCreateWithTxAndError extends DrizzleCreateEndpoint {
   _meta = { model: UserModel };
-  db = db as unknown as DrizzleDatabase;
+  db = db as unknown as DrizzleDatabaseConstraint;
   protected useTransaction = true;
 
   override async after(data: z.infer<typeof UserSchema>): Promise<z.infer<typeof UserSchema>> {
@@ -85,19 +85,19 @@ class UserCreateWithTxAndError extends DrizzleCreateEndpoint {
 
 class UserCreateWithoutTx extends DrizzleCreateEndpoint {
   _meta = { model: UserModel };
-  db = db as unknown as DrizzleDatabase;
+  db = db as unknown as DrizzleDatabaseConstraint;
   protected useTransaction = false;
 }
 
 class UserUpdateWithTx extends DrizzleUpdateEndpoint {
   _meta = { model: UserModel };
-  db = db as unknown as DrizzleDatabase;
+  db = db as unknown as DrizzleDatabaseConstraint;
   protected useTransaction = true;
 }
 
 class UserDeleteWithTx extends DrizzleDeleteEndpoint {
   _meta = { model: UserModel };
-  db = db as unknown as DrizzleDatabase;
+  db = db as unknown as DrizzleDatabaseConstraint;
   protected useTransaction = true;
 }
 

--- a/tests/api-version.test.ts
+++ b/tests/api-version.test.ts
@@ -1,9 +1,9 @@
 import { Hono } from 'hono';
 import {
   apiVersion,
+  apiVersionedResponse,
   getApiVersion,
   getApiVersionConfig,
-  versionedResponse,
 } from 'hono-crud/api-version';
 import { describe, expect, it } from 'vitest';
 
@@ -222,7 +222,7 @@ describe('API Versioning', () => {
     });
   });
 
-  describe('versionedResponse', () => {
+  describe('apiVersionedResponse', () => {
     it('should transform response based on version', async () => {
       const app = new Hono();
       app.use(
@@ -241,8 +241,8 @@ describe('API Versioning', () => {
           defaultVersion: '2',
         }),
       );
-      // versionedResponse must wrap the handler
-      app.use('*', versionedResponse());
+      // apiVersionedResponse must wrap the handler
+      app.use('*', apiVersionedResponse());
       app.get('/user', (c) => {
         return c.json({ firstName: 'John', lastName: 'Doe', id: '1' });
       });

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -15,6 +15,7 @@ import {
   createAPIKeyMiddleware,
   createAuthMiddleware,
   createJWTMiddleware,
+  defaultHashAPIKey,
   fromHono,
   generateAPIKey,
   hashAPIKey,
@@ -966,6 +967,18 @@ describe('API Key Utilities', () => {
 
     expect(hash1).toBe(hash2);
     expect(hash1).toHaveLength(64); // SHA-256 hex string
+  });
+
+  it('defaultHashAPIKey is an alias of hashAPIKey', () => {
+    expect(defaultHashAPIKey).toBe(hashAPIKey);
+  });
+
+  it('hashAPIKey produces the frozen SHA-256 lowercase-hex digest', async () => {
+    // Golden value: SHA-256('test') — pins the algorithm so stored key hashes
+    // in user databases keep matching across releases.
+    expect(await hashAPIKey('test')).toBe(
+      '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08',
+    );
   });
 
   it('isValidAPIKeyFormat should validate key format', () => {

--- a/tests/class-sort-fields.test.ts
+++ b/tests/class-sort-fields.test.ts
@@ -7,9 +7,9 @@ import { z } from 'zod';
 
 // Regression: class-based ListEndpoint subclasses must configure sorting via the
 // canonical `sortFields` / `defaultSort` fields that the base ListEndpoint reads.
-// The `orderByFields` / `defaultOrderBy` / `defaultOrderDirection` names only
-// exist as aliases inside the functional createList() config — as class fields
-// they are silently ignored, so sorting is dead.
+// The old orderBy-flavored alias keys were removed from createList() config in the
+// naming sweep; as class fields they were always silently ignored, so any such
+// field is dead config.
 
 const ItemSchema = z.object({
   id: z.uuid(),

--- a/tests/docs-ui.test.ts
+++ b/tests/docs-ui.test.ts
@@ -1,0 +1,124 @@
+import { docsIndex, redocUI, swaggerUI } from '@hono-crud/swagger';
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+
+// ============================================================================
+// swaggerUI() Tests
+// ============================================================================
+
+describe('swaggerUI', () => {
+  it('should return a middleware function', () => {
+    const middleware = swaggerUI();
+    expect(typeof middleware).toBe('function');
+  });
+
+  it('should serve HTML at the mounted path with the default specUrl', async () => {
+    const app = new Hono();
+    app.get('/docs', swaggerUI());
+
+    const res = await app.request('/docs');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/html');
+
+    const html = await res.text();
+    expect(html).toContain('/openapi.json');
+  });
+
+  it('should render a custom specUrl', async () => {
+    const app = new Hono();
+    app.get('/docs', swaggerUI({ specUrl: '/api/v2/openapi.json' }));
+
+    const res = await app.request('/docs');
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+    expect(html).toContain('/api/v2/openapi.json');
+  });
+});
+
+// ============================================================================
+// redocUI() Tests
+// ============================================================================
+
+describe('redocUI', () => {
+  it('should return a middleware function', () => {
+    const middleware = redocUI();
+    expect(typeof middleware).toBe('function');
+  });
+
+  it('should serve HTML with the default specUrl and pageTitle', async () => {
+    const app = new Hono();
+    app.get('/redoc', redocUI());
+
+    const res = await app.request('/redoc');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/html');
+
+    const html = await res.text();
+    expect(html).toContain("spec-url='/openapi.json'");
+    expect(html).toContain('<title>API Documentation</title>');
+  });
+
+  it('should render a custom specUrl and pageTitle', async () => {
+    const app = new Hono();
+    app.get('/redoc', redocUI({ specUrl: '/custom/openapi.json', pageTitle: 'Custom ReDoc' }));
+
+    const res = await app.request('/redoc');
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+    expect(html).toContain("spec-url='/custom/openapi.json'");
+    expect(html).toContain('<title>Custom ReDoc</title>');
+  });
+});
+
+// ============================================================================
+// docsIndex() Tests
+// ============================================================================
+
+describe('docsIndex', () => {
+  it('should return a middleware function', () => {
+    const middleware = docsIndex();
+    expect(typeof middleware).toBe('function');
+  });
+
+  it('should serve HTML with the default link hrefs and pageTitle', async () => {
+    const app = new Hono();
+    app.get('/', docsIndex());
+
+    const res = await app.request('/');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/html');
+
+    const html = await res.text();
+    expect(html).toContain('<title>API Documentation</title>');
+    expect(html).toContain('href="/docs"');
+    expect(html).toContain('href="/redoc"');
+    expect(html).toContain('href="/reference"');
+    expect(html).toContain('href="/openapi.json"');
+  });
+
+  it('should render custom link hrefs, specUrl, and pageTitle', async () => {
+    const app = new Hono();
+    app.get(
+      '/',
+      docsIndex({
+        docsPath: '/swagger',
+        redocPath: '/api-redoc',
+        scalarPath: '/api-reference',
+        specUrl: '/v1/openapi.json',
+        pageTitle: 'My Docs Hub',
+      }),
+    );
+
+    const res = await app.request('/');
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+    expect(html).toContain('<title>My Docs Hub</title>');
+    expect(html).toContain('href="/swagger"');
+    expect(html).toContain('href="/api-redoc"');
+    expect(html).toContain('href="/api-reference"');
+    expect(html).toContain('href="/v1/openapi.json"');
+  });
+});

--- a/tests/drizzle-dialect.test.ts
+++ b/tests/drizzle-dialect.test.ts
@@ -1,6 +1,6 @@
 import {
   DrizzleBatchUpsertEndpoint,
-  type DrizzleDatabase,
+  type DrizzleDatabaseConstraint,
   DrizzleUpsertEndpoint,
   createDrizzleCrud,
 } from '@hono-crud/drizzle';
@@ -63,7 +63,7 @@ interface StubCall {
 
 interface StubDb {
   calls: StubCall[];
-  db: DrizzleDatabase;
+  db: DrizzleDatabaseConstraint;
 }
 
 /**
@@ -123,7 +123,7 @@ function makeStubDb(): StubDb {
     transaction<T>(fn: (tx: unknown) => Promise<T>) {
       return fn(db);
     },
-  } as unknown as DrizzleDatabase;
+  } as unknown as DrizzleDatabaseConstraint;
 
   return { calls, db };
 }

--- a/tests/drizzle.test.ts
+++ b/tests/drizzle.test.ts
@@ -4,7 +4,7 @@ import {
   DrizzleBatchDeleteEndpoint,
   DrizzleCloneEndpoint,
   DrizzleCreateEndpoint,
-  type DrizzleDatabase,
+  type DrizzleDatabaseConstraint,
   DrizzleDeleteEndpoint,
   DrizzleListEndpoint,
   DrizzleReadEndpoint,
@@ -112,81 +112,79 @@ const PostModel = defineModel({
 
 class UserCreate extends DrizzleCreateEndpoint {
   _meta = { model: UserModel };
-  db = db as unknown as DrizzleDatabase;
+  db = db as unknown as DrizzleDatabaseConstraint;
 }
 
 class UserRead extends DrizzleReadEndpoint {
   _meta = { model: UserModel };
-  db = db as unknown as DrizzleDatabase;
+  db = db as unknown as DrizzleDatabaseConstraint;
   allowedIncludes = ['posts'];
 }
 
 class UserUpdate extends DrizzleUpdateEndpoint {
   _meta = { model: UserModel };
-  db = db as unknown as DrizzleDatabase;
+  db = db as unknown as DrizzleDatabaseConstraint;
 }
 
 class UserDelete extends DrizzleDeleteEndpoint {
   _meta = { model: UserModel };
-  db = db as unknown as DrizzleDatabase;
+  db = db as unknown as DrizzleDatabaseConstraint;
 }
 
 class UserList extends DrizzleListEndpoint {
   _meta = { model: UserModel };
-  db = db as unknown as DrizzleDatabase;
+  db = db as unknown as DrizzleDatabaseConstraint;
   filterFields = ['role'];
   searchFields = ['name', 'email'];
-  orderByFields = ['name', 'email'];
   allowedIncludes = ['posts'];
 }
 
 class UserRestore extends DrizzleRestoreEndpoint {
   _meta = { model: UserModel };
-  db = db as unknown as DrizzleDatabase;
+  db = db as unknown as DrizzleDatabaseConstraint;
 }
 
 class UserUpsert extends DrizzleUpsertEndpoint {
   _meta = { model: UserModel };
-  db = db as unknown as DrizzleDatabase;
+  db = db as unknown as DrizzleDatabaseConstraint;
   upsertKeys = ['email'];
 }
 
 class UserBatchCreate extends DrizzleBatchCreateEndpoint {
   _meta = { model: UserModel };
-  db = db as unknown as DrizzleDatabase;
+  db = db as unknown as DrizzleDatabaseConstraint;
 }
 
 class UserBatchDelete extends DrizzleBatchDeleteEndpoint {
   _meta = { model: UserModel };
-  db = db as unknown as DrizzleDatabase;
+  db = db as unknown as DrizzleDatabaseConstraint;
 }
 
 class UserClone extends DrizzleCloneEndpoint {
   _meta = { model: UserModel };
-  db = db as unknown as DrizzleDatabase;
+  db = db as unknown as DrizzleDatabaseConstraint;
 }
 
 class PostCreate extends DrizzleCreateEndpoint {
   _meta = { model: PostModel };
-  db = db as unknown as DrizzleDatabase;
+  db = db as unknown as DrizzleDatabaseConstraint;
 }
 
 class PostRead extends DrizzleReadEndpoint {
   _meta = { model: PostModel };
-  db = db as unknown as DrizzleDatabase;
+  db = db as unknown as DrizzleDatabaseConstraint;
   allowedIncludes = ['author'];
 }
 
 class PostList extends DrizzleListEndpoint {
   _meta = { model: PostModel };
-  db = db as unknown as DrizzleDatabase;
-  orderByFields = ['title', 'views'];
+  db = db as unknown as DrizzleDatabaseConstraint;
   allowedIncludes = ['author'];
 }
 
 class PostAggregate extends DrizzleAggregateEndpoint {
   _meta = { model: PostModel };
-  db = db as unknown as DrizzleDatabase;
+  db = db as unknown as DrizzleDatabaseConstraint;
 
   aggregateConfig = {
     sumFields: ['views'],
@@ -204,7 +202,7 @@ let injectedAggregateFilters: AggregateOptions['filters'];
 
 class PostAggregateFiltered extends DrizzleAggregateEndpoint {
   _meta = { model: PostModel };
-  db = db as unknown as DrizzleDatabase;
+  db = db as unknown as DrizzleDatabaseConstraint;
 
   aggregateConfig = {
     sumFields: ['views'],
@@ -894,7 +892,7 @@ describe('Drizzle Transaction Support', () => {
     // Verify that endpoints can be configured with useTransaction
     class TestEndpoint extends DrizzleCreateEndpoint {
       _meta = { model: UserModel };
-      db = db as unknown as DrizzleDatabase;
+      db = db as unknown as DrizzleDatabaseConstraint;
       protected useTransaction = true;
     }
 
@@ -921,7 +919,7 @@ describe('Drizzle Transaction Support', () => {
 
     class UserCreateWithTx extends DrizzleCreateEndpoint {
       _meta = { model: UserModel };
-      db = mockDb as unknown as DrizzleDatabase;
+      db = mockDb as unknown as DrizzleDatabaseConstraint;
       protected useTransaction = true;
     }
 
@@ -963,7 +961,7 @@ describe('Drizzle Transaction Support', () => {
 
     class UserCreateNoTx extends DrizzleCreateEndpoint {
       _meta = { model: UserModel };
-      db = mockDb as unknown as DrizzleDatabase;
+      db = mockDb as unknown as DrizzleDatabaseConstraint;
       protected useTransaction = false; // Default
     }
 
@@ -1011,7 +1009,7 @@ describe('Drizzle Transaction Support', () => {
 
     class UserCreateWithError extends DrizzleCreateEndpoint {
       _meta = { model: UserModel };
-      db = mockDb as unknown as DrizzleDatabase;
+      db = mockDb as unknown as DrizzleDatabaseConstraint;
       protected useTransaction = true;
 
       override async after(data: z.infer<typeof UserSchema>): Promise<z.infer<typeof UserSchema>> {

--- a/tests/health.test.ts
+++ b/tests/health.test.ts
@@ -1,12 +1,11 @@
-import { createHealthEndpoints, createHealthHandler } from '@hono-crud/health';
+import { createHealthRoutes } from '@hono-crud/health';
 import { Hono } from 'hono';
 import { describe, expect, it } from 'vitest';
 
 describe('Health Endpoints', () => {
-  describe('createHealthEndpoints', () => {
+  describe('createHealthRoutes', () => {
     it('should return 200 for liveness check', async () => {
-      const app = new Hono();
-      createHealthEndpoints(app);
+      const app = createHealthRoutes();
 
       const res = await app.request('/health');
       expect(res.status).toBe(200);
@@ -17,8 +16,7 @@ describe('Health Endpoints', () => {
     });
 
     it('should include version when provided', async () => {
-      const app = new Hono();
-      createHealthEndpoints(app, { version: '1.2.3' });
+      const app = createHealthRoutes({ version: '1.2.3' });
 
       const res = await app.request('/health');
       const body = await res.json();
@@ -26,8 +24,7 @@ describe('Health Endpoints', () => {
     });
 
     it('should use custom paths', async () => {
-      const app = new Hono();
-      createHealthEndpoints(app, {
+      const app = createHealthRoutes({
         path: '/liveness',
         readyPath: '/readiness',
       });
@@ -40,8 +37,7 @@ describe('Health Endpoints', () => {
     });
 
     it('should return 200 readiness when all checks pass', async () => {
-      const app = new Hono();
-      createHealthEndpoints(app, {
+      const app = createHealthRoutes({
         checks: [
           { name: 'db', check: async () => true },
           { name: 'cache', check: async () => 'connected' },
@@ -59,8 +55,7 @@ describe('Health Endpoints', () => {
     });
 
     it('should return 503 when critical check fails', async () => {
-      const app = new Hono();
-      createHealthEndpoints(app, {
+      const app = createHealthRoutes({
         checks: [
           {
             name: 'db',
@@ -81,8 +76,7 @@ describe('Health Endpoints', () => {
     });
 
     it('should return degraded when non-critical check fails', async () => {
-      const app = new Hono();
-      createHealthEndpoints(app, {
+      const app = createHealthRoutes({
         checks: [
           { name: 'db', check: async () => true },
           {
@@ -102,8 +96,7 @@ describe('Health Endpoints', () => {
     });
 
     it('should timeout slow checks', async () => {
-      const app = new Hono();
-      createHealthEndpoints(app, {
+      const app = createHealthRoutes({
         defaultTimeout: 50,
         checks: [
           {
@@ -123,8 +116,7 @@ describe('Health Endpoints', () => {
     });
 
     it('should report latency', async () => {
-      const app = new Hono();
-      createHealthEndpoints(app, {
+      const app = createHealthRoutes({
         checks: [{ name: 'fast', check: async () => true }],
       });
 
@@ -135,8 +127,7 @@ describe('Health Endpoints', () => {
     });
 
     it('should respect per-check timeout', async () => {
-      const app = new Hono();
-      createHealthEndpoints(app, {
+      const app = createHealthRoutes({
         defaultTimeout: 5000,
         checks: [
           {
@@ -153,12 +144,12 @@ describe('Health Endpoints', () => {
       const body = await res.json();
       expect(body.checks[0].healthy).toBe(false);
     });
-  });
 
-  describe('createHealthHandler', () => {
-    it('should create a standalone Hono app with health routes', async () => {
-      const health = createHealthHandler({ version: '2.0.0' });
-      const res = await health.request('/health');
+    it('should mount as a sub-app via app.route()', async () => {
+      const app = new Hono();
+      app.route('/', createHealthRoutes({ version: '2.0.0' }));
+
+      const res = await app.request('/health');
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.version).toBe('2.0.0');

--- a/tests/idempotency-lifecycle.test.ts
+++ b/tests/idempotency-lifecycle.test.ts
@@ -2,7 +2,7 @@ import {
   type IdempotencyEntry,
   type IdempotencyStorage,
   MemoryIdempotencyStorage,
-  idempotency,
+  createIdempotencyMiddleware,
   setIdempotencyStorage,
 } from '@hono-crud/idempotency';
 import { idempotencyStorageRegistry } from '@hono-crud/idempotency/middleware';
@@ -99,7 +99,7 @@ describe('§4.7 idempotency storage lifecycle', () => {
 });
 
 // ============================================================================
-// §4.8 — config.storage precedence: idempotency({ storage }) uses the explicit
+// §4.8 — config.storage precedence: createIdempotencyMiddleware({ storage }) uses the explicit
 // storage over a context-injected and a global one (single resolution tier via
 // resolveIdempotencyStorage(ctx, config.storage); no double-apply).
 // ============================================================================
@@ -115,7 +115,7 @@ describe('§4.8 idempotency config.storage precedence', () => {
     // Inject a DIFFERENT storage into context.
     app.use('/*', createStorageMiddleware({ idempotencyStorage: contextStorage }));
     // config.storage must win over both.
-    app.use('/*', idempotency({ storage: explicitStorage }));
+    app.use('/*', createIdempotencyMiddleware({ storage: explicitStorage }));
     app.post('/op', (c) => c.json({ ok: true }));
 
     const res = await app.request('/op', {
@@ -137,7 +137,7 @@ describe('§4.8 idempotency config.storage precedence', () => {
 
     let handlerCalls = 0;
     const app = new Hono<StorageEnv>();
-    app.use('/*', idempotency({ storage: explicitStorage }));
+    app.use('/*', createIdempotencyMiddleware({ storage: explicitStorage }));
     app.post('/op', (c) => {
       handlerCalls++;
       return c.json({ count: handlerCalls });

--- a/tests/list-adapter-substring.test.ts
+++ b/tests/list-adapter-substring.test.ts
@@ -1,4 +1,8 @@
-import { type DrizzleDatabase, DrizzleListEndpoint, createDrizzleCrud } from '@hono-crud/drizzle';
+import {
+  type DrizzleDatabaseConstraint,
+  DrizzleListEndpoint,
+  createDrizzleCrud,
+} from '@hono-crud/drizzle';
 import { createClient } from '@libsql/client';
 import { sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/libsql';
@@ -57,7 +61,7 @@ const ProductModel = defineModel({
 
 class ProductList extends DrizzleListEndpoint {
   _meta = { model: ProductModel };
-  db = drizzleDb as unknown as DrizzleDatabase;
+  db = drizzleDb as unknown as DrizzleDatabaseConstraint;
   schema = { tags: ['Products'], summary: 'List products' };
 
   protected searchFields = ['name', 'description'];
@@ -244,7 +248,7 @@ function literalChunks(node: unknown): string {
  * to the count and main query. Returns a no-op chain for the rest so the
  * list endpoint can run end-to-end without a real driver.
  */
-function makeWhereCaptureDb(): { db: DrizzleDatabase; capture: WhereCapture } {
+function makeWhereCaptureDb(): { db: DrizzleDatabaseConstraint; capture: WhereCapture } {
   const capture: WhereCapture = { whereSql: undefined };
 
   const countChain = {
@@ -298,7 +302,7 @@ function makeWhereCaptureDb(): { db: DrizzleDatabase; capture: WhereCapture } {
     transaction<T>(fn: (tx: unknown) => Promise<T>) {
       return fn(db);
     },
-  } as unknown as DrizzleDatabase;
+  } as unknown as DrizzleDatabaseConstraint;
 
   return { db, capture };
 }

--- a/tests/managed-fields-coverage.test.ts
+++ b/tests/managed-fields-coverage.test.ts
@@ -1,4 +1,4 @@
-import { DrizzleCloneEndpoint, type DrizzleDatabase } from '@hono-crud/drizzle';
+import { DrizzleCloneEndpoint, type DrizzleDatabaseConstraint } from '@hono-crud/drizzle';
 import {
   MemoryBatchCreateEndpoint,
   MemoryCloneEndpoint,
@@ -293,7 +293,7 @@ describe('clone unique-violation → 409 JSON envelope', () => {
 
   class ProdClone extends DrizzleCloneEndpoint<any, typeof meta> {
     _meta = meta;
-    db = db as unknown as DrizzleDatabase;
+    db = db as unknown as DrizzleDatabaseConstraint;
   }
 
   let app: Hono;

--- a/tests/managed-id-timestamps.test.ts
+++ b/tests/managed-id-timestamps.test.ts
@@ -1,7 +1,7 @@
 import {
   DrizzleCloneEndpoint,
   DrizzleCreateEndpoint,
-  type DrizzleDatabase,
+  type DrizzleDatabaseConstraint,
   DrizzleUpsertEndpoint,
 } from '@hono-crud/drizzle';
 import {
@@ -274,16 +274,16 @@ describe("Model.id 'database' strategy (Drizzle $defaultFn)", () => {
 
   class DbCreate extends DrizzleCreateEndpoint<any, typeof meta> {
     _meta = meta;
-    db = db as unknown as DrizzleDatabase;
+    db = db as unknown as DrizzleDatabaseConstraint;
   }
   class DbUpsert extends DrizzleUpsertEndpoint<any, typeof meta> {
     _meta = meta;
-    db = db as unknown as DrizzleDatabase;
+    db = db as unknown as DrizzleDatabaseConstraint;
     upsertKeys = ['email'];
   }
   class DbClone extends DrizzleCloneEndpoint<any, typeof meta> {
     _meta = meta;
-    db = db as unknown as DrizzleDatabase;
+    db = db as unknown as DrizzleDatabaseConstraint;
   }
 
   let app: Hono;

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -44,7 +44,6 @@ class TestList extends MemoryListEndpoint<any, TestMeta> {
     age: ['eq', 'gt', 'gte', 'lt', 'lte', 'between'],
   };
   searchFields = ['name', 'email'];
-  orderByFields = ['name', 'age'];
 }
 
 class TestRead extends MemoryReadEndpoint<any, TestMeta> {

--- a/tests/new-features.test.ts
+++ b/tests/new-features.test.ts
@@ -1,4 +1,4 @@
-import { idempotency } from '@hono-crud/idempotency/middleware';
+import { createIdempotencyMiddleware } from '@hono-crud/idempotency/middleware';
 import { MemoryIdempotencyStorage } from '@hono-crud/idempotency/storage/memory';
 import {
   MemoryCloneEndpoint,
@@ -532,7 +532,7 @@ describe('Idempotency Middleware', () => {
   beforeEach(() => {
     storage = new MemoryIdempotencyStorage();
     app = new Hono();
-    app.use('/*', idempotency({ storage }));
+    app.use('/*', createIdempotencyMiddleware({ storage }));
     app.post('/items', (c) => c.json({ success: true, result: { id: crypto.randomUUID() } }, 201));
     app.get('/items', (c) => c.json({ success: true, result: [] }));
   });
@@ -571,7 +571,7 @@ describe('Idempotency Middleware', () => {
 
   it('should require idempotency key when configured', async () => {
     const requiredApp = new Hono();
-    requiredApp.use('/*', idempotency({ storage, required: true }));
+    requiredApp.use('/*', createIdempotencyMiddleware({ storage, required: true }));
     requiredApp.post('/items', (c) => c.json({ ok: true }));
 
     const res = await requiredApp.request('/items', { method: 'POST' });

--- a/tests/prior-state-hooks.test.ts
+++ b/tests/prior-state-hooks.test.ts
@@ -29,7 +29,11 @@ import { Hono } from 'hono';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
-import { DrizzleDeleteEndpoint, DrizzleUpdateEndpoint } from '@hono-crud/drizzle';
+import {
+  type DrizzleDatabaseConstraint,
+  DrizzleDeleteEndpoint,
+  DrizzleUpdateEndpoint,
+} from '@hono-crud/drizzle';
 import {
   MEMORY_NOOP_TX,
   MemoryDeleteEndpoint,
@@ -37,7 +41,7 @@ import {
   clearStorage,
   getStorage,
 } from '@hono-crud/memory';
-import { type DrizzleDatabase, type HookContext, defineMeta, defineModel } from 'hono-crud';
+import { type HookContext, defineMeta, defineModel } from 'hono-crud';
 
 // ============================================================================
 // Memory adapter — Update
@@ -291,7 +295,7 @@ describe('afterUpdate / afterDelete prior — drizzle adapter (real tx)', () => 
       delete: db.delete.bind(db),
     };
     return {
-      db: wrapped as unknown as DrizzleDatabase,
+      db: wrapped as unknown as DrizzleDatabaseConstraint,
       get committed() {
         return txCommitted;
       },

--- a/tests/prisma.test.ts
+++ b/tests/prisma.test.ts
@@ -399,7 +399,6 @@ class UserList extends PrismaListEndpoint {
   }
   filterFields = ['role'];
   searchFields = ['name', 'email'];
-  orderByFields = ['name', 'email'];
 }
 
 class UserRestore extends PrismaRestoreEndpoint {
@@ -480,7 +479,6 @@ class PostList extends PrismaListEndpoint {
   get prisma() {
     return mockPrisma;
   }
-  orderByFields = ['title', 'views'];
 }
 
 // Allows range filters on `views` so two operators land on the SAME field,
@@ -490,7 +488,6 @@ class PostListRanged extends PrismaListEndpoint {
   get prisma() {
     return mockPrisma;
   }
-  orderByFields = ['title', 'views'];
   filterConfig = { views: ['gte' as const, 'lte' as const] };
 }
 

--- a/tests/scalar-ui.test.ts
+++ b/tests/scalar-ui.test.ts
@@ -1,6 +1,6 @@
-import { scalarUI, setupScalar } from '@hono-crud/scalar';
+import { scalarUI } from '@hono-crud/scalar';
 import type { ScalarConfig, ScalarTheme } from '@hono-crud/scalar';
-import { setupDocsIndex } from '@hono-crud/swagger';
+import { docsIndex } from '@hono-crud/swagger';
 import { Hono } from 'hono';
 import { describe, expect, it } from 'vitest';
 
@@ -128,32 +128,35 @@ describe('scalarUI', () => {
 });
 
 // ============================================================================
-// setupScalar() Tests
+// scalarUI() mounting Tests
 // ============================================================================
 
-describe('setupScalar', () => {
-  it('should register a GET route at the specified path', async () => {
+describe('scalarUI mounting', () => {
+  it('should serve a GET route at the mounted path', async () => {
     const app = new Hono();
-    setupScalar(app, '/docs');
+    app.get('/docs', scalarUI());
 
     const res = await app.request('/docs');
     expect(res.status).toBe(200);
   });
 
-  it('should use /reference as default path', async () => {
+  it('should serve at the conventional /reference mount path', async () => {
     const app = new Hono();
-    setupScalar(app);
+    app.get('/reference', scalarUI());
 
     const res = await app.request('/reference');
     expect(res.status).toBe(200);
   });
 
-  it('should pass config to scalarUI', async () => {
+  it('should render the provided config', async () => {
     const app = new Hono();
-    setupScalar(app, '/api-docs', {
-      specUrl: '/spec.json',
-      theme: 'kepler',
-    });
+    app.get(
+      '/api-docs',
+      scalarUI({
+        specUrl: '/spec.json',
+        theme: 'kepler',
+      }),
+    );
 
     const res = await app.request('/api-docs');
     expect(res.status).toBe(200);
@@ -167,7 +170,7 @@ describe('setupScalar', () => {
     const app = new Hono();
 
     app.get('/health', (c) => c.json({ status: 'ok' }));
-    setupScalar(app, '/reference');
+    app.get('/reference', scalarUI());
     app.get('/api/users', (c) => c.json({ users: [] }));
 
     const healthRes = await app.request('/health');
@@ -185,7 +188,7 @@ describe('setupScalar', () => {
 
   it('should work with nested paths', async () => {
     const app = new Hono();
-    setupScalar(app, '/api/v1/docs');
+    app.get('/api/v1/docs', scalarUI());
 
     const res = await app.request('/api/v1/docs');
     expect(res.status).toBe(200);
@@ -195,7 +198,7 @@ describe('setupScalar', () => {
     const mainApp = new Hono();
     const subApp = new Hono();
 
-    setupScalar(subApp, '/docs', { specUrl: '/api/openapi.json' });
+    subApp.get('/docs', scalarUI({ specUrl: '/api/openapi.json' }));
 
     mainApp.route('/api', subApp);
 
@@ -265,7 +268,7 @@ describe('Scalar Integration', () => {
     );
 
     // Scalar UI
-    setupScalar(app, '/reference', { specUrl: '/openapi.json' });
+    app.get('/reference', scalarUI({ specUrl: '/openapi.json' }));
 
     // Test OpenAPI endpoint
     const specRes = await app.request('/openapi.json');
@@ -281,10 +284,13 @@ describe('Scalar Integration', () => {
 
   it('should work with baseServerURL configuration', async () => {
     const app = new Hono();
-    setupScalar(app, '/reference', {
-      specUrl: '/openapi.json',
-      baseServerURL: 'https://api.example.com',
-    });
+    app.get(
+      '/reference',
+      scalarUI({
+        specUrl: '/openapi.json',
+        baseServerURL: 'https://api.example.com',
+      }),
+    );
 
     const res = await app.request('/reference');
     expect(res.status).toBe(200);
@@ -296,16 +302,18 @@ describe('Scalar Integration', () => {
   it('docs hub links to the path scalar serves by default', async () => {
     const app = new Hono();
 
-    // Mount both packages with their respective defaults: the swagger docs hub
-    // and the scalar reference UI must agree on a single path.
-    setupDocsIndex(app);
-    setupScalar(app);
+    // The agreement between the docs hub and the scalar UI is a
+    // documented-default contract, not runtime wiring: DocsIndexConfig.scalarPath
+    // defaults to '/reference', the conventional scalar mount path.
+    app.get('/', docsIndex());
+    app.get('/reference', scalarUI());
 
-    // The hub renders a link to Scalar; extract its href and follow it.
+    // The hub renders a link to Scalar; extract its href, pin it to the
+    // documented default, and follow it.
     const hubRes = await app.request('/');
     const hubHtml = await hubRes.text();
     const scalarHref = hubHtml.match(/href="([^"]*)"[^>]*>Open Scalar/)?.[1];
-    expect(scalarHref).toBeDefined();
+    expect(scalarHref).toBe('/reference');
 
     const linkedRes = await app.request(scalarHref as string);
     expect(linkedRes.status).toBe(200);

--- a/tests/search-adapter-sql.test.ts
+++ b/tests/search-adapter-sql.test.ts
@@ -1,4 +1,4 @@
-import { type DrizzleDatabase, DrizzleSearchEndpoint } from '@hono-crud/drizzle';
+import { type DrizzleDatabaseConstraint, DrizzleSearchEndpoint } from '@hono-crud/drizzle';
 import { MemorySearchEndpoint, clearStorage, getStorage } from '@hono-crud/memory';
 import { createClient } from '@libsql/client';
 import { sql } from 'drizzle-orm';
@@ -54,7 +54,7 @@ const DrizzleProductModel = defineModel({
 
 class DrizzleProductSearch extends DrizzleSearchEndpoint {
   _meta = { model: DrizzleProductModel };
-  db = drizzleDb as unknown as DrizzleDatabase;
+  db = drizzleDb as unknown as DrizzleDatabaseConstraint;
   schema = { tags: ['Products'], summary: 'Search products' };
 
   protected searchFields = ['name', 'description'];

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -50,8 +50,6 @@ class ArticleSearch extends MemorySearchEndpoint {
   protected filterConfig = {
     views: ['gt', 'gte', 'lt', 'lte', 'eq'] as const,
   };
-
-  protected orderByFields = ['title', 'views', 'author'];
 }
 
 describe('Search Utilities', () => {

--- a/tests/transactional-hooks.test.ts
+++ b/tests/transactional-hooks.test.ts
@@ -17,7 +17,7 @@ import { Hono } from 'hono';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
-import { DrizzleCreateEndpoint } from '@hono-crud/drizzle';
+import { DrizzleCreateEndpoint, type DrizzleDatabaseConstraint } from '@hono-crud/drizzle';
 import {
   MEMORY_NOOP_TX,
   MemoryCreateEndpoint,
@@ -26,7 +26,7 @@ import {
   clearStorage,
   getStorage,
 } from '@hono-crud/memory';
-import { type DrizzleDatabase, type HookContext, defineMeta, defineModel } from 'hono-crud';
+import { type HookContext, defineMeta, defineModel } from 'hono-crud';
 
 // ============================================================================
 // Memory-adapter cases
@@ -196,7 +196,7 @@ describe('Transactional hooks — drizzle adapter', () => {
 
     class WithRollback extends DrizzleCreateEndpoint {
       _meta = meta;
-      db = mockDb as unknown as DrizzleDatabase;
+      db = mockDb as unknown as DrizzleDatabaseConstraint;
       protected override useTransaction = true;
 
       override async after(

--- a/tests/widen-unique-409.test.ts
+++ b/tests/widen-unique-409.test.ts
@@ -2,7 +2,7 @@ import {
   DrizzleBatchCreateEndpoint,
   DrizzleBatchUpsertEndpoint,
   DrizzleCreateEndpoint,
-  type DrizzleDatabase,
+  type DrizzleDatabaseConstraint,
   DrizzleImportEndpoint,
   DrizzleUpsertEndpoint,
 } from '@hono-crud/drizzle';
@@ -72,27 +72,27 @@ const meta = defineMeta({ model });
 // `tests/managed-fields-coverage.test.ts` uses for the clone 409 case.
 class WidgetCreate extends DrizzleCreateEndpoint<any, typeof meta> {
   _meta = meta;
-  db = db as unknown as DrizzleDatabase;
+  db = db as unknown as DrizzleDatabaseConstraint;
 }
 class WidgetBatchCreate extends DrizzleBatchCreateEndpoint<any, typeof meta> {
   _meta = meta;
-  db = db as unknown as DrizzleDatabase;
+  db = db as unknown as DrizzleDatabaseConstraint;
 }
 class WidgetUpsertById extends DrizzleUpsertEndpoint<any, typeof meta> {
   _meta = meta;
-  db = db as unknown as DrizzleDatabase;
+  db = db as unknown as DrizzleDatabaseConstraint;
   // Match on `id` so a duplicate `slug` (a different UNIQUE column) is a
   // genuine violation, not just an upsert.
   protected upsertKeys = ['id'];
 }
 class WidgetBatchUpsertById extends DrizzleBatchUpsertEndpoint<any, typeof meta> {
   _meta = meta;
-  db = db as unknown as DrizzleDatabase;
+  db = db as unknown as DrizzleDatabaseConstraint;
   protected upsertKeys = ['id'];
 }
 class WidgetImport extends DrizzleImportEndpoint<any, typeof meta> {
   _meta = meta;
-  db = db as unknown as DrizzleDatabase;
+  db = db as unknown as DrizzleDatabaseConstraint;
 }
 
 function buildApp(): Hono {


### PR DESCRIPTION
## Summary

The final drift-audit batch (themes 6–7). After this, every consistency theme from the audit is closed. Same process as #56/#58/#60: inventory → spec → 3 adversarial design reviews (all initially "needs-revision", 9 must-change items resolved into rev 2) → parallel implementation on disjoint file sets → adversarial re-review → gate.

### One name per role

| Role | Convention | Changes |
|---|---|---|
| Cross-cutting middleware | `create<Feature>Middleware()` | `idempotency()` → `createIdempotencyMiddleware()`; `multiTenant()`/`apiVersion()` documented as exceptions (each anchors an accessor family sharing its prefix) |
| Class mixins | `with<Feature>()` | unchanged (`withCache` etc. verified the only members) |
| Docs-page factories | `<vendor>UI()` returning `MiddlewareHandler` | swagger's app-mutating `setupSwaggerUI`/`setupReDoc`/`setupDocsIndex` → `swaggerUI()`/`redocUI()`/`docsIndex()`, field vocabulary unified on scalar's `specUrl`/`pageTitle`; `setupScalar` deleted |
| Multi-route features | `create<Feature>Routes(): Hono` | health's two old entry points collapse into `createHealthRoutes()` mounted via `app.route()` |
| Config bags | `*Config` setup bag / `*Options` per-call leaf bag | `MultiTenantMiddlewareOptions` → `MultiTenantMiddlewareConfig`, `CrudMcpOptions` → `CrudMcpConfig`; legacy exceptions documented |

### Vocabulary fixes

- **"Versioning" = record history, full stop.** HTTP negotiation renames: `ApiVersioningConfig`, `ApiVersionStrategy`, `ApiVersionTransformer`, `apiVersionedResponse()`. A grep gate proves zero HTTP-negotiation symbols match `/^Versioning/`.
- **Multi-tenant single source of truth**: new exported `TenantIdSource` union owned by the model-level config; the middleware config derives from it so the two halves can never drift again. Runtime defaults unchanged (the design review traced both halves).
- **One rate-limit key prefix** (`DEFAULT_RATE_LIMIT_KEY_PREFIX = 'rl'`); KV/Redis no longer add divergent defaults — in-flight windows under old prefixes just expire.
- **One API-key hasher**: canonical `hashAPIKey` in new `auth/hash.ts`; `defaultHashAPIKey` aliases it. Byte-identical hashing proven — stored keys keep matching.
- Vestigial `RouterOptions.base`/`docs_url`/`redoc_url` deleted; sorting aliases (`orderByFields`/`defaultOrderBy`/`defaultOrderDirection`/`defaultDirection`) finally removed from the functional config; drizzle's misleading 5-verb `DrizzleAdapters` bundle deleted.

### Docs now document this codebase

CLAUDE.md and AGENTS.md (kept byte-identical, verified by diff) gain the naming doctrine above and a **corrected Drizzle Adapter Pattern section** — the old one named types that don't exist anywhere (`DrizzleDatabase`/`InternalDatabase`/`toInternal`); the new one uses the real `DrizzleDatabaseConstraint`/`Database<Row>`/`QueryBuilder<Row>`/`cast<Row>()`. All docs/READMEs/examples migrated to the new names and call patterns; 8 test files still using the long-dead `DrizzleDatabase` name updated.

### Verification

- Gate green: build, typecheck, unit, workers, examples typecheck, biome, **plus grep gates** — every old name returns zero hits outside historical CHANGELOGs (gates run with `git grep -P`; this platform's `-E` silently fails on `\b`)
- Full suite green without tripwire firings; local-consumer smoke passes
- 98 files, +685/−563

One changeset, patch bumps across the 8 affected packages with the complete migration table.

Out of scope by design: `ERPOS_INTEGRATION.md` (owner's untracked draft — flagged stale by the audit, owner decision).