### PR TITLE
refactor: satellites declare hono-crud as caret-range peerDependency

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,8 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }

--- a/.changeset/satellite-peer-deps.md
+++ b/.changeset/satellite-peer-deps.md
@@ -1,0 +1,11 @@
+---
+"@hono-crud/cache": patch
+"@hono-crud/rate-limit": patch
+"@hono-crud/idempotency": patch
+"@hono-crud/memory": patch
+"@hono-crud/drizzle": patch
+"@hono-crud/prisma": patch
+"@hono-crud/mcp": patch
+---
+
+`hono-crud` is now a peerDependency (caret range) instead of an exact-pinned dependency. Previously, published packages pinned the exact core version (e.g. `0.13.13`), so an app on any other core version got two physical copies of `hono-crud` installed — silently corrupting satellite exception codes through `createErrorHandler` (e.g. `RATE_LIMIT_EXCEEDED` degraded to `HTTP_ERROR`, `details.retryAfter` dropped) and breaking `setLogger()` for all adapter logging. The resolver now dedupes onto the app's single copy. npm >= 7 and pnpm >= 8 auto-install peers, so installs are unchanged.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Install the core package plus the adapter you need (and Swagger UI, if you want 
 npm install hono-crud @hono-crud/memory @hono-crud/swagger hono zod
 ```
 
-Peer dependencies: `hono >= 4.0.0` and `zod >= 4.0.0` are required.
+Peer dependencies: `hono >= 4.11.7 <5` and `zod >= 4.0.0` are required.
 
 ## Packages
 
@@ -497,7 +497,7 @@ See the [examples/](./examples) directory for complete working applications:
 
 ## Requirements
 
-- Node.js >= 20
+- Node.js >= 20.19
 - TypeScript >= 5.0
 
 ## License

--- a/examples/local-consumer/package.json
+++ b/examples/local-consumer/package.json
@@ -15,7 +15,7 @@
     "@hono-crud/memory": "workspace:*",
     "@hono-crud/rate-limit": "workspace:*",
     "@hono-crud/swagger": "workspace:*",
-    "hono": "^4.11.4",
+    "hono": "^4.11.7",
     "hono-crud": "workspace:*",
     "zod": "^4.3.5"
   },

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@types/pluralize": "^0.0.33",
     "drizzle-orm": "^0.45.1",
     "drizzle-zod": "^0.8.3",
-    "hono": "^4.11.4",
+    "hono": "^4.11.7",
     "hono-crud": "workspace:*",
     "pg": "^8.17.2",
     "prisma": "^7.2.0",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -49,14 +49,13 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
-    "hono-crud": "workspace:*"
-  },
   "peerDependencies": {
-    "hono": ">=4.11.7 <5"
+    "hono": ">=4.11.7 <5",
+    "hono-crud": "workspace:^"
   },
   "devDependencies": {
-    "hono": "^4.11.4",
+    "hono": "^4.11.7",
+    "hono-crud": "workspace:*",
     "tsup": "^8.4.0",
     "typescript": "^5.8.3"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -117,7 +117,7 @@
     "zod": ">=4.0.0"
   },
   "devDependencies": {
-    "hono": "^4.11.4",
+    "hono": "^4.11.7",
     "tsup": "^8.4.0",
     "typescript": "^5.8.3",
     "zod": "^4.3.5"

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -48,19 +48,18 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
-    "hono-crud": "workspace:*"
-  },
   "peerDependencies": {
     "drizzle-orm": ">=0.30.0",
     "drizzle-zod": ">=0.8.0",
     "hono": ">=4.11.7 <5",
+    "hono-crud": "workspace:^",
     "zod": ">=4.0.0"
   },
   "devDependencies": {
     "drizzle-orm": "^0.45.1",
     "drizzle-zod": "^0.8.3",
-    "hono": "^4.11.4",
+    "hono": "^4.11.7",
+    "hono-crud": "workspace:*",
     "tsup": "^8.4.0",
     "typescript": "^5.8.3",
     "zod": "^4.3.5"

--- a/packages/health/package.json
+++ b/packages/health/package.json
@@ -51,7 +51,7 @@
     "hono": ">=4.11.7 <5"
   },
   "devDependencies": {
-    "hono": "^4.11.4",
+    "hono": "^4.11.7",
     "tsup": "^8.4.0",
     "typescript": "^5.8.3"
   }

--- a/packages/idempotency/package.json
+++ b/packages/idempotency/package.json
@@ -48,14 +48,13 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
-    "hono-crud": "workspace:*"
-  },
   "peerDependencies": {
-    "hono": ">=4.11.7 <5"
+    "hono": ">=4.11.7 <5",
+    "hono-crud": "workspace:^"
   },
   "devDependencies": {
-    "hono": "^4.11.4",
+    "hono": "^4.11.7",
+    "hono-crud": "workspace:*",
     "tsup": "^8.4.0",
     "typescript": "^5.8.3"
   }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -51,17 +51,18 @@
     "access": "public"
   },
   "dependencies": {
-    "hono-crud": "workspace:*",
     "@hono/mcp": "^0.3.0"
   },
   "peerDependencies": {
-    "hono": ">=4.11.7 <5",
     "@modelcontextprotocol/sdk": "^1.25.1",
-    "zod": ">=4"
+    "hono": ">=4.11.7 <5",
+    "hono-crud": "workspace:^",
+    "zod": ">=4.0.0"
   },
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "hono": "^4.11.4",
+    "hono": "^4.11.7",
+    "hono-crud": "workspace:*",
     "tsup": "^8.4.0",
     "typescript": "^5.8.3",
     "zod": "^4.3.5"

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -47,15 +47,14 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
-    "hono-crud": "workspace:*"
-  },
   "peerDependencies": {
     "hono": ">=4.11.7 <5",
+    "hono-crud": "workspace:^",
     "zod": ">=4.0.0"
   },
   "devDependencies": {
-    "hono": "^4.11.4",
+    "hono": "^4.11.7",
+    "hono-crud": "workspace:*",
     "tsup": "^8.4.0",
     "typescript": "^5.8.3",
     "zod": "^4.3.5"

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -47,14 +47,12 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
-    "hono-crud": "workspace:*"
-  },
   "peerDependencies": {
     "@prisma/adapter-pg": ">=5.0.0",
     "@prisma/client": ">=5.0.0",
     "fastest-levenshtein": ">=1.0.0",
     "hono": ">=4.11.7 <5",
+    "hono-crud": "workspace:^",
     "pluralize": ">=8.0.0",
     "zod": ">=4.0.0"
   },
@@ -76,7 +74,8 @@
     "@prisma/client": "^7.2.0",
     "@types/pluralize": "^0.0.33",
     "fastest-levenshtein": "^1.0.16",
-    "hono": "^4.11.4",
+    "hono": "^4.11.7",
+    "hono-crud": "workspace:*",
     "pluralize": "^8.0.0",
     "tsup": "^8.4.0",
     "typescript": "^5.8.3",

--- a/packages/rate-limit/package.json
+++ b/packages/rate-limit/package.json
@@ -50,14 +50,13 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
-    "hono-crud": "workspace:*"
-  },
   "peerDependencies": {
-    "hono": ">=4.11.7 <5"
+    "hono": ">=4.11.7 <5",
+    "hono-crud": "workspace:^"
   },
   "devDependencies": {
-    "hono": "^4.11.4",
+    "hono": "^4.11.7",
+    "hono-crud": "workspace:*",
     "tsup": "^8.4.0",
     "typescript": "^5.8.3"
   }

--- a/packages/scalar/package.json
+++ b/packages/scalar/package.json
@@ -55,7 +55,7 @@
     "hono": ">=4.11.7 <5"
   },
   "devDependencies": {
-    "hono": "^4.11.4",
+    "hono": "^4.11.7",
     "tsup": "^8.4.0",
     "typescript": "^5.8.3"
   }

--- a/packages/swagger/package.json
+++ b/packages/swagger/package.json
@@ -56,7 +56,7 @@
     "hono": ">=4.11.7 <5"
   },
   "devDependencies": {
-    "hono": "^4.11.4",
+    "hono": "^4.11.7",
     "tsup": "^8.4.0",
     "typescript": "^5.8.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,7 +84,7 @@ importers:
         specifier: ^0.8.3
         version: 0.8.3(drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260426.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@7.3.0(prisma@7.3.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.16.0)(mysql2@3.15.3)(pg@8.17.2)(postgres@3.4.7)(prisma@7.3.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)))(zod@4.3.6)
       hono:
-        specifier: ^4.11.4
+        specifier: ^4.11.7
         version: 4.11.7
       hono-crud:
         specifier: workspace:*
@@ -132,7 +132,7 @@ importers:
         specifier: ^1.19.9
         version: 1.19.9(hono@4.11.7)
       hono:
-        specifier: ^4.11.4
+        specifier: ^4.11.7
         version: 4.11.7
       hono-crud:
         specifier: workspace:*
@@ -152,14 +152,13 @@ importers:
         version: 5.9.3
 
   packages/cache:
-    dependencies:
+    devDependencies:
+      hono:
+        specifier: ^4.11.7
+        version: 4.11.7
       hono-crud:
         specifier: workspace:*
         version: link:../core
-    devDependencies:
-      hono:
-        specifier: ^4.11.4
-        version: 4.11.7
       tsup:
         specifier: ^8.4.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -174,7 +173,7 @@ importers:
         version: 1.2.0(hono@4.11.7)(zod@4.3.6)
     devDependencies:
       hono:
-        specifier: ^4.11.4
+        specifier: ^4.11.7
         version: 4.11.7
       tsup:
         specifier: ^8.4.0
@@ -187,10 +186,6 @@ importers:
         version: 4.3.6
 
   packages/drizzle:
-    dependencies:
-      hono-crud:
-        specifier: workspace:*
-        version: link:../core
     devDependencies:
       drizzle-orm:
         specifier: ^0.45.1
@@ -199,8 +194,11 @@ importers:
         specifier: ^0.8.3
         version: 0.8.3(drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260426.1)(@electric-sql/pglite@0.3.15)(@libsql/client@0.15.15)(@prisma/client@7.3.0(prisma@7.3.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.16.0)(mysql2@3.15.3)(pg@8.17.2)(postgres@3.4.7)(prisma@7.3.0(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)))(zod@4.3.6)
       hono:
-        specifier: ^4.11.4
+        specifier: ^4.11.7
         version: 4.11.7
+      hono-crud:
+        specifier: workspace:*
+        version: link:../core
       tsup:
         specifier: ^8.4.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -214,7 +212,7 @@ importers:
   packages/health:
     devDependencies:
       hono:
-        specifier: ^4.11.4
+        specifier: ^4.11.7
         version: 4.11.7
       tsup:
         specifier: ^8.4.0
@@ -224,14 +222,13 @@ importers:
         version: 5.9.3
 
   packages/idempotency:
-    dependencies:
+    devDependencies:
+      hono:
+        specifier: ^4.11.7
+        version: 4.11.7
       hono-crud:
         specifier: workspace:*
         version: link:../core
-    devDependencies:
-      hono:
-        specifier: ^4.11.4
-        version: 4.11.7
       tsup:
         specifier: ^8.4.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -244,16 +241,16 @@ importers:
       '@hono/mcp':
         specifier: ^0.3.0
         version: 0.3.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(hono-rate-limiter@0.5.3(hono@4.11.7))(hono@4.11.7)(zod@4.3.6)
-      hono-crud:
-        specifier: workspace:*
-        version: link:../core
     devDependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
       hono:
-        specifier: ^4.11.4
+        specifier: ^4.11.7
         version: 4.11.7
+      hono-crud:
+        specifier: workspace:*
+        version: link:../core
       tsup:
         specifier: ^8.4.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -265,14 +262,13 @@ importers:
         version: 4.3.6
 
   packages/memory:
-    dependencies:
+    devDependencies:
+      hono:
+        specifier: ^4.11.7
+        version: 4.11.7
       hono-crud:
         specifier: workspace:*
         version: link:../core
-    devDependencies:
-      hono:
-        specifier: ^4.11.4
-        version: 4.11.7
       tsup:
         specifier: ^8.4.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -288,9 +284,6 @@ importers:
       '@prisma/adapter-pg':
         specifier: '>=5.0.0'
         version: 7.3.0
-      hono-crud:
-        specifier: workspace:*
-        version: link:../core
     devDependencies:
       '@prisma/client':
         specifier: ^7.2.0
@@ -302,8 +295,11 @@ importers:
         specifier: ^1.0.16
         version: 1.0.16
       hono:
-        specifier: ^4.11.4
+        specifier: ^4.11.7
         version: 4.11.7
+      hono-crud:
+        specifier: workspace:*
+        version: link:../core
       pluralize:
         specifier: ^8.0.0
         version: 8.0.0
@@ -318,14 +314,13 @@ importers:
         version: 4.3.6
 
   packages/rate-limit:
-    dependencies:
+    devDependencies:
+      hono:
+        specifier: ^4.11.7
+        version: 4.11.7
       hono-crud:
         specifier: workspace:*
         version: link:../core
-    devDependencies:
-      hono:
-        specifier: ^4.11.4
-        version: 4.11.7
       tsup:
         specifier: ^8.4.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -340,7 +335,7 @@ importers:
         version: 0.9.38(hono@4.11.7)
     devDependencies:
       hono:
-        specifier: ^4.11.4
+        specifier: ^4.11.7
         version: 4.11.7
       tsup:
         specifier: ^8.4.0
@@ -356,7 +351,7 @@ importers:
         version: 0.5.3(hono@4.11.7)
     devDependencies:
       hono:
-        specifier: ^4.11.4
+        specifier: ^4.11.7
         version: 4.11.7
       tsup:
         specifier: ^8.4.0


### PR DESCRIPTION
## Summary

Batch 1 of the 2026-06-12 drift/consolidation audit (9 batches planned).

All 7 hono-crud-consuming satellites (`cache`, `rate-limit`, `idempotency`, `memory`, `drizzle`, `prisma`, `mcp`) declared `"hono-crud": "workspace:*"` under `dependencies`, which pnpm publishes as an **exact pin** (verified live: `npm view @hono-crud/rate-limit dependencies` → `{"hono-crud": "0.13.13"}`). The moment an app's core version differs from the pin, npm/pnpm install **two physical copies** of hono-crud:

- Satellite exceptions re-wrap through `createErrorHandler`'s HTTPException path with corrupted error codes — a `RateLimitExceededException` still returns 429 but as `HTTP_ERROR` instead of `RATE_LIMIT_EXCEEDED`, with `details.retryAfter` dropped (breaks any client branching on documented codes).
- `setLogger()` on the app's copy never reaches drizzle/cache/mcp/rate-limit logging (`currentLogger` module singleton duplicated).

### Changes

- `hono-crud` moved to `peerDependencies` as `workspace:^` (publishes as `^0.13.x`) + `devDependencies` `workspace:*` for local dev/typecheck. npm ≥7 / pnpm ≥8 auto-install peers, so consumer installs are unchanged — the resolver is now forced to dedupe onto the app's single copy.
- **Same PR, load-bearing**: `.changeset/config.json` gains `___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.onlyUpdatePeerDependentsWhenOutOfRange: true`. Without it, Changesets major-bumps every peer-dependent satellite to 1.0.0 on the next core release.
- hono devDependency floor `^4.11.4` → `^4.11.7` everywhere (matches the declared peer floor `>=4.11.7 <5`); mcp zod peer spelling unified to `>=4.0.0`.
- README claims corrected: `hono >= 4.11.7 <5` (was `>= 4.0.0`), Node `>= 20.19` (was `>= 20`).

## Verification

- `pnpm -r build`, `pnpm -r typecheck`, `test:unit` (1097), `test:workers` (42), `example:local` (real-consumer file-install simulation) — all green.
- `pnpm pack` tarball of rate-limit: `peerDependencies: { "hono-crud": "^0.13.13" }`, no `dependencies` block.
- Simulated next Version PR (`changeset version` with a dummy core patch): core → 0.13.14, satellites take **patch bumps only** (no 1.0.0 majors), peer ranges untouched.