### PR TITLE
refactor!: feature subpaths canonical, root barrel = CRUD core, curated /internal

### DIFF
--- a/.changeset/export-surface-rewrite.md
+++ b/.changeset/export-surface-rewrite.md
@@ -1,0 +1,39 @@
+---
+"hono-crud": patch
+"@hono-crud/memory": patch
+"@hono-crud/mcp": patch
+---
+
+BREAKING: export-surface rewrite — the root barrel owns only the CRUD core; every feature family is importable only from its subpath.
+
+The rule: each `hono-crud/<feature>` subpath barrel is the complete canonical surface of its feature family; the root `'hono-crud'` barrel owns only the CRUD core (model/meta, router/registrar, endpoint classes + result types, exceptions/error-handler, generic context helpers, core infra utils, OpenAPI utilities) and never exports renamed aliases; `hono-crud/internal` is now an explicit curated list (no `export *`).
+
+Evicted from the root barrel (import from the subpath instead):
+
+- `hono-crud/auth` — all middleware/guards/storage/validators/JWT-claims plus the auth context accessors (`getUser`, `getUserId`, `hasRole`, …) and types (`AuthEnv`, `JWTClaims`, `ApprovalStorage`, …).
+- `hono-crud/logging` — `createLoggingMiddleware`, storage setters/getters, redact/extract/truncate utilities, `MemoryLoggingStorage`, `getRequestStartTime`, logging types. (`getRequestId`/`generateRequestId` remain on the root as generic context helpers.)
+- `hono-crud/storage` — `createStorageMiddleware` + per-feature storage middlewares, `getStorage(ctx, key)` and resolvers, `StorageRegistry`, `StorageEnv`, storage contracts.
+- `hono-crud/events` — `CrudEventEmitter`, emitter setters/getters, `registerWebhooks`, `CRUD_EVENT_TYPES`, event/webhook types.
+- `hono-crud/serialization` — `applyProfile` family, `SerializationProfile`/`SerializationConfig`.
+- `hono-crud/encryption` — encrypt/decrypt helpers, `StaticKeyProvider`, `encryptedValueSchema`, encryption types.
+- `hono-crud/api-version` — `apiVersion`, `getApiVersion`, `getApiVersionConfig`, `apiVersionedResponse`, versioning-strategy types.
+- `hono-crud/audit` — `AuditLogger`, `MemoryAuditLogStorage`, `createAuditLogger`, audit storage setters/getters, and (newly on the barrel) `getAuditConfig` + `calculateChanges`.
+- `hono-crud/versioning` — `VersionManager`, `MemoryVersioningStorage`, `createVersionManager`, versioning storage setters/getters, and (newly on the barrel) `getVersioningConfig`.
+- `hono-crud/multi-tenant` — `multiTenant`, `TenantEnv`, `MultiTenantMiddlewareConfig`, and (newly on the barrel) `getMultiTenantConfig` + `extractTenantId`.
+- `hono-crud/functional` — `createCreate`/`createList`/`createRead`/`createUpdate`/`createDelete` and their config types.
+- `hono-crud/builder` (new subpath) — `crud` and the `*Builder` classes.
+- `hono-crud/config` — the endpoint-config types (`CreateEndpointConfig`, …, `EndpointsConfig`, `AdapterBundle`, `GeneratedEndpoints`). `defineEndpoints` (the function) stays on the root.
+
+Deleted outright (no new home):
+
+- The rename aliases `getContextRequestId`, `matchLoggingPath`, `extractLoggingUserId`, `LoggingPathPattern` — use `getRequestId` (root), `matchPath`, `extractUserId`, `PathPattern` (all on `hono-crud/logging`).
+- The 17 `Config*Endpoint` type aliases (`ConfigCreateEndpoint`, …) — use the original `*EndpointConfig` names from `hono-crud/config`.
+- `getHandlerForApp` is no longer on the public barrel (it remains module-level in core).
+
+`@hono-crud/memory`: the `getStorage` export alias is removed — use `getStore`.
+
+`@hono-crud/mcp`: now imports exclusively from `hono-crud/internal` (no behavior change).
+
+The model-meta contract types (`AuditConfig`, `VersioningConfig`, `MultiTenantConfig`, `SoftDeleteConfig`, `AuditLogEntry`, `VersionHistoryEntry`, …) stay on the root barrel — they are fields of the model meta, distinct from the feature runtime.
+
+(Published as a patch per this repo's pre-1.0 versioning policy.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,22 @@ This pattern avoids coupling to specific Drizzle versions while maintaining inte
 - Documented exceptions (legacy, rename only with owner sign-off): RouterOptions,
   RegisterCrudOptions, CreateDrizzleCrudOptions, PerTenantOpenApiOptions.
 
+## Export Surface Doctrine
+
+1. **Each feature subpath barrel is the complete canonical surface of its feature.** If a
+   symbol belongs to a feature family (auth, logging, storage, events, serialization,
+   encryption, api-version, audit, versioning, multi-tenant, functional, builder, config,
+   health, cloudflare), it is importable from that subpath and nowhere else.
+2. **The root barrel (`hono-crud`) owns only the CRUD core** — model/meta, router/registrar,
+   endpoint classes and their result types, exceptions/error-handler, generic context helpers,
+   core infra utils, and OpenAPI utilities. It may never export renamed aliases.
+3. **`/internal` is an explicit curated list** — `export * from './index'` is forbidden in
+   `packages/core/src/internal.ts`. Every re-export is named, grouped by category.
+4. **First-party satellites import only from `hono-crud/internal`** (plus their own deps) —
+   never from the root barrel or feature subpaths.
+5. **Package categories:** a separate npm package requires vendor-dep isolation, or a DB
+   adapter, or a core-extension. Anything else is a core subpath, not a new package.
+
 ## Edge Runtime Compatibility
 
 This library targets edge runtimes (Cloudflare Workers, Deno, Bun). All library source code in `src/` must be edge-safe.

--- a/README.md
+++ b/README.md
@@ -165,7 +165,9 @@ hono-crud supports four ways to define endpoints. All produce classes compatible
 | **Config-based** | Declarative, all-in-one | `defineEndpoints({ meta, list: { ... } }, MemoryAdapters)` |
 
 ```typescript
-import { createList, crud, defineEndpoints } from 'hono-crud';
+import { defineEndpoints } from 'hono-crud';
+import { crud } from 'hono-crud/builder';
+import { createList } from 'hono-crud/functional';
 import { MemoryAdapters } from '@hono-crud/memory';
 
 // Functional
@@ -260,7 +262,7 @@ See [docs/database-adapters.md](./docs/database-adapters.md) for complete setup 
 Built-in JWT and API Key middleware with composable guards:
 
 ```typescript
-import { createJWTMiddleware, requireRoles, requireAuthenticated, anyOf } from 'hono-crud';
+import { createJWTMiddleware, requireRoles, requireAuthenticated, anyOf } from 'hono-crud/auth';
 
 // JWT middleware
 app.use('/api/*', createJWTMiddleware({
@@ -320,7 +322,7 @@ See [docs/rate-limiting.md](./docs/rate-limiting.md).
 ### Logging
 
 ```typescript
-import { createLoggingMiddleware, setLoggingStorage, MemoryLoggingStorage } from 'hono-crud';
+import { createLoggingMiddleware, setLoggingStorage, MemoryLoggingStorage } from 'hono-crud/logging';
 
 setLoggingStorage(new MemoryLoggingStorage());
 
@@ -444,9 +446,12 @@ See [docs/advanced-features.md](./docs/advanced-features.md) for examples of eve
 
 ### Subpath Imports
 
-Several core features are also exposed as tree-shakeable subpaths, so apps that only need one feature can import it directly without pulling in the rest of the library:
+The `'hono-crud'` root barrel owns the CRUD core (models, endpoints, registrar, exceptions, OpenAPI utilities). Every feature family lives only on its tree-shakeable subpath:
 
 ```typescript
+import { createJWTMiddleware, requireRoles } from 'hono-crud/auth';
+import { createLoggingMiddleware, MemoryLoggingStorage } from 'hono-crud/logging';
+import { createStorageMiddleware, type StorageEnv } from 'hono-crud/storage';
 import { multiTenant } from 'hono-crud/multi-tenant';
 import { createAuditLogger, MemoryAuditLogStorage } from 'hono-crud/audit';
 import { VersionManager, MemoryVersioningStorage } from 'hono-crud/versioning';
@@ -454,10 +459,11 @@ import { CrudEventEmitter, registerWebhooks } from 'hono-crud/events';
 import { encryptFields, decryptFields, StaticKeyProvider } from 'hono-crud/encryption';
 import { applyProfile, type SerializationProfile } from 'hono-crud/serialization';
 import { apiVersion, getApiVersion } from 'hono-crud/api-version';
+import { createCreate, createList } from 'hono-crud/functional';
+import { crud } from 'hono-crud/builder';
 import { createHealthRoutes } from 'hono-crud/health';
+import { getWaitUntil } from 'hono-crud/cloudflare';
 ```
-
-These symbols also remain available from the `'hono-crud'` barrel for convenience (health is subpath-only).
 
 Idempotency ships as its own package:
 

--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -246,14 +246,16 @@ Track record version history with rollback support.
 
 ```typescript
 import {
-  createVersionManager,
-  setVersioningStorage,
-  MemoryVersioningStorage,
   VersionHistoryEndpoint,
   VersionReadEndpoint,
   VersionCompareEndpoint,
   VersionRollbackEndpoint,
 } from 'hono-crud';
+import {
+  createVersionManager,
+  setVersioningStorage,
+  MemoryVersioningStorage,
+} from 'hono-crud/versioning';
 
 // Setup storage
 setVersioningStorage(new MemoryVersioningStorage());
@@ -303,7 +305,7 @@ import {
   createAuditLogger,
   setAuditStorage,
   MemoryAuditLogStorage,
-} from 'hono-crud';
+} from 'hono-crud/audit';
 
 // Setup storage
 setAuditStorage(new MemoryAuditLogStorage());
@@ -481,7 +483,7 @@ Event emitter for CRUD operations with webhook delivery.
 ### Event Emitter
 
 ```typescript
-import { CrudEventEmitter, setEventEmitter, getEventEmitter } from 'hono-crud';
+import { CrudEventEmitter, setEventEmitter, getEventEmitter } from 'hono-crud/events';
 
 const events = new CrudEventEmitter();
 setEventEmitter(events);
@@ -505,7 +507,7 @@ events.onAny((event) => {
 ### Webhooks
 
 ```typescript
-import { registerWebhooks } from 'hono-crud';
+import { registerWebhooks } from 'hono-crud/events';
 
 registerWebhooks({
   endpoints: [
@@ -534,7 +536,7 @@ import {
   decryptFields,
   StaticKeyProvider,
   type FieldEncryptionConfig,
-} from 'hono-crud';
+} from 'hono-crud/encryption';
 
 const keyProvider = new StaticKeyProvider(process.env.ENCRYPTION_KEY!);
 
@@ -594,7 +596,7 @@ the idempotency middleware resolves from (context storage takes priority over
 the global one):
 
 ```typescript
-import { createStorageMiddleware } from 'hono-crud';
+import { createStorageMiddleware } from 'hono-crud/storage';
 import { MemoryIdempotencyStorage } from '@hono-crud/idempotency';
 
 app.use('*', createStorageMiddleware({
@@ -619,7 +621,7 @@ app.use('*', createStorageMiddleware({
 Isolate data by tenant using header, path, query, or JWT extraction.
 
 ```typescript
-import { multiTenant } from 'hono-crud';
+import { multiTenant } from 'hono-crud/multi-tenant';
 
 // Extract tenant from header (default)
 app.use('/api/*', multiTenant({
@@ -905,7 +907,7 @@ then your route handlers — `apiVersionedResponse()` wraps handlers via
 never runs.
 
 ```typescript
-import { apiVersion, apiVersionedResponse, getApiVersion, getApiVersionConfig } from 'hono-crud';
+import { apiVersion, apiVersionedResponse, getApiVersion, getApiVersionConfig } from 'hono-crud/api-version';
 
 app.use('/api/*', apiVersion({
   versions: [
@@ -942,7 +944,7 @@ Each entry in `versions` is an `ApiVersionConfig` (`version`, optional
 Transform response data based on context (e.g., public vs admin views).
 
 ```typescript
-import { applyProfile, type SerializationProfile } from 'hono-crud';
+import { applyProfile, type SerializationProfile } from 'hono-crud/serialization';
 
 const publicProfile: SerializationProfile = {
   include: ['id', 'name', 'avatar'],

--- a/docs/alternative-api-patterns.md
+++ b/docs/alternative-api-patterns.md
@@ -118,7 +118,7 @@ import {
   createRead,
   createUpdate,
   createDelete,
-} from 'hono-crud';
+} from 'hono-crud/functional';
 ```
 
 ### Basic Usage
@@ -252,7 +252,7 @@ Chainable API with method chaining for readable, discoverable configuration.
 ### Import
 
 ```typescript
-import { crud } from 'hono-crud';
+import { crud } from 'hono-crud/builder';
 ```
 
 ### Basic Usage

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -8,8 +8,8 @@ hono-crud provides JWT and API Key authentication middleware, plus composable au
 
 ```typescript
 import { Hono } from 'hono';
-import { createJWTMiddleware } from 'hono-crud';
-import type { AuthEnv } from 'hono-crud';
+import { createJWTMiddleware } from 'hono-crud/auth';
+import type { AuthEnv } from 'hono-crud/auth';
 
 const app = new Hono<AuthEnv>();
 
@@ -53,7 +53,7 @@ app.use('/api/*', createJWTMiddleware({
 ### Manual Token Verification
 
 ```typescript
-import { verifyJWT, decodeJWT } from 'hono-crud';
+import { verifyJWT, decodeJWT } from 'hono-crud/auth';
 
 // Verify and decode
 const claims = await verifyJWT(token, { secret: process.env.JWT_SECRET! });
@@ -72,7 +72,7 @@ import {
   MemoryAPIKeyStorage,
   setAPIKeyStorage,
   generateAPIKey,
-} from 'hono-crud';
+} from 'hono-crud/auth';
 
 // Setup storage
 const apiKeyStorage = new MemoryAPIKeyStorage();
@@ -133,7 +133,7 @@ app.use('/api/*', createAPIKeyMiddleware({
 Support both JWT and API Key on the same routes:
 
 ```typescript
-import { createAuthMiddleware, optionalAuth } from 'hono-crud';
+import { createAuthMiddleware, optionalAuth } from 'hono-crud/auth';
 
 // Require one of JWT or API Key
 app.use('/api/*', createAuthMiddleware({
@@ -161,7 +161,7 @@ Guards are Hono middleware that check authorization after authentication.
 ### Role Guards
 
 ```typescript
-import { requireRoles, requireAllRoles, requireAuthenticated } from 'hono-crud';
+import { requireRoles, requireAllRoles, requireAuthenticated } from 'hono-crud/auth';
 
 // Require at least one of the specified roles (OR)
 app.use('/admin/*', requireRoles('admin', 'super-admin'));
@@ -176,7 +176,7 @@ app.use('/api/*', requireAuthenticated());
 ### Permission Guards
 
 ```typescript
-import { requirePermissions, requireAnyPermission } from 'hono-crud';
+import { requirePermissions, requireAnyPermission } from 'hono-crud/auth';
 
 // Require ALL permissions
 app.use('/users/*', requirePermissions('users:read', 'users:write'));
@@ -188,7 +188,7 @@ app.use('/data/*', requireAnyPermission('data:read', 'data:admin'));
 ### Custom Guards
 
 ```typescript
-import { requireAuth, requireOwnership, requireOwnershipOrRole } from 'hono-crud';
+import { requireAuth, requireOwnership, requireOwnershipOrRole } from 'hono-crud/auth';
 
 // Custom authorization check
 app.use('/premium/*', requireAuth((user, ctx) => {
@@ -211,7 +211,7 @@ app.use('/posts/:id/*', requireOwnershipOrRole(
 ### Guard Composition
 
 ```typescript
-import { allOf, anyOf, denyAll, allowAll } from 'hono-crud';
+import { allOf, anyOf, denyAll, allowAll } from 'hono-crud/auth';
 
 // ALL guards must pass (AND)
 app.use('/secure/*', allOf(
@@ -237,7 +237,8 @@ app.use('/public/*', allowAll());
 ### Guards with registerCrud
 
 ```typescript
-import { registerCrud, requireAuthenticated, requireRoles } from 'hono-crud';
+import { registerCrud } from 'hono-crud';
+import { requireAuthenticated, requireRoles } from 'hono-crud/auth';
 
 registerCrud(app, '/users', {
   create: UserCreate,

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -33,7 +33,7 @@ For multi-tenant or per-request storage, inject the storage through
 cache mixin resolves from (context storage takes priority over the global one):
 
 ```typescript
-import { createStorageMiddleware } from 'hono-crud';
+import { createStorageMiddleware } from 'hono-crud/storage';
 import { MemoryCacheStorage } from '@hono-crud/cache';
 
 app.use('*', createStorageMiddleware({

--- a/docs/database-adapters.md
+++ b/docs/database-adapters.md
@@ -102,13 +102,13 @@ registerCrud(app, '/tasks', {
 ### Storage Helpers
 
 ```typescript
-import { clearStorage, getStorage } from '@hono-crud/memory';
+import { clearStorage, getStore } from '@hono-crud/memory';
 
 // Clear all in-memory data
 clearStorage();
 
 // Access raw storage for a table
-const store = getStorage<Task>('tasks');
+const store = getStore<Task>('tasks');
 store.set('some-id', { id: 'some-id', title: 'Test', done: false });
 ```
 

--- a/docs/hooks-and-approvals.md
+++ b/docs/hooks-and-approvals.md
@@ -617,7 +617,7 @@ CREATE INDEX idx_pending_expiring  ON pending_actions(expires_at) WHERE status =
 ```
 
 ```ts
-import type { ApprovalStorage, PendingAction } from 'hono-crud';
+import type { ApprovalStorage, PendingAction } from 'hono-crud/auth';
 import type { PgClient } from 'pg';
 
 export class PostgresApprovalStorage implements ApprovalStorage {
@@ -990,7 +990,8 @@ notify the approver (Slack, email, push). Two patterns again.
 Wrap any `ApprovalStorage` implementation with a notifier:
 
 ```ts
-import type { ApprovalStorage, PendingAction, CrudEventEmitter } from 'hono-crud';
+import type { ApprovalStorage, PendingAction } from 'hono-crud/auth';
+import type { CrudEventEmitter } from 'hono-crud/events';
 
 export class NotifyingApprovalStorage implements ApprovalStorage {
   constructor(

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -11,7 +11,7 @@ import {
   createLoggingMiddleware,
   setLoggingStorage,
   MemoryLoggingStorage,
-} from 'hono-crud';
+} from 'hono-crud/logging';
 
 // Set storage (required before middleware runs)
 setLoggingStorage(new MemoryLoggingStorage({ maxEntries: 10000 }));
@@ -25,8 +25,8 @@ context var that the logging middleware resolves from (context storage takes
 priority over the global one):
 
 ```typescript
-import { createStorageMiddleware } from 'hono-crud';
-import { MemoryLoggingStorage } from 'hono-crud';
+import { createStorageMiddleware } from 'hono-crud/storage';
+import { MemoryLoggingStorage } from 'hono-crud/logging';
 
 app.use('*', createStorageMiddleware({
   loggingStorage: new MemoryLoggingStorage(),
@@ -114,7 +114,7 @@ app.use('*', createLoggingMiddleware({
 ## Accessing Request Context
 
 ```typescript
-import { getRequestId, getRequestStartTime } from 'hono-crud';
+import { getRequestId, getRequestStartTime } from 'hono-crud/logging';
 
 app.get('/api/data', (c) => {
   const requestId = getRequestId(c);       // string
@@ -134,7 +134,7 @@ app.get('/api/data', (c) => {
 Implement the `LoggingStorage` interface for custom backends:
 
 ```typescript
-import type { LoggingStorage, LogEntry, LogQueryOptions } from 'hono-crud';
+import type { LoggingStorage, LogEntry, LogQueryOptions } from 'hono-crud/logging';
 
 class PostgresLoggingStorage implements LoggingStorage {
   async store(entry: LogEntry): Promise<void> {
@@ -173,7 +173,7 @@ Sensitive values are replaced with `'[REDACTED]'` in logged output. Redaction ap
 ### Using Redaction Utilities Directly
 
 ```typescript
-import { redactHeaders, redactObject, shouldRedact } from 'hono-crud';
+import { redactHeaders, redactObject, shouldRedact } from 'hono-crud/logging';
 
 // Redact specific headers
 const safeHeaders = redactHeaders(

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -41,7 +41,7 @@ rate-limit middleware resolves from (context storage takes priority over the
 global one):
 
 ```typescript
-import { createStorageMiddleware } from 'hono-crud';
+import { createStorageMiddleware } from 'hono-crud/storage';
 import { MemoryRateLimitStorage } from '@hono-crud/rate-limit';
 
 app.use('*', createStorageMiddleware({

--- a/examples/drizzle/d1-crud.ts
+++ b/examples/drizzle/d1-crud.ts
@@ -35,14 +35,8 @@ import { swaggerUI } from '@hono-crud/swagger';
 import { drizzle } from 'drizzle-orm/d1';
 import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 import { Hono } from 'hono';
-import {
-  type StorageEnv,
-  createStorageMiddleware,
-  defineMeta,
-  defineModel,
-  fromHono,
-  registerCrud,
-} from 'hono-crud';
+import { defineMeta, defineModel, fromHono, registerCrud } from 'hono-crud';
+import { type StorageEnv, createStorageMiddleware } from 'hono-crud/storage';
 import { z } from 'zod';
 
 // ============================================================================

--- a/examples/local-consumer/src/app.ts
+++ b/examples/local-consumer/src/app.ts
@@ -24,36 +24,29 @@ import {
   MemoryVersionReadEndpoint,
   MemoryVersionRollbackEndpoint,
   clearStorage,
-  getStorage,
+  getStore,
 } from '@hono-crud/memory';
 import { MemoryRateLimitStorage, createRateLimitMiddleware } from '@hono-crud/rate-limit';
 import { swaggerUI } from '@hono-crud/swagger';
 import { type Context, Hono, type MiddlewareHandler } from 'hono';
 import {
-  type AuthEnv,
-  type AuthUser,
-  CrudEventEmitter,
-  type CrudEventPayload,
-  MemoryAuditLogStorage,
-  MemoryVersioningStorage,
   type ResponseEnvelope,
-  type SerializationProfile,
-  StaticKeyProvider,
-  apiVersion,
-  applyProfile,
   createErrorHandler,
-  createStorageMiddleware,
-  decryptValue,
   defineMeta,
   defineModel,
-  encryptValue,
   fromHono,
-  getApiVersion,
-  multiTenant,
   registerCrud,
-  requireRoles,
 } from 'hono-crud';
+import { apiVersion, getApiVersion } from 'hono-crud/api-version';
+import { MemoryAuditLogStorage } from 'hono-crud/audit';
+import { type AuthEnv, type AuthUser, requireRoles } from 'hono-crud/auth';
+import { StaticKeyProvider, decryptValue, encryptValue } from 'hono-crud/encryption';
+import { CrudEventEmitter, type CrudEventPayload } from 'hono-crud/events';
 import { createHealthRoutes } from 'hono-crud/health';
+import { multiTenant } from 'hono-crud/multi-tenant';
+import { type SerializationProfile, applyProfile } from 'hono-crud/serialization';
+import { createStorageMiddleware } from 'hono-crud/storage';
+import { MemoryVersioningStorage } from 'hono-crud/versioning';
 import { z } from 'zod';
 
 type AppEnv = AuthEnv & {
@@ -627,8 +620,8 @@ export function createApp() {
     return c.json(applyProfile(body, publicUserProfile));
   });
   app.post('/seed', (c) => {
-    const userStore = getStorage<User>('users');
-    const postStore = getStorage<Post>('posts');
+    const userStore = getStore<User>('users');
+    const postStore = getStore<Post>('posts');
     const userId = '00000000-0000-4000-8000-000000000001';
     const postId = '00000000-0000-4000-8000-000000000101';
     userStore.set(userId, {
@@ -662,7 +655,7 @@ export function createApp() {
       readyPath: '/ready',
       version: 'local-consumer',
       checks: [
-        { name: 'memory-users', check: async () => `${getStorage<User>('users').size} users` },
+        { name: 'memory-users', check: async () => `${getStore<User>('users').size} users` },
         {
           name: 'memory-cache',
           check: async () => `${cacheStorage.getStats().size} cache entries`,

--- a/examples/memory/alternative-apis.ts
+++ b/examples/memory/alternative-apis.ts
@@ -24,22 +24,17 @@ import {
 import { swaggerUI } from '@hono-crud/swagger';
 import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
+import { defineEndpoints, defineMeta, defineModel, fromHono, registerCrud } from 'hono-crud';
+// Builder/Fluent API
+import { crud } from 'hono-crud/builder';
+// Function-based API
 import {
-  // Function-based API
   createCreate,
   createDelete,
   createList,
   createRead,
   createUpdate,
-  // Builder/Fluent API
-  crud,
-  // Config-based API
-  defineEndpoints,
-  defineMeta,
-  defineModel,
-  fromHono,
-  registerCrud,
-} from 'hono-crud';
+} from 'hono-crud/functional';
 import { z } from 'zod';
 
 // Clear storage on start

--- a/examples/memory/audit-logging.ts
+++ b/examples/memory/audit-logging.ts
@@ -12,16 +12,13 @@ import {
  * to track changes to your data.
  */
 import { Hono } from 'hono';
+import { type AuditLogEntry, defineMeta, defineModel, fromHono } from 'hono-crud';
 import {
-  type AuditLogEntry,
   type AuditLogStorage,
   MemoryAuditLogStorage,
-  defineMeta,
-  defineModel,
-  fromHono,
   getAuditStorage,
   setAuditStorage,
-} from 'hono-crud';
+} from 'hono-crud/audit';
 import { z } from 'zod';
 
 type AppEnv = {

--- a/examples/memory/cascade-delete.ts
+++ b/examples/memory/cascade-delete.ts
@@ -14,7 +14,7 @@ import {
   MemoryDeleteEndpoint,
   MemoryListEndpoint,
   clearStorage,
-  getStorage,
+  getStore,
 } from '@hono-crud/memory';
 import { Hono } from 'hono';
 import { defineMeta, defineModel, fromHono } from 'hono-crud';
@@ -196,13 +196,13 @@ app.delete('/authors-restrict/:id', AuthorRestrictDelete);
 async function main() {
   console.log('=== Cascade Delete Demo ===\n');
 
-  const authorStore = getStorage<Author>('authors');
-  const bookStore = getStorage<Book>('books');
-  const reviewStore = getStorage<Review>('reviews');
-  const authorSetNullStore = getStorage<Author>('authors_setnull');
-  const bookSetNullStore = getStorage<Book>('books_setnull');
-  const authorRestrictStore = getStorage<Author>('authors_restrict');
-  const bookRestrictStore = getStorage<Book>('books_restrict');
+  const authorStore = getStore<Author>('authors');
+  const bookStore = getStore<Book>('books');
+  const reviewStore = getStore<Review>('reviews');
+  const authorSetNullStore = getStore<Author>('authors_setnull');
+  const bookSetNullStore = getStore<Book>('books_setnull');
+  const authorRestrictStore = getStore<Author>('authors_restrict');
+  const bookRestrictStore = getStore<Book>('books_restrict');
 
   // =========================================================================
   // Demo 1: Cascade Delete

--- a/examples/memory/comprehensive.ts
+++ b/examples/memory/comprehensive.ts
@@ -27,7 +27,7 @@ import {
   MemoryUpdateEndpoint,
   MemoryUpsertEndpoint,
   clearStorage,
-  getStorage,
+  getStore,
 } from '@hono-crud/memory';
 import { redocUI, swaggerUI } from '@hono-crud/swagger';
 import { serve } from '@hono/node-server';
@@ -427,11 +427,11 @@ app.put('/categories', CategoryUpsert);
 app.get('/seed', async (c) => {
   clearStorage();
 
-  const userStore = getStorage<User>('users');
-  const profileStore = getStorage<Profile>('profiles');
-  const postStore = getStorage<Post>('posts');
-  const commentStore = getStorage<Comment>('comments');
-  const categoryStore = getStorage<Category>('categories');
+  const userStore = getStore<User>('users');
+  const profileStore = getStore<Profile>('profiles');
+  const postStore = getStore<Post>('posts');
+  const commentStore = getStore<Comment>('comments');
+  const categoryStore = getStore<Category>('categories');
 
   // Seed users
   const users: User[] = [

--- a/examples/memory/computed-fields.ts
+++ b/examples/memory/computed-fields.ts
@@ -20,7 +20,7 @@ import {
   MemoryReadEndpoint,
   MemoryUpdateEndpoint,
   clearStorage,
-  getStorage,
+  getStore,
 } from '@hono-crud/memory';
 import { swaggerUI } from '@hono-crud/swagger';
 import { serve } from '@hono/node-server';
@@ -250,7 +250,7 @@ app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
 // ============================================================================
 
 function addSampleData() {
-  const userStore = getStorage<User>('users');
+  const userStore = getStore<User>('users');
 
   const sampleUsers: User[] = [
     {

--- a/examples/memory/field-selection.ts
+++ b/examples/memory/field-selection.ts
@@ -19,7 +19,7 @@ import {
   MemoryReadEndpoint,
   MemoryUpdateEndpoint,
   clearStorage,
-  getStorage,
+  getStore,
 } from '@hono-crud/memory';
 import { swaggerUI } from '@hono-crud/swagger';
 import { serve } from '@hono/node-server';
@@ -267,7 +267,7 @@ app.get('/docs', swaggerUI({ specUrl: '/openapi.json' }));
 // ============================================================================
 
 function addSampleData() {
-  const userStore = getStorage<User>('users');
+  const userStore = getStore<User>('users');
 
   const sampleUsers: User[] = [
     {

--- a/examples/memory/rate-limiting.ts
+++ b/examples/memory/rate-limiting.ts
@@ -29,7 +29,8 @@ import {
 import { swaggerUI } from '@hono-crud/swagger';
 import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
-import { type AuthEnv, defineMeta, defineModel, fromHono, registerCrud } from 'hono-crud';
+import { defineMeta, defineModel, fromHono, registerCrud } from 'hono-crud';
+import type { AuthEnv } from 'hono-crud/auth';
 import { z } from 'zod';
 
 // Clear storage on start

--- a/examples/memory/relations.ts
+++ b/examples/memory/relations.ts
@@ -14,7 +14,7 @@ import {
   MemoryListEndpoint,
   MemoryReadEndpoint,
   clearStorage,
-  getStorage,
+  getStore,
 } from '@hono-crud/memory';
 import { swaggerUI } from '@hono-crud/swagger';
 import { serve } from '@hono/node-server';
@@ -337,7 +337,7 @@ app.get('/seed', async (c) => {
   clearStorage();
 
   // Create users
-  const users = getStorage<z.infer<typeof UserSchema>>('users');
+  const users = getStore<z.infer<typeof UserSchema>>('users');
   const userId1 = 'a0000000-0000-0000-0000-000000000001';
   const userId2 = 'a0000000-0000-0000-0000-000000000002';
 
@@ -355,7 +355,7 @@ app.get('/seed', async (c) => {
   });
 
   // Create profiles
-  const profiles = getStorage<z.infer<typeof ProfileSchema>>('profiles');
+  const profiles = getStore<z.infer<typeof ProfileSchema>>('profiles');
   const profileId1 = 'b0000000-0000-0000-0000-000000000001';
   const profileId2 = 'b0000000-0000-0000-0000-000000000002';
 
@@ -372,7 +372,7 @@ app.get('/seed', async (c) => {
   });
 
   // Create posts
-  const posts = getStorage<z.infer<typeof PostSchema>>('posts');
+  const posts = getStore<z.infer<typeof PostSchema>>('posts');
   const postId1 = 'c0000000-0000-0000-0000-000000000001';
   const postId2 = 'c0000000-0000-0000-0000-000000000002';
 
@@ -392,7 +392,7 @@ app.get('/seed', async (c) => {
   });
 
   // Create comments
-  const comments = getStorage<z.infer<typeof CommentSchema>>('comments');
+  const comments = getStore<z.infer<typeof CommentSchema>>('comments');
   const commentId1 = 'd0000000-0000-0000-0000-000000000001';
   const commentId2 = 'd0000000-0000-0000-0000-000000000002';
 

--- a/examples/memory/versioning.ts
+++ b/examples/memory/versioning.ts
@@ -15,16 +15,13 @@ import {
  * to track the history of changes to your data.
  */
 import { Hono } from 'hono';
+import { type VersionHistoryEntry, defineMeta, defineModel, fromHono } from 'hono-crud';
 import {
   MemoryVersioningStorage,
-  type VersionHistoryEntry,
   type VersioningStorage,
-  defineMeta,
-  defineModel,
-  fromHono,
   getVersioningStorage,
   setVersioningStorage,
-} from 'hono-crud';
+} from 'hono-crud/versioning';
 import { z } from 'zod';
 
 type AppEnv = {

--- a/packages/cache/src/storage/cloudflare-kv.ts
+++ b/packages/cache/src/storage/cloudflare-kv.ts
@@ -40,7 +40,7 @@ export interface KVCacheStorageOptions {
  * @example
  * ```ts
  * import { KVCacheStorage } from '@hono-crud/cache';
- * import { createStorageMiddleware } from 'hono-crud';
+ * import { createStorageMiddleware } from 'hono-crud/storage';
  *
  * app.use('*', async (c, next) => {
  *   const cacheStorage = new KVCacheStorage({ kv: c.env.CACHE_KV });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -73,6 +73,10 @@
       "types": "./dist/functional/index.d.ts",
       "import": "./dist/functional/index.js"
     },
+    "./builder": {
+      "types": "./dist/builder/index.d.ts",
+      "import": "./dist/builder/index.js"
+    },
     "./health": {
       "types": "./dist/health/index.d.ts",
       "import": "./dist/health/index.js"

--- a/packages/core/src/api-version/middleware.ts
+++ b/packages/core/src/api-version/middleware.ts
@@ -36,7 +36,7 @@ function extractFromUrl(ctx: Context, pattern: string): string | undefined {
  * @example
  * ```ts
  * import { Hono } from 'hono';
- * import { apiVersion } from 'hono-crud';
+ * import { apiVersion } from 'hono-crud/api-version';
  *
  * const app = new Hono();
  *

--- a/packages/core/src/audit/index.ts
+++ b/packages/core/src/audit/index.ts
@@ -404,3 +404,7 @@ export function createAuditLogger(
   // The AuditLogger constructor will use resolveAuditStorage internally
   return new AuditLogger(config, storage, ctx);
 }
+
+// Config normalization + change calculation — the audit barrel is the complete
+// canonical surface of the audit family.
+export { calculateChanges, getAuditConfig } from './config';

--- a/packages/core/src/auth/types.ts
+++ b/packages/core/src/auth/types.ts
@@ -93,7 +93,7 @@ export type JWTAlgorithm = (typeof JWT_ALGORITHMS)[number];
  *
  * @example
  * ```ts
- * import { JWTClaimsSchema } from 'hono-crud';
+ * import { JWTClaimsSchema } from 'hono-crud/auth';
  *
  * // Parse and validate claims
  * const result = JWTClaimsSchema.safeParse(decodedPayload);

--- a/packages/core/src/builder/index.ts
+++ b/packages/core/src/builder/index.ts
@@ -5,7 +5,7 @@
  *
  * @example
  * ```ts
- * import { crud } from 'hono-crud';
+ * import { crud } from 'hono-crud/builder';
  * import { MemoryListEndpoint, MemoryCreateEndpoint } from '@hono-crud/memory';
  *
  * const UserList = crud(userMeta).list()

--- a/packages/core/src/cloudflare/index.ts
+++ b/packages/core/src/cloudflare/index.ts
@@ -8,7 +8,7 @@
  * ```ts
  * import type { CloudflareEnv, WaitUntil } from 'hono-crud/cloudflare';
  * import { getWaitUntil } from 'hono-crud/cloudflare';
- * import { registerWebhooks } from 'hono-crud';
+ * import { registerWebhooks } from 'hono-crud/events';
  *
  * type Env = CloudflareEnv<{
  *   DB: D1Database;
@@ -57,7 +57,7 @@ export interface KVNamespace {
  * @example
  * ```ts
  * import { getWaitUntil } from 'hono-crud/cloudflare';
- * import { registerWebhooks } from 'hono-crud';
+ * import { registerWebhooks } from 'hono-crud/events';
  *
  * app.use('*', async (c, next) => {
  *   registerWebhooks({

--- a/packages/core/src/core/openapi.ts
+++ b/packages/core/src/core/openapi.ts
@@ -294,7 +294,8 @@ export class HonoOpenAPIHandler<E extends Env = Env> {
  * @example
  * ```ts
  * import { OpenAPIHono } from '@hono/zod-openapi';
- * import { fromHono, multiTenant } from 'hono-crud';
+ * import { fromHono } from 'hono-crud';
+ * import { multiTenant } from 'hono-crud/multi-tenant';
  *
  * const app = fromHono(new OpenAPIHono());
  *

--- a/packages/core/src/endpoints/subscribe.ts
+++ b/packages/core/src/endpoints/subscribe.ts
@@ -65,7 +65,8 @@ function stripSensitiveFields(data: unknown, excludeFields: string[]): unknown {
  * @example
  * ```ts
  * import { Hono } from 'hono';
- * import { createSubscribeHandler, CrudEventEmitter } from 'hono-crud';
+ * import { createSubscribeHandler } from 'hono-crud';
+ * import { CrudEventEmitter } from 'hono-crud/events';
  *
  * const app = new Hono();
  *

--- a/packages/core/src/events/emitter.ts
+++ b/packages/core/src/events/emitter.ts
@@ -15,7 +15,7 @@ import type {
  *
  * @example
  * ```ts
- * import { CrudEventEmitter } from 'hono-crud';
+ * import { CrudEventEmitter } from 'hono-crud/events';
  *
  * const events = new CrudEventEmitter();
  *

--- a/packages/core/src/events/webhook.ts
+++ b/packages/core/src/events/webhook.ts
@@ -157,7 +157,7 @@ async function deliverToEndpoint(
  *
  * @example
  * ```ts
- * import { registerWebhooks, getEventEmitter } from 'hono-crud';
+ * import { registerWebhooks, getEventEmitter } from 'hono-crud/events';
  *
  * const emitter = getEventEmitter(); // Compatibility global, or pass your own emitter.
  * const unsubscribe = registerWebhooks({

--- a/packages/core/src/functional/index.ts
+++ b/packages/core/src/functional/index.ts
@@ -5,7 +5,7 @@
  *
  * @example
  * ```ts
- * import { createCreate, createList } from 'hono-crud';
+ * import { createCreate, createList } from 'hono-crud/functional';
  * import { MemoryCreateEndpoint, MemoryListEndpoint } from '@hono-crud/memory';
  *
  * const UserCreate = createCreate({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,12 @@
+/**
+ * Public root barrel — owns the CRUD core only.
+ *
+ * Feature families (auth, logging, storage, events, serialization, encryption,
+ * api-version, audit, versioning, multi-tenant, functional, builder, config,
+ * health, cloudflare) live exclusively on their `hono-crud/<feature>` subpaths.
+ * This barrel never exports renamed aliases.
+ */
+
 // Combined environment type
 import type { AuthEnv } from './auth/types';
 import type { LoggingEnv } from './logging/types';
@@ -8,7 +17,7 @@ export type HonoCrudEnv = AuthEnv & LoggingEnv & StorageEnv;
 
 // Core exports
 export { OpenAPIRoute, isRouteClass } from './core/route';
-export { fromHono, HonoOpenAPIHandler, getHandlerForApp } from './core/openapi';
+export { fromHono, HonoOpenAPIHandler } from './core/openapi';
 export type { OpenAPIConfig, RouterOptions, RegisteredRoute } from './core/openapi';
 export { buildPerTenantOpenApi, wrapCacheStorageForOpenApi } from './openapi/lazy';
 export type {
@@ -38,22 +47,6 @@ export type {
   ErrorHook,
   ErrorHandlerConfig,
 } from './core/error-handler';
-export {
-  AuditLogger,
-  MemoryAuditLogStorage,
-  createAuditLogger,
-  setAuditStorage,
-  getAuditStorage,
-} from './audit';
-export type { AuditLogStorage } from './audit';
-export {
-  VersionManager,
-  MemoryVersioningStorage,
-  createVersionManager,
-  setVersioningStorage,
-  getVersioningStorage,
-} from './versioning';
-export type { VersioningStorage } from './versioning';
 export {
   getTimestampsConfig,
   getManagedInputExclusions,
@@ -89,15 +82,7 @@ export { applyComputedFields, applyComputedFieldsToArray } from './core/computed
 export { extractNestedData, isDirectNestedData } from './core/nested-writes';
 export { parseAggregateField, parseAggregateQuery } from './core/aggregate';
 export { applyUpsertRestore, getSoftDeleteConfig } from './core/soft-delete';
-export { getAuditConfig, calculateChanges } from './audit/config';
-export { getVersioningConfig } from './versioning/config';
-export { getMultiTenantConfig, extractTenantId } from './multi-tenant/config';
 export { parseSearchMode } from './endpoints/search-utils';
-export { multiTenant } from './multi-tenant';
-export type {
-  MultiTenantMiddlewareConfig,
-  TenantEnv,
-} from './multi-tenant';
 export type {
   FilterOperator,
   FilterConfig,
@@ -295,26 +280,15 @@ export {
   getErrorMessage,
 } from './utils/error-coerce';
 
-// Context helper exports — generic accessors from utils/context, the
-// auth-flavored accessor family from auth/context.
+// Context helper exports — generic accessors from utils/context. The
+// auth-flavored accessor family (getUser, hasRole, …) lives on 'hono-crud/auth'.
 export {
   getContextVar,
   setContextVar,
   getTenantId,
-  getRequestId as getContextRequestId,
+  getRequestId,
+  generateRequestId,
 } from './utils/context';
-export {
-  getUserId,
-  getUser,
-  getUserRoles,
-  getUserPermissions,
-  getAuthType,
-  hasRole,
-  hasPermission,
-  hasAllRoles,
-  hasAnyRole,
-  hasAllPermissions,
-} from './auth/context';
 
 // OpenAPI utilities
 export {
@@ -330,285 +304,10 @@ export {
   errorResponses,
 } from './endpoints/responses';
 
-// Auth exports
-export {
-  // Middleware
-  createJWTMiddleware,
-  verifyJWT,
-  decodeJWT,
-  createAPIKeyMiddleware,
-  validateAPIKey,
-  defaultHashAPIKey,
-  createAuthMiddleware,
-  optionalAuth,
-  requireAuthentication,
-  // Guards
-  requireRoles,
-  requireAllRoles,
-  requirePermissions,
-  requireAnyPermission,
-  requireAuth,
-  requireOwnership,
-  requireOwnershipOrRole,
-  requirePolicy,
-  POLICIES_CONTEXT_KEY,
-  // Approval guard (HIL)
-  requireApproval,
-  // Approval storage
-  MemoryApprovalStorage,
-  parseIso8601Duration,
-  allOf,
-  anyOf,
-  denyAll,
-  allowAll,
-  requireAuthenticated,
-  // Endpoint
-  AuthenticatedEndpoint,
-  withAuth,
-  // Storage
-  MemoryAPIKeyStorage,
-  generateAPIKey,
-  hashAPIKey,
-  isValidAPIKeyFormat,
-  getAPIKeyStorage,
-  setAPIKeyStorage,
-  // Validators
-  validateJWTClaims,
-  validateAPIKeyEntry,
-  // JWT Claims Schema
-  JWTClaimsSchema,
-  parseJWTClaims,
-  safeParseJWTClaims,
-  JWT_ALGORITHMS,
-} from './auth/index';
-export type {
-  AuthUser,
-  AuthType,
-  AuthEnv,
-  JWTAlgorithm,
-  JWTClaims,
-  JWTConfig,
-  ValidatedJWTClaims,
-  APIKeyEntry,
-  APIKeyLookupResult,
-  APIKeyConfig,
-  PathPattern,
-  AuthConfig,
-  AuthorizationCheck,
-  OwnershipExtractor,
-  Guard,
-  EndpointAuthConfig,
-  AuthEndpointMethods,
-  JWTClaimsValidationOptions,
-  // Approval types
-  ApprovalConfig,
-  ApprovalStorage,
-  PendingAction,
-  PendingActionStatus,
-  ActionSource,
-} from './auth/index';
-
-// Logging exports
-export {
-  // Middleware
-  createLoggingMiddleware,
-  setLoggingStorage,
-  getLoggingStorage,
-  getRequestId,
-  getRequestStartTime,
-  // Utilities
-  shouldRedact,
-  redactObject,
-  redactHeaders,
-  matchPath as matchLoggingPath,
-  shouldExcludePath,
-  extractClientIp,
-  extractHeaders,
-  extractQuery,
-  extractUserId as extractLoggingUserId,
-  truncateBody,
-  isAllowedContentType,
-  generateRequestId,
-  // Storage implementations
-  MemoryLoggingStorage,
-} from './logging/index';
-export type {
-  LogLevel,
-  RequestLogEntry,
-  ResponseLogEntry,
-  LogEntry,
-  LogQueryOptions,
-  LoggingStorage,
-  PathPattern as LoggingPathPattern,
-  RedactField,
-  RequestBodyConfig,
-  ResponseBodyConfig,
-  LoggingConfig,
-  LoggingEnv,
-  MemoryLoggingStorageOptions,
-} from './logging/index';
-
-// Storage exports (context-based storage management)
-export {
-  // Middleware
-  createStorageMiddleware,
-  createLoggingStorageMiddleware,
-  createAuditStorageMiddleware,
-  createVersioningStorageMiddleware,
-  createAPIKeyStorageMiddleware,
-  createCacheStorageMiddleware,
-  createRateLimitStorageMiddleware,
-  createIdempotencyStorageMiddleware,
-  // Helpers
-  getStorage,
-  resolveLoggingStorage,
-  resolveAuditStorage,
-  resolveVersioningStorage,
-  resolveAPIKeyStorage,
-  getLoggingStorageRequired,
-  getAuditStorageRequired,
-  getVersioningStorageRequired,
-  // Shared storage-feature helper
-  createStorageFeature,
-  // Registry
-  StorageRegistry,
-} from './storage/index';
-export type {
-  StorageEnv,
-  StorageMiddlewareConfig,
-  StorageFeature,
-  StorageFeatureOptions,
-  CacheStorage,
-  CacheEntry,
-  CacheSetOptions,
-  CacheStats,
-  RateLimitStorage,
-  FixedWindowEntry,
-  SlidingWindowEntry,
-  RateLimitEntry,
-  IdempotencyStorage,
-  IdempotencyEntry,
-} from './storage/index';
-
 // Context-var key registry (single source of truth for context-var keys)
 export { CONTEXT_KEYS } from './core/context-keys';
 export type { ContextKey } from './core/context-keys';
 
-// Event system exports
-export {
-  CrudEventEmitter,
-  getEventEmitter,
-  setEventEmitter,
-  resolveEventEmitter,
-  registerWebhooks,
-  CRUD_EVENT_TYPES,
-} from './events/index';
-export type {
-  CrudEventType,
-  CrudEventPayload,
-  CrudEventListener,
-  EventSubscription,
-  WebhookEndpoint,
-  WebhookConfig,
-  WebhookDeliveryResult,
-} from './events/index';
-
-// Serialization profile exports
-export {
-  applyProfile,
-  applyProfileToArray,
-  resolveProfile,
-  createSerializer,
-  createArraySerializer,
-} from './serialization/index';
-export type {
-  SerializationProfile,
-  SerializationConfig,
-} from './serialization/index';
-
-// Encryption exports
-export {
-  encryptValue,
-  decryptValue,
-  isEncryptedValue,
-  encryptFields,
-  decryptFields,
-  StaticKeyProvider,
-  encryptedValueSchema,
-} from './encryption/index';
-export type {
-  EncryptionKeyProvider,
-  FieldEncryptionConfig,
-  EncryptedValue,
-} from './encryption/index';
-
-// API versioning exports
-export {
-  apiVersion,
-  getApiVersion,
-  getApiVersionConfig,
-  apiVersionedResponse,
-} from './api-version/index';
-export type {
-  ApiVersionStrategy,
-  ApiVersionTransformer,
-  ApiVersionConfig,
-  ApiVersioningConfig,
-  ApiVersionEnv,
-} from './api-version/index';
-
-// ============================================================================
-// Alternative API Patterns
-// ============================================================================
-
-// Functional API
-export {
-  createCreate,
-  createList,
-  createRead,
-  createUpdate,
-  createDelete,
-} from './functional/index';
-export type {
-  CreateConfig,
-  ListConfig,
-  ReadConfig,
-  UpdateConfig,
-  DeleteConfig,
-} from './functional/index';
-
-// Builder/Fluent API
-export {
-  crud,
-  CrudBuilder,
-  CreateBuilder,
-  ListBuilder,
-  ReadBuilder,
-  UpdateBuilder,
-  DeleteBuilder,
-} from './builder/index';
-
-// Config-Based API
+// Config-Based API. The endpoint-config TYPES live canonically on
+// 'hono-crud/config'; only the function is part of the CRUD core.
 export { defineEndpoints } from './config/index';
-export type {
-  CreateEndpointConfig as ConfigCreateEndpoint,
-  ListEndpointConfig as ConfigListEndpoint,
-  ReadEndpointConfig as ConfigReadEndpoint,
-  UpdateEndpointConfig as ConfigUpdateEndpoint,
-  DeleteEndpointConfig as ConfigDeleteEndpoint,
-  SearchEndpointConfig as ConfigSearchEndpoint,
-  AggregateEndpointConfig as ConfigAggregateEndpoint,
-  RestoreEndpointConfig as ConfigRestoreEndpoint,
-  BatchCreateEndpointConfig as ConfigBatchCreateEndpoint,
-  BatchUpdateEndpointConfig as ConfigBatchUpdateEndpoint,
-  BatchDeleteEndpointConfig as ConfigBatchDeleteEndpoint,
-  BatchRestoreEndpointConfig as ConfigBatchRestoreEndpoint,
-  BatchUpsertEndpointConfig as ConfigBatchUpsertEndpoint,
-  ExportEndpointConfig as ConfigExportEndpoint,
-  ImportEndpointConfig as ConfigImportEndpoint,
-  UpsertEndpointConfig as ConfigUpsertEndpoint,
-  CloneEndpointConfig as ConfigCloneEndpoint,
-  EndpointsConfig,
-  AdapterBundle,
-  GeneratedEndpoints,
-} from './config/index';

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -1,24 +1,56 @@
 /**
  * Adapter-authoring entrypoint for first-party `@hono-crud/*` packages.
  *
- * This re-exports the full public API plus a small set of internal building
- * blocks (endpoint primitives, cursor helpers, the `AdapterBundle` contract)
- * that adapter packages need to implement storage backends. It is NOT part of
- * the stable public API and may change between minor versions — application
- * code should import from `hono-crud` instead.
+ * An explicit, curated list of the building blocks (endpoint primitives,
+ * cursor helpers, storage contracts, the `AdapterBundle` contract) that
+ * adapter and middleware packages need to implement storage backends and
+ * core extensions. First-party satellites import ONLY from this entrypoint.
+ * It is NOT part of the stable public API and may change between minor
+ * versions — application code should import from `hono-crud` or a
+ * `hono-crud/<feature>` subpath instead.
  */
 
-export * from './index';
+// ============================================================================
+// Model & meta foundation
+// ============================================================================
 
-// Cursor codecs and shared meta types not surfaced on the public barrel.
-export { encodeCursor, decodeCursor } from './core/cursor';
-export type { MetaInput } from './core/types';
-
-// The model shape adapters operate on.
+// The meta contract endpoints are generic over, and the model shape adapters
+// operate on (`Row` always derives from the consumer's Zod schema).
+export type { Constructor, MetaInput } from './core/types';
 export type { ModelObject } from './endpoints/types';
 
-// The contract adapter bundles implement, plus the generated-endpoints map.
-export type { AdapterBundle, GeneratedEndpoints } from './config/index';
+// ============================================================================
+// Core types shared with adapters
+// ============================================================================
+
+export { assertNever, isFilterOperator } from './core/types';
+export type {
+  AggregateField,
+  AggregateOptions,
+  AggregateResult,
+  ErrorResponse,
+  FilterCondition,
+  FilterOperator,
+  IncludeOptions,
+  ListFilters,
+  NestedUpdateInput,
+  NestedWriteResult,
+  OpenAPIRouteSchema,
+  PaginatedResult,
+  RelationConfig,
+  RelationsConfig,
+  ResponseEnvelopeInfo,
+  SearchOptions,
+  SearchResult,
+  SearchResultItem,
+} from './core/types';
+
+// ============================================================================
+// Route & registrar primitives
+// ============================================================================
+
+export { OpenAPIRoute } from './core/route';
+export type { CrudEndpointName, CrudEndpoints } from './core/register';
 
 // Canonical CRUD route table: [endpoint name, HTTP verb, sub-path] rows in
 // registration order — the single source of truth registerCrud iterates.
@@ -28,7 +60,46 @@ export { CRUD_ROUTES } from './core/crud-routes';
 export { getRegisteredCrudResources } from './core/resource-registry';
 export type { RegisteredCrudResource } from './core/resource-registry';
 
-// Version-history endpoint primitives (not on the public barrel).
+// ============================================================================
+// Endpoint primitives (the classes adapters extend) + their result types
+// ============================================================================
+
+export { CreateEndpoint } from './endpoints/create';
+export { ReadEndpoint } from './endpoints/read';
+export { UpdateEndpoint } from './endpoints/update';
+export { DeleteEndpoint } from './endpoints/delete';
+export type { CascadeResult } from './endpoints/delete';
+export { ListEndpoint } from './endpoints/list';
+export { RestoreEndpoint } from './endpoints/restore';
+export { CloneEndpoint } from './endpoints/clone';
+export { UpsertEndpoint } from './endpoints/upsert';
+export type { UpsertResult } from './endpoints/upsert';
+export { BatchCreateEndpoint } from './endpoints/batch-create';
+export { BatchUpdateEndpoint } from './endpoints/batch-update';
+export type { BatchUpdateItem, BatchUpdateResult } from './endpoints/batch-update';
+export { BatchDeleteEndpoint } from './endpoints/batch-delete';
+export type { BatchDeleteResult } from './endpoints/batch-delete';
+export { BatchRestoreEndpoint } from './endpoints/batch-restore';
+export type { BatchRestoreResult } from './endpoints/batch-restore';
+export { BatchUpsertEndpoint } from './endpoints/batch-upsert';
+export type { BatchUpsertItemResult, BatchUpsertResult } from './endpoints/batch-upsert';
+export { BulkPatchEndpoint } from './endpoints/bulk-patch';
+export type { BulkPatchResult } from './endpoints/bulk-patch';
+export { AggregateEndpoint, computeAggregations } from './endpoints/aggregate';
+export { SearchEndpoint, searchInMemory } from './endpoints/search';
+export { ExportEndpoint } from './endpoints/export';
+export type { ExportFormat, ExportOptions, ExportResult } from './endpoints/export';
+export { ImportEndpoint } from './endpoints/import';
+export type {
+  ImportMode,
+  ImportOptions,
+  ImportResult,
+  ImportRowResult,
+  ImportRowStatus,
+  ImportSummary,
+} from './endpoints/import';
+
+// Version-history endpoint primitives.
 export {
   VersionHistoryEndpoint,
   VersionReadEndpoint,
@@ -36,36 +107,15 @@ export {
   VersionRollbackEndpoint,
 } from './endpoints/version-history';
 
-// Primitives for first-party middleware packages (cache, rate-limit, …).
-export { ApiException, ConfigurationException } from './core/exceptions';
-export { getContextVar, setContextVar } from './utils/context';
-export { CONTEXT_KEYS } from './core/context-keys';
-export type { ContextKey } from './core/context-keys';
-export { createStorageFeature } from './storage/feature';
-export type { StorageFeature, StorageFeatureOptions } from './storage/feature';
-export type {
-  CacheStorage,
-  CacheEntry,
-  CacheSetOptions,
-  CacheStats,
-  RateLimitStorage,
-  FixedWindowEntry,
-  SlidingWindowEntry,
-  RateLimitEntry,
-  IdempotencyStorage,
-  IdempotencyEntry,
-} from './storage/contracts';
-export type { Constructor } from './core/types';
-export type { KVNamespace } from './cloudflare/index';
-export { matchPath, matchAny, isPathIncluded } from './utils/path-match';
-export type { PathPattern } from './utils/path-match';
-export { getClientIp } from './utils/request-info';
-export type { ClientIpOptions } from './utils/request-info';
-export { defaultExtractToken as extractBearerToken } from './auth/middleware/jwt';
+// ============================================================================
+// Orchestration helpers adapters call back into
+// ============================================================================
 
-// Generic TTL Map store composed by the in-memory cache/rate-limit/idempotency backends.
-export { MemoryTtlStore } from './storage/memory-ttl-store';
-export type { MemoryTtlStoreOptions } from './storage/memory-ttl-store';
+// Cursor codecs shared by every list/pagination implementation.
+export { encodeCursor, decodeCursor } from './core/cursor';
+
+// Upsert-family soft-delete restore ("match-and-restore" contract).
+export { applyUpsertRestore } from './core/soft-delete';
 
 // Relation batch/single-item orchestrator consumed by the drizzle/prisma/memory adapters.
 export {
@@ -84,3 +134,60 @@ export type {
   SyncFetchRelated,
   SyncRelationLoaderAdapter,
 } from './relations/batch-loader';
+
+// The contract adapter bundles implement, plus the generated-endpoints map.
+export type { AdapterBundle, GeneratedEndpoints } from './config/index';
+
+// ============================================================================
+// Exceptions & logging
+// ============================================================================
+
+export {
+  ApiException,
+  ConfigurationException,
+  NotFoundException,
+  UnauthorizedException,
+} from './core/exceptions';
+export { getLogger } from './core/logger';
+export type { Logger } from './core/logger';
+
+// ============================================================================
+// Context primitives
+// ============================================================================
+
+export { getContextVar, setContextVar } from './utils/context';
+export { CONTEXT_KEYS } from './core/context-keys';
+export type { ContextKey } from './core/context-keys';
+export { getUserId } from './auth/context';
+export { defaultExtractToken as extractBearerToken } from './auth/middleware/jwt';
+
+// ============================================================================
+// Primitives for first-party middleware packages (cache, rate-limit, …)
+// ============================================================================
+
+export { createStorageFeature } from './storage/feature';
+export type { StorageFeature, StorageFeatureOptions } from './storage/feature';
+// Companion of `createStorageFeature` — its `registry` member is a
+// `StorageRegistry<T>`, so satellite-inferred types must be able to name it.
+export { StorageRegistry } from './storage/registry';
+export type {
+  CacheStorage,
+  CacheEntry,
+  CacheSetOptions,
+  CacheStats,
+  RateLimitStorage,
+  FixedWindowEntry,
+  SlidingWindowEntry,
+  RateLimitEntry,
+  IdempotencyStorage,
+  IdempotencyEntry,
+} from './storage/contracts';
+export type { KVNamespace } from './cloudflare/index';
+export { matchPath, matchAny, isPathIncluded } from './utils/path-match';
+export type { PathPattern } from './utils/path-match';
+export { getClientIp } from './utils/request-info';
+export type { ClientIpOptions } from './utils/request-info';
+
+// Generic TTL Map store composed by the in-memory cache/rate-limit/idempotency backends.
+export { MemoryTtlStore } from './storage/memory-ttl-store';
+export type { MemoryTtlStoreOptions } from './storage/memory-ttl-store';

--- a/packages/core/src/logging/middleware.ts
+++ b/packages/core/src/logging/middleware.ts
@@ -51,7 +51,7 @@ export const loggingStorageRegistry = loggingStorageFeature.registry;
  *
  * @example
  * ```ts
- * import { setLoggingStorage, MemoryLoggingStorage } from 'hono-crud';
+ * import { setLoggingStorage, MemoryLoggingStorage } from 'hono-crud/logging';
  *
  * setLoggingStorage(new MemoryLoggingStorage());
  * ```
@@ -150,7 +150,7 @@ export function getRequestStartTime<E extends Env>(ctx: Context<E>): number | un
  *   createLoggingMiddleware,
  *   setLoggingStorage,
  *   MemoryLoggingStorage,
- * } from 'hono-crud';
+ * } from 'hono-crud/logging';
  *
  * // Setup storage (do this once at startup)
  * setLoggingStorage(new MemoryLoggingStorage());

--- a/packages/core/src/logging/storage/memory.ts
+++ b/packages/core/src/logging/storage/memory.ts
@@ -47,7 +47,7 @@ export interface MemoryLoggingStorageOptions {
  *
  * @example
  * ```ts
- * import { MemoryLoggingStorage, setLoggingStorage } from 'hono-crud';
+ * import { MemoryLoggingStorage, setLoggingStorage } from 'hono-crud/logging';
  *
  * const storage = new MemoryLoggingStorage({
  *   maxEntries: 5000,

--- a/packages/core/src/logging/types.ts
+++ b/packages/core/src/logging/types.ts
@@ -385,7 +385,7 @@ export interface LoggingConfig<E extends Env = Env> {
  *
  * @example
  * ```ts
- * import type { LoggingEnv } from 'hono-crud';
+ * import type { LoggingEnv } from 'hono-crud/logging';
  *
  * type AppEnv = LoggingEnv & {
  *   Variables: {

--- a/packages/core/src/multi-tenant/index.ts
+++ b/packages/core/src/multi-tenant/index.ts
@@ -91,7 +91,7 @@ export interface MultiTenantMiddlewareConfig
  * @example
  * ```ts
  * import { Hono } from 'hono';
- * import { multiTenant } from 'hono-crud';
+ * import { multiTenant } from 'hono-crud/multi-tenant';
  *
  * const app = new Hono();
  *
@@ -207,7 +207,7 @@ export function multiTenant<E extends Env = Env>(
  * @example
  * ```ts
  * import { Hono } from 'hono';
- * import type { TenantEnv } from 'hono-crud';
+ * import type { TenantEnv } from 'hono-crud/multi-tenant';
  *
  * const app = new Hono<TenantEnv>();
  * app.use('/*', multiTenant());
@@ -223,3 +223,7 @@ export type TenantEnv<TenantKey extends string = 'tenantId'> = {
     [K in TenantKey]: string;
   };
 };
+
+// Config normalization + tenant extraction — the multi-tenant barrel is the
+// complete canonical surface of the multi-tenant family.
+export { extractTenantId, getMultiTenantConfig } from './config';

--- a/packages/core/src/storage/middleware.ts
+++ b/packages/core/src/storage/middleware.ts
@@ -28,7 +28,8 @@ const STORAGE_SLOTS: Record<keyof StorageMiddlewareConfig, ContextKey> = {
  * @example
  * ```ts
  * import { Hono } from 'hono';
- * import { createStorageMiddleware, MemoryCacheStorage } from 'hono-crud';
+ * import { MemoryCacheStorage } from '@hono-crud/cache';
+ * import { createStorageMiddleware } from 'hono-crud/storage';
  * import { MemoryRateLimitStorage } from '@hono-crud/rate-limit';
  *
  * const app = new Hono();

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -13,7 +13,7 @@ import type { CacheStorage, IdempotencyStorage, RateLimitStorage } from './contr
  * @example
  * ```ts
  * import { Hono } from 'hono';
- * import { StorageEnv, createStorageMiddleware } from 'hono-crud';
+ * import { StorageEnv, createStorageMiddleware } from 'hono-crud/storage';
  *
  * const app = new Hono<StorageEnv>();
  *

--- a/packages/core/src/versioning/index.ts
+++ b/packages/core/src/versioning/index.ts
@@ -422,3 +422,7 @@ export function createVersionManager(
 ): VersionManager {
   return new VersionManager(config, tableName, storage, ctx);
 }
+
+// Config normalization — the versioning barrel is the complete canonical
+// surface of the versioning family.
+export { getVersioningConfig } from './config';

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     'src/multi-tenant/index.ts',
     'src/config/index.ts',
     'src/functional/index.ts',
+    'src/builder/index.ts',
     'src/health/index.ts',
     'src/cloudflare/index.ts',
   ],

--- a/packages/mcp/src/schema.ts
+++ b/packages/mcp/src/schema.ts
@@ -1,4 +1,4 @@
-import type { OpenAPIRouteSchema } from 'hono-crud';
+import type { OpenAPIRouteSchema } from 'hono-crud/internal';
 import type { ZodType } from 'zod';
 
 /** A flat MCP input schema: a map of field name to Zod schema. */

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -1,6 +1,12 @@
 import type { Context, Hono, MiddlewareHandler } from 'hono';
-import type { CrudEndpointName, CrudEndpoints, OpenAPIRoute, OpenAPIRouteSchema } from 'hono-crud';
-import type { MetaInput, PathPattern } from 'hono-crud/internal';
+import type {
+  CrudEndpointName,
+  CrudEndpoints,
+  MetaInput,
+  OpenAPIRoute,
+  OpenAPIRouteSchema,
+  PathPattern,
+} from 'hono-crud/internal';
 
 /**
  * The five standard CRUD operations exposed as MCP tools. Pinned to core's

--- a/packages/memory/src/helpers.ts
+++ b/packages/memory/src/helpers.ts
@@ -68,13 +68,6 @@ export function clearStorage(): void {
 }
 
 /**
- * Gets the storage for a specific table. Useful for testing.
- */
-export function getStorage<T>(tableName: string): Map<string, T> {
-  return getStore<T>(tableName);
-}
-
-/**
  * Finds a record in the store whose values match `data` on every upsert key.
  *
  * Soft-deleted rows are matched too: upsert-family endpoints restore them on

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -1,4 +1,4 @@
-export { clearStorage, getStorage, getStore, storage } from './helpers';
+export { clearStorage, getStore, storage } from './helpers';
 export * from './crud';
 export * from './batch';
 export * from './advanced';
@@ -34,7 +34,7 @@ import {
  *
  * @example
  * ```ts
- * import { defineEndpoints } from 'hono-crud';
+ * import { defineEndpoints } from 'hono-crud/config';
  * import { MemoryAdapters } from '@hono-crud/memory';
  *
  * const userEndpoints = defineEndpoints({ meta: userMeta, list: {}, create: {} }, MemoryAdapters);

--- a/packages/rate-limit/src/storage/cloudflare-kv.ts
+++ b/packages/rate-limit/src/storage/cloudflare-kv.ts
@@ -50,7 +50,7 @@ export interface KVRateLimitStorageOptions {
  * @example
  * ```ts
  * import { KVRateLimitStorage } from '@hono-crud/rate-limit';
- * import { createStorageMiddleware } from 'hono-crud';
+ * import { createStorageMiddleware } from 'hono-crud/storage';
  *
  * app.use('*', async (c, next) => {
  *   const rateLimitStorage = new KVRateLimitStorage({ kv: c.env.RATE_LIMIT_KV });

--- a/tests/aggregate.test.ts
+++ b/tests/aggregate.test.ts
@@ -1,4 +1,4 @@
-import { MemoryAggregateEndpoint, clearStorage, getStorage } from '@hono-crud/memory';
+import { MemoryAggregateEndpoint, clearStorage, getStore } from '@hono-crud/memory';
 import { Hono } from 'hono';
 import {
   computeAggregations,
@@ -49,7 +49,7 @@ describe('Aggregations', () => {
     clearStorage();
 
     // Seed test data
-    const store = getStorage<Record<string, unknown>>('products');
+    const store = getStore<Record<string, unknown>>('products');
 
     const products = [
       {

--- a/tests/api-key-storage.test.ts
+++ b/tests/api-key-storage.test.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
-import { ApiException, type AuthEnv, MemoryAPIKeyStorage, createAPIKeyMiddleware } from 'hono-crud';
+import { ApiException } from 'hono-crud';
+import { type AuthEnv, MemoryAPIKeyStorage, createAPIKeyMiddleware } from 'hono-crud/auth';
 import { apiKeyStorageRegistry, setAPIKeyStorage } from 'hono-crud/auth/storage/memory';
 import { createStorageMiddleware } from 'hono-crud/storage';
 import type { StorageEnv } from 'hono-crud/storage/types';

--- a/tests/audit.test.ts
+++ b/tests/audit.test.ts
@@ -3,18 +3,18 @@ import {
   MemoryDeleteEndpoint,
   MemoryUpdateEndpoint,
   clearStorage,
-  getStorage,
+  getStore,
 } from '@hono-crud/memory';
 import { Hono } from 'hono';
+import { defineModel } from 'hono-crud';
 import {
   AuditLogger,
   MemoryAuditLogStorage,
   calculateChanges,
   createAuditLogger,
-  defineModel,
   getAuditStorage,
   setAuditStorage,
-} from 'hono-crud';
+} from 'hono-crud/audit';
 /**
  * Tests for audit logging functionality.
  */
@@ -305,7 +305,7 @@ describe('Audit Logging', () => {
 
     it('should log update from endpoint', async () => {
       // First create a record
-      const store = getStorage<Record<string, unknown>>('users');
+      const store = getStore<Record<string, unknown>>('users');
       store.set('123', {
         id: '123',
         name: 'John',
@@ -342,7 +342,7 @@ describe('Audit Logging', () => {
 
     it('should log delete from endpoint', async () => {
       // First create a record
-      const store = getStorage<Record<string, unknown>>('users');
+      const store = getStore<Record<string, unknown>>('users');
       store.set('123', {
         id: '123',
         name: 'John',

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -5,8 +5,9 @@ import {
   clearStorage,
 } from '@hono-crud/memory';
 import { Hono } from 'hono';
+import { ApiException, fromHono, registerCrud } from 'hono-crud';
+import type { MetaInput, Model } from 'hono-crud';
 import {
-  ApiException,
   type AuthEnv,
   type JWTClaims,
   MemoryAPIKeyStorage,
@@ -16,12 +17,10 @@ import {
   createAuthMiddleware,
   createJWTMiddleware,
   defaultHashAPIKey,
-  fromHono,
   generateAPIKey,
   hashAPIKey,
   isValidAPIKeyFormat,
   optionalAuth,
-  registerCrud,
   requireAllRoles,
   requireAnyPermission,
   requireOwnership,
@@ -29,8 +28,7 @@ import {
   requirePermissions,
   requireRoles,
   withAuth,
-} from 'hono-crud';
-import type { MetaInput, Model } from 'hono-crud';
+} from 'hono-crud/auth';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 

--- a/tests/batch-upsert.test.ts
+++ b/tests/batch-upsert.test.ts
@@ -2,7 +2,7 @@ import {
   MemoryBatchUpsertEndpoint,
   MemoryListEndpoint,
   clearStorage,
-  getStorage,
+  getStore,
 } from '@hono-crud/memory';
 import { Hono } from 'hono';
 import { defineMeta, defineModel, fromHono } from 'hono-crud';
@@ -96,8 +96,8 @@ describe('Batch Upsert', () => {
 
   beforeEach(() => {
     clearStorage();
-    productStore = getStorage<Product>('products');
-    settingsStore = getStorage<Settings>('settings');
+    productStore = getStore<Product>('products');
+    settingsStore = getStore<Settings>('settings');
 
     app = fromHono(new Hono());
     app.put('/products/batch', ProductBatchUpsert);

--- a/tests/cascade-delete.test.ts
+++ b/tests/cascade-delete.test.ts
@@ -2,7 +2,7 @@ import {
   MemoryCreateEndpoint,
   MemoryDeleteEndpoint,
   clearStorage,
-  getStorage,
+  getStore,
 } from '@hono-crud/memory';
 import { Hono } from 'hono';
 import { defineMeta, defineModel, fromHono } from 'hono-crud';
@@ -174,14 +174,14 @@ describe('Cascade Delete', () => {
 
   beforeEach(() => {
     clearStorage();
-    userCascadeStore = getStorage<User>('users_cascade');
-    postCascadeStore = getStorage<Post>('posts_cascade');
-    profileCascadeStore = getStorage<Profile>('profiles_cascade');
-    commentStore = getStorage<Comment>('comments');
-    userSetNullStore = getStorage<User>('users_setnull');
-    postSetNullStore = getStorage<Post>('posts_setnull');
-    userRestrictStore = getStorage<User>('users_restrict');
-    postRestrictStore = getStorage<Post>('posts_restrict');
+    userCascadeStore = getStore<User>('users_cascade');
+    postCascadeStore = getStore<Post>('posts_cascade');
+    profileCascadeStore = getStore<Profile>('profiles_cascade');
+    commentStore = getStore<Comment>('comments');
+    userSetNullStore = getStore<User>('users_setnull');
+    postSetNullStore = getStore<Post>('posts_setnull');
+    userRestrictStore = getStore<User>('users_restrict');
+    postRestrictStore = getStore<Post>('posts_restrict');
 
     app = fromHono(new Hono());
     app.post('/users-cascade', UserCascadeCreate);

--- a/tests/conformance/adapters/drizzle.ts
+++ b/tests/conformance/adapters/drizzle.ts
@@ -31,14 +31,8 @@ import { createClient } from '@libsql/client';
 import { sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/libsql';
 import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
-import {
-  type HookContext,
-  defineMeta,
-  defineModel,
-  fromHono,
-  multiTenant,
-  registerCrud,
-} from 'hono-crud';
+import { type HookContext, defineMeta, defineModel, fromHono, registerCrud } from 'hono-crud';
+import { multiTenant } from 'hono-crud/multi-tenant';
 import { z } from 'zod';
 import type { AdapterContext, AdapterDescriptor, HookRecorder } from '../contract';
 import { CONFORMANCE_FILTER_CONFIG, buildConformanceSchema } from '../model';

--- a/tests/conformance/adapters/memory.ts
+++ b/tests/conformance/adapters/memory.ts
@@ -24,14 +24,8 @@ import {
   clearStorage,
 } from '@hono-crud/memory';
 import { OpenAPIHono } from '@hono/zod-openapi';
-import {
-  type HookContext,
-  defineMeta,
-  defineModel,
-  fromHono,
-  multiTenant,
-  registerCrud,
-} from 'hono-crud';
+import { type HookContext, defineMeta, defineModel, fromHono, registerCrud } from 'hono-crud';
+import { multiTenant } from 'hono-crud/multi-tenant';
 import { z } from 'zod';
 import type { AdapterContext, AdapterDescriptor, HookRecorder } from '../contract';
 import { CONFORMANCE_FILTER_CONFIG, buildConformanceSchema } from '../model';

--- a/tests/conformance/adapters/prisma.ts
+++ b/tests/conformance/adapters/prisma.ts
@@ -32,14 +32,8 @@ import {
   createPrismaCrud,
 } from '@hono-crud/prisma';
 import { OpenAPIHono } from '@hono/zod-openapi';
-import {
-  type HookContext,
-  defineMeta,
-  defineModel,
-  fromHono,
-  multiTenant,
-  registerCrud,
-} from 'hono-crud';
+import { type HookContext, defineMeta, defineModel, fromHono, registerCrud } from 'hono-crud';
+import { multiTenant } from 'hono-crud/multi-tenant';
 import { z } from 'zod';
 import type { AdapterContext, AdapterDescriptor, HookRecorder } from '../contract';
 import { CONFORMANCE_FILTER_CONFIG, buildConformanceSchema } from '../model';

--- a/tests/drizzle-dialect.test.ts
+++ b/tests/drizzle-dialect.test.ts
@@ -1,13 +1,14 @@
 import {
   DrizzleBatchUpsertEndpoint,
   type DrizzleDatabaseConstraint,
+  type DrizzleDialect,
   DrizzleUpsertEndpoint,
   createDrizzleCrud,
 } from '@hono-crud/drizzle';
 import { substringMatch } from '@hono-crud/drizzle/advanced';
 import { sql } from 'drizzle-orm';
 import { sqliteTable, text } from 'drizzle-orm/sqlite-core';
-import { type DrizzleDialect, defineMeta, defineModel } from 'hono-crud';
+import { defineMeta, defineModel } from 'hono-crud';
 /**
  * Tests for the Drizzle adapter's `dialect` option.
  *

--- a/tests/error-envelope-schema.test.ts
+++ b/tests/error-envelope-schema.test.ts
@@ -1,8 +1,5 @@
 import {
   ApiException,
-  type AuthEndpointMethods,
-  AuthenticatedEndpoint,
-  type EndpointAuthConfig,
   ForbiddenException,
   InputValidationException,
   NotFoundException,
@@ -14,8 +11,13 @@ import {
   structuredErrorSchema,
   successEnvelopeSchema,
   validationIssueSchema,
-  withAuth,
 } from 'hono-crud';
+import {
+  type AuthEndpointMethods,
+  AuthenticatedEndpoint,
+  type EndpointAuthConfig,
+  withAuth,
+} from 'hono-crud/auth';
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 

--- a/tests/error-handler.test.ts
+++ b/tests/error-handler.test.ts
@@ -5,14 +5,16 @@ import {
   type ErrorHook,
   type ErrorMapper,
   InputValidationException,
-  type LoggingStorage,
-  MemoryLoggingStorage,
   NotFoundException,
   createErrorHandler,
-  createLoggingMiddleware,
-  setLoggingStorage,
   zodErrorMapper,
 } from 'hono-crud';
+import {
+  type LoggingStorage,
+  MemoryLoggingStorage,
+  createLoggingMiddleware,
+  setLoggingStorage,
+} from 'hono-crud/logging';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ZodError, z } from 'zod';
 

--- a/tests/error-shapes.test.ts
+++ b/tests/error-shapes.test.ts
@@ -29,7 +29,7 @@ import {
   MemorySearchEndpoint,
   MemoryUpdateEndpoint,
   clearStorage,
-  getStorage,
+  getStore,
 } from '@hono-crud/memory';
 import { OpenAPIHono } from '@hono/zod-openapi';
 import { Hono } from 'hono';
@@ -40,12 +40,12 @@ import {
   defineMeta,
   defineModel,
   fromHono,
-  multiTenant,
   setContextVar,
   toOpenApiPaths,
   validationIssueSchema,
 } from 'hono-crud';
 import * as honoCrudBarrel from 'hono-crud';
+import { multiTenant } from 'hono-crud/multi-tenant';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
@@ -93,7 +93,7 @@ describe('error-shape unification', () => {
       const app = fromHono(honoApp);
       app.patch('/posts/:id', PostUpdate);
 
-      getStorage<Post>('errshapes_policy').set('p1', {
+      getStore<Post>('errshapes_policy').set('p1', {
         id: 'p1',
         authorId: 'alice',
         title: 'Alice',

--- a/tests/event-payload-tenant.test.ts
+++ b/tests/event-payload-tenant.test.ts
@@ -10,16 +10,9 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
 import { MemoryCreateEndpoint, clearStorage } from '@hono-crud/memory';
-import {
-  CrudEventEmitter,
-  type CrudEventPayload,
-  defineMeta,
-  defineModel,
-  fromHono,
-  multiTenant,
-  setContextVar,
-  setEventEmitter,
-} from 'hono-crud';
+import { defineMeta, defineModel, fromHono, setContextVar } from 'hono-crud';
+import { CrudEventEmitter, type CrudEventPayload, setEventEmitter } from 'hono-crud/events';
+import { multiTenant } from 'hono-crud/multi-tenant';
 
 const TENANT = 'tenant-payload-test';
 const ORG = 'org-payload-test';

--- a/tests/logging.test.ts
+++ b/tests/logging.test.ts
@@ -1,29 +1,24 @@
 import { Hono } from 'hono';
 import type { ExecutionContext } from 'hono';
+import { generateRequestId, getRequestId } from 'hono-crud';
 import {
-  // Types
   type LogEntry,
   type LogLevel,
   type LoggingStorage,
-  // Storage
   MemoryLoggingStorage,
-  // Middleware
   createLoggingMiddleware,
   extractHeaders,
-  generateRequestId,
   getLoggingStorage,
-  getRequestId,
   getRequestStartTime,
   isAllowedContentType,
-  matchLoggingPath,
+  matchPath,
   redactHeaders,
   redactObject,
   setLoggingStorage,
   shouldExcludePath,
-  // Utilities
   shouldRedact,
   truncateBody,
-} from 'hono-crud';
+} from 'hono-crud/logging';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ============================================================================
@@ -149,37 +144,37 @@ describe('Logging Utilities', () => {
     });
   });
 
-  describe('matchLoggingPath', () => {
+  describe('matchPath', () => {
     it('should match exact paths', () => {
-      expect(matchLoggingPath('/health', '/health')).toBe(true);
-      expect(matchLoggingPath('/api/users', '/api/users')).toBe(true);
-      expect(matchLoggingPath('/api/users', '/api/posts')).toBe(false);
+      expect(matchPath('/health', '/health')).toBe(true);
+      expect(matchPath('/api/users', '/api/users')).toBe(true);
+      expect(matchPath('/api/users', '/api/posts')).toBe(false);
     });
 
     it('should match single wildcard (*)', () => {
-      expect(matchLoggingPath('/api/users', '/api/*')).toBe(true);
-      expect(matchLoggingPath('/api/posts', '/api/*')).toBe(true);
-      expect(matchLoggingPath('/api/users/123', '/api/*')).toBe(false);
-      expect(matchLoggingPath('/other/users', '/api/*')).toBe(false);
+      expect(matchPath('/api/users', '/api/*')).toBe(true);
+      expect(matchPath('/api/posts', '/api/*')).toBe(true);
+      expect(matchPath('/api/users/123', '/api/*')).toBe(false);
+      expect(matchPath('/other/users', '/api/*')).toBe(false);
     });
 
     it('should match double wildcard (**)', () => {
-      expect(matchLoggingPath('/api/v1/users', '/api/**')).toBe(true);
-      expect(matchLoggingPath('/api/v1/users/123', '/api/**')).toBe(true);
-      expect(matchLoggingPath('/api/', '/api/**')).toBe(true);
-      expect(matchLoggingPath('/other/path', '/api/**')).toBe(false);
+      expect(matchPath('/api/v1/users', '/api/**')).toBe(true);
+      expect(matchPath('/api/v1/users/123', '/api/**')).toBe(true);
+      expect(matchPath('/api/', '/api/**')).toBe(true);
+      expect(matchPath('/other/path', '/api/**')).toBe(false);
     });
 
     it('should match regex patterns', () => {
-      expect(matchLoggingPath('/v1/test', /^\/v\d+\/test$/)).toBe(true);
-      expect(matchLoggingPath('/v2/test', /^\/v\d+\/test$/)).toBe(true);
-      expect(matchLoggingPath('/va/test', /^\/v\d+\/test$/)).toBe(false);
+      expect(matchPath('/v1/test', /^\/v\d+\/test$/)).toBe(true);
+      expect(matchPath('/v2/test', /^\/v\d+\/test$/)).toBe(true);
+      expect(matchPath('/va/test', /^\/v\d+\/test$/)).toBe(false);
     });
 
     it('should handle mixed wildcards', () => {
-      expect(matchLoggingPath('/api/v1/users', '/api/*/users')).toBe(true);
-      expect(matchLoggingPath('/api/v2/users', '/api/*/users')).toBe(true);
-      expect(matchLoggingPath('/api/v1/posts', '/api/*/users')).toBe(false);
+      expect(matchPath('/api/v1/users', '/api/*/users')).toBe(true);
+      expect(matchPath('/api/v2/users', '/api/*/users')).toBe(true);
+      expect(matchPath('/api/v1/posts', '/api/*/users')).toBe(false);
     });
   });
 

--- a/tests/managed-fields-coverage.test.ts
+++ b/tests/managed-fields-coverage.test.ts
@@ -4,7 +4,7 @@ import {
   MemoryCloneEndpoint,
   MemoryImportEndpoint,
   clearStorage,
-  getStorage,
+  getStore,
 } from '@hono-crud/memory';
 import { createClient } from '@libsql/client';
 import { sql } from 'drizzle-orm';
@@ -80,18 +80,18 @@ function memoryProductsApp() {
     async create(data: any) {
       // Re-use the adapter's create path so engine-managed fields are stamped.
       const record = this.applyManagedInsertFields(data as Record<string, unknown>, 'memory');
-      const store = getStorage<Product>('mfc_products');
+      const store = getStore<Product>('mfc_products');
       store.set(String((record as any).id), record as Product);
       return record as Product;
     }
     async update(existing: Product, data: any) {
-      const store = getStorage<Product>('mfc_products');
+      const store = getStore<Product>('mfc_products');
       const merged = { ...existing, ...data, updatedAt: Date.now() } as Product;
       store.set(existing.id, merged);
       return merged;
     }
     async findExisting(data: any) {
-      const store = getStorage<Product>('mfc_products');
+      const store = getStore<Product>('mfc_products');
       for (const v of store.values()) {
         if (v.slug === data.slug) return v;
       }
@@ -109,7 +109,7 @@ function memoryProductsApp() {
     _meta = meta;
     async create(data: any) {
       const record = this.applyManagedInsertFields(data as Record<string, unknown>, 'memory');
-      const store = getStorage<Product>('mfc_products');
+      const store = getStore<Product>('mfc_products');
       store.set(String((record as any).id), record as Product);
       return record as Product;
     }
@@ -195,7 +195,7 @@ describe('clone fresh-stamping: timestamps + id are engine-fresh, not copied fro
     // Seed directly into the in-memory store with an old timestamp so a
     // copy-vs-stamp difference is unambiguous.
     const sourceCreatedAt = 1_000;
-    const store = getStorage<Product>('mfc_products');
+    const store = getStore<Product>('mfc_products');
     store.set('src-1', {
       id: 'src-1',
       name: 'Source',

--- a/tests/managed-id-timestamps.test.ts
+++ b/tests/managed-id-timestamps.test.ts
@@ -14,7 +14,7 @@ import {
   MemoryUpdateEndpoint,
   MemoryUpsertEndpoint,
   clearStorage,
-  getStorage,
+  getStore,
 } from '@hono-crud/memory';
 import { createClient } from '@libsql/client';
 import { sql } from 'drizzle-orm';
@@ -152,7 +152,7 @@ describe('Model.id strategy', () => {
   it('function generator => used as PK on create + batchCreate + upsert + clone', async () => {
     counter = 0;
     const app = memoryApp({ id: seqId });
-    const store = getStorage<Item>('items');
+    const store = getStore<Item>('items');
 
     // create
     const c = await app.request('/items', {
@@ -446,7 +446,7 @@ describe('Model.timestamps', () => {
     const app = memoryApp({
       timestamps: { createdAt: 'created_ms', updatedAt: 'updated_ms' },
     });
-    const store = getStorage<Record<string, unknown>>('items');
+    const store = getStore<Record<string, unknown>>('items');
     const res = await app.request('/items', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -2,7 +2,9 @@ import { MemoryCreateEndpoint, MemoryListEndpoint } from '@hono-crud/memory';
 import { OpenAPIHono } from '@hono/zod-openapi';
 import type { Context, MiddlewareHandler, Next } from 'hono';
 import type { MetaInput } from 'hono-crud';
-import { createCreate, createList, crud, fromHono, registerCrud } from 'hono-crud';
+import { fromHono, registerCrud } from 'hono-crud';
+import { crud } from 'hono-crud/builder';
+import { createCreate, createList } from 'hono-crud/functional';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 

--- a/tests/multi-tenant.test.ts
+++ b/tests/multi-tenant.test.ts
@@ -5,10 +5,11 @@ import {
   MemoryReadEndpoint,
   MemoryUpdateEndpoint,
   clearStorage,
-  getStorage,
+  getStore,
 } from '@hono-crud/memory';
 import { OpenAPIHono } from '@hono/zod-openapi';
-import { defineMeta, defineModel, fromHono, multiTenant } from 'hono-crud';
+import { defineMeta, defineModel, fromHono } from 'hono-crud';
+import { multiTenant } from 'hono-crud/multi-tenant';
 /**
  * Tests for Multi-Tenancy functionality.
  */
@@ -84,7 +85,7 @@ describe('Multi-Tenancy', () => {
 
   beforeEach(() => {
     clearStorage();
-    documentStore = getStorage<Document>('documents');
+    documentStore = getStore<Document>('documents');
 
     // Use OpenAPIHono directly for proper middleware support
     const honoApp = new OpenAPIHono();

--- a/tests/nested-writes.test.ts
+++ b/tests/nested-writes.test.ts
@@ -3,7 +3,7 @@ import {
   MemoryReadEndpoint,
   MemoryUpdateEndpoint,
   clearStorage,
-  getStorage,
+  getStore,
 } from '@hono-crud/memory';
 import { Hono } from 'hono';
 import { defineMeta, defineModel, fromHono } from 'hono-crud';
@@ -110,9 +110,9 @@ describe('Nested Writes', () => {
 
   beforeEach(() => {
     clearStorage();
-    userStore = getStorage<User>('users');
-    profileStore = getStorage<Profile>('profiles');
-    postStore = getStorage<Post>('posts');
+    userStore = getStore<User>('users');
+    profileStore = getStore<Profile>('profiles');
+    postStore = getStore<Post>('posts');
 
     app = fromHono(new Hono());
     app.post('/users', UserCreate);

--- a/tests/per-endpoint-middlewares.test.ts
+++ b/tests/per-endpoint-middlewares.test.ts
@@ -14,15 +14,8 @@
 
 import { MemoryAdapters, clearStorage } from '@hono-crud/memory';
 import { Hono } from 'hono';
-import {
-  MemoryApprovalStorage,
-  defineEndpoints,
-  defineMeta,
-  defineModel,
-  fromHono,
-  registerCrud,
-  requireApproval,
-} from 'hono-crud';
+import { defineEndpoints, defineMeta, defineModel, fromHono, registerCrud } from 'hono-crud';
+import { MemoryApprovalStorage, requireApproval } from 'hono-crud/auth';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 

--- a/tests/prior-state-hooks.test.ts
+++ b/tests/prior-state-hooks.test.ts
@@ -39,7 +39,7 @@ import {
   MemoryDeleteEndpoint,
   MemoryUpdateEndpoint,
   clearStorage,
-  getStorage,
+  getStore,
 } from '@hono-crud/memory';
 import { type HookContext, defineMeta, defineModel } from 'hono-crud';
 
@@ -63,7 +63,7 @@ describe('afterUpdate(prior, current, ctx) — memory adapter', () => {
 
   beforeEach(() => {
     clearStorage();
-    const store = getStorage<Row>('widgets');
+    const store = getStore<Row>('widgets');
     store.set('w1', { id: 'w1', name: 'A', counter: 1 });
   });
 
@@ -158,7 +158,7 @@ describe('afterDelete(prior, ctx) — memory adapter', () => {
       primaryKeys: ['id'],
     });
     const meta = defineMeta({ model: Model });
-    getStorage<Row>('rigid').set('d1', { id: 'd1', label: 'first' });
+    getStore<Row>('rigid').set('d1', { id: 'd1', label: 'first' });
 
     let captured: Row | undefined;
 
@@ -190,7 +190,7 @@ describe('afterDelete(prior, ctx) — memory adapter', () => {
       softDelete: true,
     });
     const meta = defineMeta({ model: Model });
-    getStorage<Row>('soft').set('s1', { id: 's1', label: 'soft', deletedAt: null });
+    getStore<Row>('soft').set('s1', { id: 's1', label: 'soft', deletedAt: null });
 
     let captured: Row | undefined;
 
@@ -218,7 +218,7 @@ describe('afterDelete(prior, ctx) — memory adapter', () => {
     expect(captured?.deletedAt ?? null).toBeNull();
 
     // Confirm the row was actually soft-deleted by inspecting the store.
-    const stored = getStorage<Row>('soft').get('s1');
+    const stored = getStore<Row>('soft').get('s1');
     expect(stored?.deletedAt).toBeTruthy();
   });
 });

--- a/tests/prisma.test.ts
+++ b/tests/prisma.test.ts
@@ -19,16 +19,13 @@ import {
   registerPrismaModelMappings,
 } from '@hono-crud/prisma';
 import { Hono } from 'hono';
+import { type AggregateOptions, defineModel, fromHono, registerCrud } from 'hono-crud';
 import {
-  type AggregateOptions,
   MemoryVersioningStorage,
   createVersionManager,
-  defineModel,
-  fromHono,
   getVersioningConfig,
-  registerCrud,
   setVersioningStorage,
-} from 'hono-crud';
+} from 'hono-crud/versioning';
 /**
  * Tests for Prisma ORM adapter.
  * Uses a mock Prisma client for testing without requiring a real database.

--- a/tests/require-approval.test.ts
+++ b/tests/require-approval.test.ts
@@ -15,13 +15,8 @@
 import { Hono } from 'hono';
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import {
-  ApiException,
-  MemoryApprovalStorage,
-  parseIso8601Duration,
-  requireApproval,
-  setContextVar,
-} from 'hono-crud';
+import { ApiException, setContextVar } from 'hono-crud';
+import { MemoryApprovalStorage, parseIso8601Duration, requireApproval } from 'hono-crud/auth';
 
 describe('requireApproval middleware', () => {
   let storage: MemoryApprovalStorage;

--- a/tests/require-policy.test.ts
+++ b/tests/require-policy.test.ts
@@ -29,9 +29,9 @@ import {
   defineMeta,
   defineModel,
   fromHono,
-  requirePolicy,
   setContextVar,
 } from 'hono-crud';
+import { requirePolicy } from 'hono-crud/auth';
 
 // ============================================================================
 // Fixture

--- a/tests/resolve-schema.test.ts
+++ b/tests/resolve-schema.test.ts
@@ -12,7 +12,8 @@
 
 import { MemoryCreateEndpoint, MemoryListEndpoint, clearStorage } from '@hono-crud/memory';
 import { OpenAPIHono } from '@hono/zod-openapi';
-import { buildPerTenantOpenApi, defineMeta, defineModel, fromHono, multiTenant } from 'hono-crud';
+import { buildPerTenantOpenApi, defineMeta, defineModel, fromHono } from 'hono-crud';
+import { multiTenant } from 'hono-crud/multi-tenant';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 

--- a/tests/response-envelope.test.ts
+++ b/tests/response-envelope.test.ts
@@ -33,7 +33,7 @@ import {
   MemoryReadEndpoint,
   MemoryUpdateEndpoint,
   clearStorage,
-  getStorage,
+  getStore,
 } from '@hono-crud/memory';
 import {
   ConflictException,
@@ -81,8 +81,8 @@ class Del extends MemoryDeleteEndpoint {
 
 beforeEach(() => {
   clearStorage();
-  getStorage<Row>('widgets_env').set('w1', { id: 'w1', name: 'one' });
-  getStorage<Row>('widgets_env').set('w2', { id: 'w2', name: 'two' });
+  getStore<Row>('widgets_env').set('w1', { id: 'w1', name: 'one' });
+  getStore<Row>('widgets_env').set('w2', { id: 'w2', name: 'two' });
 });
 
 // ============================================================================

--- a/tests/search-abstract-fixes.test.ts
+++ b/tests/search-abstract-fixes.test.ts
@@ -1,4 +1,4 @@
-import { MemorySearchEndpoint, clearStorage, getStorage } from '@hono-crud/memory';
+import { MemorySearchEndpoint, clearStorage, getStore } from '@hono-crud/memory';
 import { Hono } from 'hono';
 import { defineModel } from 'hono-crud';
 import type { SearchOptions, SearchResult } from 'hono-crud/core/types';
@@ -70,7 +70,7 @@ describe('Fix 1 — getSearchableFields() works on Zod 4', () => {
 
   it('returns a non-empty field set so default-search end-to-end matches rows', async () => {
     clearStorage();
-    const store = getStorage<Record<string, unknown>>('autodetect');
+    const store = getStore<Record<string, unknown>>('autodetect');
     store.set('a', { id: 'a', title: 'hello world', description: 'something' });
     store.set('b', { id: 'b', title: 'unrelated', description: 'something else' });
 
@@ -151,7 +151,7 @@ describe('Fix 2 — searchParamName changes the on-wire query param', () => {
 
   beforeEach(() => {
     clearStorage();
-    const store = getStorage<Record<string, unknown>>('posts');
+    const store = getStore<Record<string, unknown>>('posts');
     store.set('1', { id: '1', title: 'hello world', body: 'a post body' });
     store.set('2', { id: '2', title: 'goodbye', body: 'another post body' });
   });

--- a/tests/search-adapter-sql.test.ts
+++ b/tests/search-adapter-sql.test.ts
@@ -1,5 +1,5 @@
 import { type DrizzleDatabaseConstraint, DrizzleSearchEndpoint } from '@hono-crud/drizzle';
-import { MemorySearchEndpoint, clearStorage, getStorage } from '@hono-crud/memory';
+import { MemorySearchEndpoint, clearStorage, getStore } from '@hono-crud/memory';
 import { createClient } from '@libsql/client';
 import { sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/libsql';
@@ -304,7 +304,7 @@ describe('Memory search adapter — LIKE wildcard semantics (literal chars)', ()
 
   beforeEach(() => {
     clearStorage();
-    const store = getStorage<Record<string, unknown>>('memory_products');
+    const store = getStore<Record<string, unknown>>('memory_products');
     for (const row of ROWS) {
       store.set(row.id, row);
     }
@@ -339,7 +339,7 @@ describe("Memory search adapter — mode='all' token-AND semantics", () => {
 
   beforeEach(() => {
     clearStorage();
-    const store = getStorage<Record<string, unknown>>('memory_products');
+    const store = getStore<Record<string, unknown>>('memory_products');
     for (const row of ROWS) {
       store.set(row.id, row);
     }

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -1,4 +1,4 @@
-import { MemorySearchEndpoint, clearStorage, getStorage } from '@hono-crud/memory';
+import { MemorySearchEndpoint, clearStorage, getStore } from '@hono-crud/memory';
 import { Hono } from 'hono';
 import {
   buildSearchConfig,
@@ -253,7 +253,7 @@ describe('MemorySearchEndpoint', () => {
     clearStorage();
 
     // Seed test data
-    const store = getStorage<Record<string, unknown>>('articles');
+    const store = getStore<Record<string, unknown>>('articles');
 
     const articles = [
       {

--- a/tests/serialization-profile-finalize.test.ts
+++ b/tests/serialization-profile-finalize.test.ts
@@ -17,7 +17,7 @@ import {
   MemoryRestoreEndpoint,
   MemorySearchEndpoint,
   clearStorage,
-  getStorage,
+  getStore,
 } from '@hono-crud/memory';
 import { Hono } from 'hono';
 import { defineModel } from 'hono-crud';
@@ -89,7 +89,7 @@ describe('serializationProfile is applied by the finalize pipeline', () => {
 
   beforeEach(() => {
     clearStorage();
-    const store = getStorage<Record<string, unknown>>('widgets');
+    const store = getStore<Record<string, unknown>>('widgets');
     store.set('w1', { id: 'w1', name: 'alpha gadget', secret: 'top-secret-1', deletedAt: null });
     store.set('w2', { id: 'w2', name: 'beta gadget', secret: 'top-secret-2', deletedAt: null });
     // A soft-deleted record for the restore path.

--- a/tests/single-source-enums.test.ts
+++ b/tests/single-source-enums.test.ts
@@ -1,13 +1,8 @@
 import { DRIZZLE_DIALECTS } from '@hono-crud/drizzle';
-import {
-  AGGREGATE_OPERATIONS,
-  CRUD_EVENT_TYPES,
-  encryptedValueSchema,
-  isEncryptedValue,
-  JWT_ALGORITHMS,
-  SEARCH_MODES,
-  SORT_DIRECTIONS,
-} from 'hono-crud';
+import { AGGREGATE_OPERATIONS, SEARCH_MODES, SORT_DIRECTIONS } from 'hono-crud';
+import { JWT_ALGORITHMS } from 'hono-crud/auth';
+import { encryptedValueSchema, isEncryptedValue } from 'hono-crud/encryption';
+import { CRUD_EVENT_TYPES } from 'hono-crud/events';
 import { describe, expect, it } from 'vitest';
 
 // These lock the `as const` single-source arrays from which the corresponding

--- a/tests/storage-unification.test.ts
+++ b/tests/storage-unification.test.ts
@@ -239,10 +239,14 @@ describe('§4.2 two-getter contract per feature', () => {
 
 describe('§4.5 deleted createCrudMiddleware / unified createStorageMiddleware', () => {
   it('createCrudMiddleware is no longer exported from hono-crud', async () => {
-    const mod = (await import('hono-crud')) as Record<string, unknown>;
-    expect(mod.createCrudMiddleware).toBeUndefined();
-    // The replacement is present.
-    expect(typeof mod.createStorageMiddleware).toBe('function');
+    const rootMod = (await import('hono-crud')) as Record<string, unknown>;
+    const storageMod = (await import('hono-crud/storage')) as Record<string, unknown>;
+    expect(rootMod.createCrudMiddleware).toBeUndefined();
+    expect(storageMod.createCrudMiddleware).toBeUndefined();
+    // The replacement is present on its canonical subpath (the storage family
+    // lives only on 'hono-crud/storage', not on the root barrel).
+    expect(rootMod.createStorageMiddleware).toBeUndefined();
+    expect(typeof storageMod.createStorageMiddleware).toBe('function');
   });
 
   it('createStorageMiddleware injects all eight slots, readable via getStorage()', async () => {

--- a/tests/transactional-hooks.test.ts
+++ b/tests/transactional-hooks.test.ts
@@ -24,7 +24,7 @@ import {
   MemoryDeleteEndpoint,
   MemoryUpdateEndpoint,
   clearStorage,
-  getStorage,
+  getStore,
 } from '@hono-crud/memory';
 import { type HookContext, defineMeta, defineModel } from 'hono-crud';
 
@@ -143,7 +143,7 @@ describe('Transactional hooks — memory adapter', () => {
     // the after-hook threw, so the store retains it. (We assert presence
     // by size rather than a specific id because the memory adapter
     // auto-generates the primary key.)
-    const store = getStorage<z.infer<typeof Schema>>('memo_items');
+    const store = getStore<z.infer<typeof Schema>>('memo_items');
     expect(store.size).toBeGreaterThan(0);
   });
 });

--- a/tests/upsert.test.ts
+++ b/tests/upsert.test.ts
@@ -3,7 +3,7 @@ import {
   MemoryReadEndpoint,
   MemoryUpsertEndpoint,
   clearStorage,
-  getStorage,
+  getStore,
 } from '@hono-crud/memory';
 import { Hono } from 'hono';
 import { defineMeta, defineModel, fromHono } from 'hono-crud';
@@ -108,8 +108,8 @@ describe('Upsert', () => {
 
   beforeEach(() => {
     clearStorage();
-    userStore = getStorage<User>('users');
-    subscriptionStore = getStorage<Subscription>('subscriptions');
+    userStore = getStore<User>('users');
+    subscriptionStore = getStore<Subscription>('subscriptions');
 
     app = fromHono(new Hono());
     app.put('/users', UserUpsert);

--- a/tests/versioning.test.ts
+++ b/tests/versioning.test.ts
@@ -6,18 +6,18 @@ import {
   MemoryVersionReadEndpoint,
   MemoryVersionRollbackEndpoint,
   clearStorage,
-  getStorage,
+  getStore,
 } from '@hono-crud/memory';
 import { Hono } from 'hono';
+import { defineModel } from 'hono-crud';
 import {
   MemoryVersioningStorage,
   VersionManager,
   createVersionManager,
-  defineModel,
   getVersioningConfig,
   getVersioningStorage,
   setVersioningStorage,
-} from 'hono-crud';
+} from 'hono-crud/versioning';
 /**
  * Tests for record versioning functionality.
  */
@@ -384,7 +384,7 @@ describe('Record Versioning', () => {
   describe('UpdateEndpoint with Versioning', () => {
     it('should save version before update', async () => {
       // First create a document
-      const store = getStorage<Record<string, unknown>>('documents');
+      const store = getStore<Record<string, unknown>>('documents');
       const docId = crypto.randomUUID();
       store.set(docId, {
         id: docId,
@@ -432,7 +432,7 @@ describe('Record Versioning', () => {
     beforeEach(async () => {
       // Create a document
       docId = crypto.randomUUID();
-      const store = getStorage<Record<string, unknown>>('documents');
+      const store = getStore<Record<string, unknown>>('documents');
       store.set(docId, {
         id: docId,
         title: 'Current Title',
@@ -540,7 +540,7 @@ describe('Record Versioning', () => {
       expect(result.result.version).toBe(4); // Incremented to 4 after rollback
 
       // Verify the document was updated
-      const store = getStorage<Record<string, unknown>>('documents');
+      const store = getStore<Record<string, unknown>>('documents');
       const doc = store.get(docId);
       expect(doc?.title).toBe('Title v1');
       expect(doc?.version).toBe(4);

--- a/tests/workers/edge-compat.test.ts
+++ b/tests/workers/edge-compat.test.ts
@@ -95,7 +95,9 @@ describe('Edge Runtime Compatibility (Workers)', () => {
   describe('Hono app in Workers', () => {
     it('should import the root package entry in a Workers isolate', async () => {
       const mod = await import('hono-crud');
-      expect(mod.createStorageMiddleware).toBeTypeOf('function');
+      expect(mod.fromHono).toBeTypeOf('function');
+      const { createStorageMiddleware } = await import('hono-crud/storage');
+      expect(createStorageMiddleware).toBeTypeOf('function');
       const { KVCacheStorage } = await import('@hono-crud/cache');
       const { KVRateLimitStorage } = await import('@hono-crud/rate-limit');
       expect(KVCacheStorage).toBeTypeOf('function');
@@ -133,7 +135,8 @@ describe('Edge Runtime Compatibility (Workers)', () => {
       // createStorageMiddleware injects every first-class storage slot
       // (audit/versioning/logging/events plus cache/rate-limit/idempotency)
       // via the CONTEXT_KEYS lookup map.
-      const { createStorageMiddleware, MemoryAuditLogStorage } = await import('hono-crud');
+      const { createStorageMiddleware } = await import('hono-crud/storage');
+      const { MemoryAuditLogStorage } = await import('hono-crud/audit');
 
       const audit = new MemoryAuditLogStorage();
       const app = new Hono<StorageEnv>();


### PR DESCRIPTION
## Summary

Batch 3, PR-B (stacked on #67 — merge that first, then retarget/merge this). The breaking half of the export-surface restructure, enforcing the owner-approved ownership rule:

1. **Each feature subpath barrel is the complete canonical surface of its family.** Audit/versioning/multi-tenant barrels gain their previously root-only accessors (`getAuditConfig`, `calculateChanges`, `getVersioningConfig`, `getMultiTenantConfig`, `extractTenantId`).
2. **The root barrel owns only the CRUD core** — model/meta + the `core/types.ts` contract types, registrar (`fromHono`, `registerCrud`, ...), all endpoint classes, `defineEndpoints`, exceptions + error handler, generic context helpers + `CONTEXT_KEYS`, core utils, `HonoCrudEnv`. Feature runtime blocks (auth, logging, storage, events, serialization, encryption, api-version, audit, versioning, multi-tenant, functional, builder) are subpath-only.
3. **`/internal` is an explicit curated list** (123 symbols, organized by category, derived from the actual import sites + companion types) — `export * from './index'` is gone. Every public symbol now has exactly **one import path and one name**.
4. **All rename aliases deleted**: `getContextRequestId`, `matchLoggingPath`, `extractLoggingUserId`, `LoggingPathPattern`, 17 `Config*Endpoint` aliases. `getHandlerForApp` is module-private again.
5. **New `./builder` subpath** (config/functional had subpaths; builder didn't). Final exports map: 18 uniform entries.
6. `@hono-crud/memory` drops its `getStorage` alias (`getStore` is the name — root's `getStorage(ctx, key)` meant something unrelated); `@hono-crud/mcp` now imports only from `/internal` like every other satellite.

~60 test/example/doc files swept to subpath imports; CLAUDE.md gains the Export Surface Doctrine; latent bug fixed en route (a test importing `DrizzleDialect` from a path that never exported it).

Breaking, sanctioned pre-1.0 (patch bump per repo policy).

## Verification

`pnpm -r build` / `-r typecheck` / `typecheck:examples` / lint (0 errors) / `test:unit` 1158 / `test:workers` 42 / `example:local` / conformance typecheck — all green. Grep gates: zero satellite root imports, zero `export *` in internal.ts, zero deleted aliases repo-wide. `pnpm pack` tarball: all 18 exports-map entries resolve (incl. `dist/builder`, `dist/health`, `dist/cloudflare`).