### PR TITLE
feat: real keyset cursor pagination on all adapters

### DIFF
--- a/.changeset/keyset-cursor-pagination.md
+++ b/.changeset/keyset-cursor-pagination.md
@@ -1,0 +1,14 @@
+---
+"hono-crud": patch
+"@hono-crud/memory": patch
+"@hono-crud/drizzle": patch
+"@hono-crud/prisma": patch
+---
+
+Cursor pagination is now real on all three adapters. Previously core advertised cursor query params and `next_cursor`/`prev_cursor` response fields, but only the memory adapter implemented them — Drizzle and Prisma silently fell back to offset pagination.
+
+- **Drizzle**: keyset via `WHERE cursorField > decoded ORDER BY cursorField LIMIT n+1`; **Prisma**: native `cursor` + `skip: 1` + `take: n+1`. All three adapters build the cursor-mode `result_info` envelope through one shared core helper, so the shape is byte-identical.
+- **`prev_cursor` removed** (breaking): cursor walks are next-only (Stripe-style) — SQL keyset "previous" requires a reversed query and was only ever implemented in memory.
+- **`order_by` is forced to the cursor field during cursor walks** (documented on the query param) — previously the three adapters could diverge on sort semantics mid-walk.
+- **No silent degradation**: cursor query params and `next_cursor` only appear in the OpenAPI schema when the endpoint enables cursor pagination AND the adapter supports it; enabling it on an unsupporting adapter throws `ConfigurationException` instead of quietly serving offset pages.
+- List-query logic deduplicated per adapter (`executeDrizzleListQuery` / memory store query helper, mirroring Prisma's existing `executePrismaQuery`) and batch OpenAPI scaffolding shared by the three id-keyed batch verbs.

--- a/packages/core/src/core/cursor.ts
+++ b/packages/core/src/core/cursor.ts
@@ -2,6 +2,8 @@
  * Cursor-pagination codec. Opaque base64 wrapper around a cursor value.
  */
 
+import type { PaginatedResult } from './types';
+
 /** Encodes a cursor value to an opaque base64 string. */
 export function encodeCursor(value: string | number): string {
   return btoa(String(value));
@@ -17,4 +19,62 @@ export function decodeCursor(cursor: string): string | null {
   } catch {
     return null;
   }
+}
+
+/** Input for {@link buildCursorPage}. */
+export interface CursorPageInput<T> {
+  /**
+   * The overfetched window: up to `limit + 1` rows ordered ascending by the
+   * cursor field. The extra row is the has-more sentinel; the helper trims it.
+   */
+  rows: T[];
+  /** Page size of the cursor walk (`?limit=`, falling back to per_page). */
+  limit: number;
+  /** Total rows matching the filters (WITHOUT the cursor window condition). */
+  totalCount: number;
+  /** Field the cursor encodes — `next_cursor` derives from the boundary row. */
+  cursorField: string;
+  /** Whether a valid decoded cursor was applied to this query (not page one). */
+  cursorApplied: boolean;
+}
+
+/** Output of {@link buildCursorPage}: trimmed page + cursor-mode result_info. */
+export interface CursorPage<T> {
+  items: T[];
+  result_info: PaginatedResult<T>['result_info'];
+}
+
+/**
+ * Builds the cursor-mode page from an overfetched keyset window.
+ *
+ * The single source of the cursor-mode `result_info` envelope so the three
+ * adapters (memory/drizzle/prisma) return byte-identical shapes:
+ * `{ page: 0, per_page: limit, total_count, has_next_page, has_prev_page,
+ * next_cursor? }` — no `total_pages`, no `prev_cursor` (cursor walks are
+ * next-only, Stripe-style). Adapters fetch `limit + 1` rows ordered by the
+ * cursor field; the surplus row proves there is a next page and is trimmed
+ * here, and `next_cursor` encodes the boundary (last returned) row's cursor
+ * field.
+ */
+export function buildCursorPage<T>(input: CursorPageInput<T>): CursorPage<T> {
+  const { rows, limit, totalCount, cursorField, cursorApplied } = input;
+
+  const hasNextPage = rows.length > limit;
+  const items = hasNextPage ? rows.slice(0, limit) : rows;
+  const boundary = items[items.length - 1] as unknown as Record<string, unknown> | undefined;
+
+  return {
+    items,
+    result_info: {
+      page: 0,
+      per_page: limit,
+      total_count: totalCount,
+      has_next_page: hasNextPage,
+      has_prev_page: cursorApplied,
+      next_cursor:
+        hasNextPage && boundary !== undefined
+          ? encodeCursor(boundary[cursorField] as string | number)
+          : undefined,
+    },
+  };
 }

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -166,10 +166,11 @@ export interface PaginatedResult<T> {
     has_next_page: boolean;
     /** Whether there is a previous page available */
     has_prev_page: boolean;
-    /** Cursor for fetching the next page (cursor-based pagination) */
+    /**
+     * Cursor for fetching the next page (cursor-based pagination).
+     * Cursor walks are next-only (Stripe-style); there is no prev_cursor.
+     */
     next_cursor?: string;
-    /** Cursor for fetching the previous page (cursor-based pagination) */
-    prev_cursor?: string;
   };
 }
 

--- a/packages/core/src/endpoints/batch-delete.ts
+++ b/packages/core/src/endpoints/batch-delete.ts
@@ -1,8 +1,8 @@
 import type { Env } from 'hono';
-import { type ZodObject, type ZodRawShape, z } from 'zod';
+import type { ZodObject, ZodRawShape } from 'zod';
 import type { HookMode, MetaInput, OpenAPIRouteSchema } from '../core/types';
 import { CrudEndpoint } from './base';
-import { errorResponseSchema } from './responses';
+import { batchResultResponses, errorResponseSchema, idsBodySchema } from './responses';
 import type { ModelObject } from './types';
 
 /**
@@ -77,9 +77,7 @@ export abstract class BatchDeleteEndpoint<
    * Returns the request body schema for batch deletion.
    */
   protected getBodySchema(): ZodObject<ZodRawShape> {
-    return z.object({
-      ids: z.array(z.string()).min(1).max(this.maxBatchSize),
-    }) as unknown as ZodObject<ZodRawShape>;
+    return idsBodySchema(this.maxBatchSize);
   }
 
   /**
@@ -99,46 +97,11 @@ export abstract class BatchDeleteEndpoint<
         },
       },
       responses: {
-        200: {
-          description: softDelete
-            ? 'Resources soft-deleted successfully'
-            : 'Resources deleted successfully',
-          content: {
-            'application/json': {
-              schema: z.object({
-                success: z.literal(true),
-                result: z.object({
-                  deleted: z.array(this.getModelSchema()),
-                  count: z.number(),
-                  notFound: z.array(z.string()).optional(),
-                }),
-              }),
-            },
-          },
-        },
-        207: {
-          description: 'Partial success (some items failed or not found)',
-          content: {
-            'application/json': {
-              schema: z.object({
-                success: z.literal(true),
-                result: z.object({
-                  deleted: z.array(this.getModelSchema()),
-                  count: z.number(),
-                  notFound: z.array(z.string()).optional(),
-                  errors: z
-                    .array(
-                      z.object({
-                        id: z.string(),
-                        error: z.string(),
-                      }),
-                    )
-                    .optional(),
-                }),
-              }),
-            },
-          },
-        },
+        ...batchResultResponses(
+          'deleted',
+          this.getModelSchema(),
+          softDelete ? 'Resources soft-deleted successfully' : 'Resources deleted successfully',
+        ),
         400: errorResponseSchema('Validation error'),
       },
     };

--- a/packages/core/src/endpoints/batch-restore.ts
+++ b/packages/core/src/endpoints/batch-restore.ts
@@ -1,9 +1,9 @@
 import type { Env } from 'hono';
-import { type ZodObject, type ZodRawShape, z } from 'zod';
+import type { ZodObject, ZodRawShape } from 'zod';
 import { ApiException } from '../core/exceptions';
 import type { HookMode, MetaInput, OpenAPIRouteSchema } from '../core/types';
 import { CrudEndpoint } from './base';
-import { errorResponseSchema } from './responses';
+import { batchResultResponses, errorResponseSchema, idsBodySchema } from './responses';
 import type { ModelObject } from './types';
 
 /**
@@ -78,9 +78,7 @@ export abstract class BatchRestoreEndpoint<
    * Returns the request body schema for batch restoration.
    */
   protected getBodySchema(): ZodObject<ZodRawShape> {
-    return z.object({
-      ids: z.array(z.string()).min(1).max(this.maxBatchSize),
-    }) as unknown as ZodObject<ZodRawShape>;
+    return idsBodySchema(this.maxBatchSize);
   }
 
   /**
@@ -99,44 +97,11 @@ export abstract class BatchRestoreEndpoint<
         },
       },
       responses: {
-        200: {
-          description: 'Resources restored successfully',
-          content: {
-            'application/json': {
-              schema: z.object({
-                success: z.literal(true),
-                result: z.object({
-                  restored: z.array(this.getModelSchema()),
-                  count: z.number(),
-                  notFound: z.array(z.string()).optional(),
-                }),
-              }),
-            },
-          },
-        },
-        207: {
-          description: 'Partial success (some items failed or not found)',
-          content: {
-            'application/json': {
-              schema: z.object({
-                success: z.literal(true),
-                result: z.object({
-                  restored: z.array(this.getModelSchema()),
-                  count: z.number(),
-                  notFound: z.array(z.string()).optional(),
-                  errors: z
-                    .array(
-                      z.object({
-                        id: z.string(),
-                        error: z.string(),
-                      }),
-                    )
-                    .optional(),
-                }),
-              }),
-            },
-          },
-        },
+        ...batchResultResponses(
+          'restored',
+          this.getModelSchema(),
+          'Resources restored successfully',
+        ),
         400: errorResponseSchema('Soft delete not enabled or validation error'),
       },
     };

--- a/packages/core/src/endpoints/batch-update.ts
+++ b/packages/core/src/endpoints/batch-update.ts
@@ -3,7 +3,7 @@ import { type ZodObject, type ZodRawShape, z } from 'zod';
 import { getManagedInputExclusions } from '../core/managed-fields';
 import type { HookMode, MetaInput, OpenAPIRouteSchema } from '../core/types';
 import { CrudEndpoint } from './base';
-import { errorResponseSchema } from './responses';
+import { batchResultResponses, errorResponseSchema } from './responses';
 import { type ModelObject, getSchemaFields } from './types';
 
 /**
@@ -127,44 +127,7 @@ export abstract class BatchUpdateEndpoint<
         },
       },
       responses: {
-        200: {
-          description: 'Resources updated successfully',
-          content: {
-            'application/json': {
-              schema: z.object({
-                success: z.literal(true),
-                result: z.object({
-                  updated: z.array(this.getModelSchema()),
-                  count: z.number(),
-                  notFound: z.array(z.string()).optional(),
-                }),
-              }),
-            },
-          },
-        },
-        207: {
-          description: 'Partial success (some items failed or not found)',
-          content: {
-            'application/json': {
-              schema: z.object({
-                success: z.literal(true),
-                result: z.object({
-                  updated: z.array(this.getModelSchema()),
-                  count: z.number(),
-                  notFound: z.array(z.string()).optional(),
-                  errors: z
-                    .array(
-                      z.object({
-                        id: z.string(),
-                        error: z.string(),
-                      }),
-                    )
-                    .optional(),
-                }),
-              }),
-            },
-          },
-        },
+        ...batchResultResponses('updated', this.getModelSchema(), 'Resources updated successfully'),
         400: errorResponseSchema('Validation error'),
       },
     };

--- a/packages/core/src/endpoints/list.ts
+++ b/packages/core/src/endpoints/list.ts
@@ -1,5 +1,6 @@
 import type { Env } from 'hono';
 import { type ZodObject, type ZodRawShape, z } from 'zod';
+import { ConfigurationException } from '../core/exceptions';
 import type {
   FilterConfig,
   MetaInput,
@@ -52,15 +53,42 @@ export abstract class ListEndpoint<
   /**
    * Enable cursor-based pagination.
    * When enabled, clients can use `?cursor=xxx&limit=N` alongside standard page/per_page.
-   * The cursor is an opaque base64-encoded string representing the last item's sort key.
+   * The cursor is an opaque base64-encoded string encoding the boundary item's
+   * cursor field; walks are next-only (Stripe-style, no prev_cursor).
+   *
+   * During a cursor walk, results are always ordered by {@link cursorField}
+   * ascending — user `sort`/`order` parameters are ignored.
+   *
+   * Requires an adapter whose `list` implements the keyset window
+   * ({@link supportsCursorPagination}); enabling it on an adapter without
+   * support throws a loud `ConfigurationException` at request time instead of
+   * silently falling back to offset pagination.
    */
   protected cursorPaginationEnabled = false;
 
   /**
+   * Whether the adapter's `list` implementation supports keyset cursor
+   * pagination. Declared by adapter List endpoints (memory/drizzle/prisma all
+   * set it to `true`); stays `false` on the abstract core class so an adapter
+   * that never implemented the cursor window cannot silently degrade to
+   * offset pagination.
+   */
+  protected supportsCursorPagination = false;
+
+  /**
    * The field used as the cursor key. Must be unique and sortable (e.g., primary key or timestamp).
-   * @default 'id' (first primary key)
+   * @default 'id'
    */
   protected cursorField?: string;
+
+  /**
+   * Cursor pagination is only advertised (query params + `next_cursor` doc
+   * schema) and parsed when the endpoint enables it AND the adapter
+   * implements it.
+   */
+  protected isCursorPaginationActive(): boolean {
+    return this.cursorPaginationEnabled && this.supportsCursorPagination;
+  }
 
   // Relations configuration
   /** Allowed relation names that can be included via ?include=relation1,relation2 */
@@ -175,10 +203,12 @@ export abstract class ListEndpoint<
         });
     }
 
-    // Add cursor-based pagination parameters
-    if (this.cursorPaginationEnabled) {
+    // Add cursor-based pagination parameters (only when the adapter actually
+    // implements the keyset window — never advertise a no-op).
+    if (this.isCursorPaginationActive()) {
       shape.cursor = z.string().optional().meta({
-        description: 'Opaque cursor for fetching the next page',
+        description:
+          'Opaque cursor for fetching the next page. During a cursor walk, results are ordered by the cursor field ascending and sort/order are ignored.',
       });
       shape.limit = z.string().optional().meta({
         description: 'Number of items to return (cursor pagination)',
@@ -219,6 +249,21 @@ export abstract class ListEndpoint<
    * Generates OpenAPI schema from meta configuration.
    */
   getSchema(): OpenAPIRouteSchema {
+    // `next_cursor` is only documented when cursor pagination is genuinely
+    // available (enabled AND implemented by the adapter); cursor walks are
+    // next-only, so no prev_cursor exists anywhere.
+    const resultInfoShape: Record<string, z.ZodTypeAny> = {
+      page: z.number(),
+      per_page: z.number(),
+      total_count: z.number().optional(),
+      total_pages: z.number().optional(),
+      has_next_page: z.boolean(),
+      has_prev_page: z.boolean(),
+    };
+    if (this.isCursorPaginationActive()) {
+      resultInfoShape.next_cursor = z.string().optional();
+    }
+
     return {
       ...this.schema,
       request: {
@@ -232,16 +277,7 @@ export abstract class ListEndpoint<
               schema: z.object({
                 success: z.literal(true),
                 result: z.array(this.getModelSchema()),
-                result_info: z.object({
-                  page: z.number(),
-                  per_page: z.number(),
-                  total_count: z.number().optional(),
-                  total_pages: z.number().optional(),
-                  has_next_page: z.boolean(),
-                  has_prev_page: z.boolean(),
-                  next_cursor: z.string().optional(),
-                  prev_cursor: z.string().optional(),
-                }),
+                result_info: z.object(resultInfoShape),
               }),
             },
           },
@@ -267,7 +303,7 @@ export abstract class ListEndpoint<
       defaultSort: this.defaultSort,
       defaultPerPage: this.defaultPerPage,
       maxPerPage: this.maxPerPage,
-      cursorPaginationEnabled: this.cursorPaginationEnabled,
+      cursorPaginationEnabled: this.isCursorPaginationActive(),
       cursorField: this.cursorField,
       softDeleteQueryParam: softDeleteConfig.queryParam,
       allowedIncludes: this.allowedIncludes,
@@ -319,6 +355,16 @@ export abstract class ListEndpoint<
    * Main handler for the list operation.
    */
   async handle(): Promise<Response> {
+    // Loud misconfiguration: cursor pagination was enabled on an adapter
+    // whose `list` does not implement the keyset window. Silently falling
+    // back to offset pagination is the one unacceptable state — clients would
+    // get documented-looking cursor params that are validated then ignored.
+    if (this.cursorPaginationEnabled && !this.supportsCursorPagination) {
+      throw new ConfigurationException(
+        "cursorPaginationEnabled is true but this adapter's List endpoint does not implement cursor pagination (supportsCursorPagination is false). Use an adapter List endpoint that supports it, or disable cursorPaginationEnabled.",
+      );
+    }
+
     // Validate tenant ID if multi-tenancy is enabled
     const tenantId = this.validateTenantId();
 

--- a/packages/core/src/endpoints/responses.ts
+++ b/packages/core/src/endpoints/responses.ts
@@ -1,6 +1,7 @@
 /**
- * Shared OpenAPI error-response factories — the exported, doc-facing source
- * of truth for the canonical error envelope.
+ * Shared OpenAPI response factories — the exported, doc-facing source of
+ * truth for the canonical error envelope, plus the scaffolding shared by the
+ * id-keyed batch verbs (`idsBodySchema` / `batchResultResponses`).
  *
  * Every endpoint declares the same `{ success: false, error: { code,
  * message, details? } }` envelope for its 4xx/5xx responses. These factories
@@ -14,7 +15,7 @@
  * test.
  */
 
-import { type ZodObject, z } from 'zod';
+import { type ZodObject, type ZodRawShape, type ZodType, z } from 'zod';
 
 /** The error-envelope Zod object: `{ success: false, error: {...} }`. */
 export function errorResponseZodSchema(): ZodObject<{
@@ -60,4 +61,69 @@ export function errorResponses(
     out[Number(status)] = errorResponseSchema(description);
   }
   return out;
+}
+
+/**
+ * Request-body schema shared by the ids-keyed batch verbs (batch-delete /
+ * batch-restore): `{ ids: string[] }` with 1..maxBatchSize entries.
+ */
+export function idsBodySchema(maxBatchSize: number): ZodObject<ZodRawShape> {
+  return z.object({
+    ids: z.array(z.string()).min(1).max(maxBatchSize),
+  }) as unknown as ZodObject<ZodRawShape>;
+}
+
+/**
+ * The 200 + 207 OpenAPI response pair shared by the three id-keyed batch
+ * verbs (batch-delete / batch-restore / batch-update). The 200 result is
+ * `{ [resultKey]: Model[], count, notFound? }`; the 207 adds the per-id
+ * `errors` block. Spread into a `responses` map and add the verb-specific
+ * 400 alongside.
+ *
+ * batch-create is intentionally NOT a consumer: its envelope genuinely
+ * differs (201 success status, no `notFound`, errors keyed by `index:
+ * number` rather than `id: string`). batch-upsert (200-only,
+ * items/createdCount/updatedCount envelope) is likewise out of scope.
+ */
+export function batchResultResponses(
+  resultKey: string,
+  modelSchema: ZodType,
+  successDescription: string,
+) {
+  const resultSchema = (withErrors: boolean) =>
+    z.object({
+      success: z.literal(true),
+      result: z.object({
+        [resultKey]: z.array(modelSchema),
+        count: z.number(),
+        notFound: z.array(z.string()).optional(),
+        ...(withErrors
+          ? {
+              errors: z
+                .array(
+                  z.object({
+                    id: z.string(),
+                    error: z.string(),
+                  }),
+                )
+                .optional(),
+            }
+          : {}),
+      }),
+    });
+
+  return {
+    200: {
+      description: successDescription,
+      content: {
+        'application/json': { schema: resultSchema(false) },
+      },
+    },
+    207: {
+      description: 'Partial success (some items failed or not found)',
+      content: {
+        'application/json': { schema: resultSchema(true) },
+      },
+    },
+  };
 }

--- a/packages/core/src/endpoints/types.ts
+++ b/packages/core/src/endpoints/types.ts
@@ -133,6 +133,7 @@ export function parseListFilters(
     defaultPerPage = 20,
     maxPerPage = 100,
     cursorPaginationEnabled = false,
+    cursorField,
     softDeleteQueryParam = 'withDeleted',
     allowedIncludes = [],
     fieldSelectionEnabled = false,
@@ -275,6 +276,17 @@ export function parseListFilters(
   if (!options.per_page) options.per_page = defaultPerPage;
   if (!options.order_by && defaultSort?.field) options.order_by = defaultSort.field;
   if (!options.order_by_direction) options.order_by_direction = defaultSort?.order ?? 'asc';
+
+  // Cursor-mode ordering contract (defined ONCE, for every adapter): when a
+  // cursor walk is in play (`cursor` and/or `limit` supplied with cursor
+  // pagination enabled), ORDER BY is forced to the cursor field ascending —
+  // user `sort`/`order` are ignored. Keyset pagination is only correct when
+  // rows are ordered by the cursor key, so adapters must never see a
+  // conflicting order_by alongside cursor options.
+  if (cursorPaginationEnabled && (options.cursor !== undefined || options.limit !== undefined)) {
+    options.order_by = cursorField ?? 'id';
+    options.order_by_direction = 'asc';
+  }
 
   // Apply default fields if field selection is enabled but no fields were specified
   if (fieldSelectionEnabled && !options.fields && defaultSelectFields.length > 0) {

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -111,8 +111,11 @@ export {
 // Orchestration helpers adapters call back into
 // ============================================================================
 
-// Cursor codecs shared by every list/pagination implementation.
-export { encodeCursor, decodeCursor } from './core/cursor';
+// Cursor codecs shared by every list/pagination implementation, plus the
+// cursor-mode result_info builder that keeps the three adapters' cursor
+// envelopes byte-identical.
+export { encodeCursor, decodeCursor, buildCursorPage } from './core/cursor';
+export type { CursorPage, CursorPageInput } from './core/cursor';
 
 // Upsert-family soft-delete restore ("match-and-restore" contract).
 export { applyUpsertRestore } from './core/soft-delete';

--- a/packages/drizzle/src/advanced.ts
+++ b/packages/drizzle/src/advanced.ts
@@ -1,4 +1,4 @@
-import { asc, desc, eq, isNotNull, isNull, sql } from 'drizzle-orm';
+import { eq, isNull, sql } from 'drizzle-orm';
 import type { Env } from 'hono';
 import { UpsertEndpoint } from 'hono-crud/internal';
 import { BatchUpsertEndpoint } from 'hono-crud/internal';
@@ -34,8 +34,10 @@ import {
   type DrizzleTable,
   and,
   batchLoadDrizzleRelations,
+  buildPaginatedResult,
   buildWhereCondition,
   cast,
+  executeDrizzleListQuery,
   findByUpsertKeys,
   getColumn,
   getTable,
@@ -689,25 +691,11 @@ export abstract class DrizzleSearchEndpoint<
     filters: ListFilters,
   ): Promise<SearchResult<ModelObject<M['model']>>> {
     const table = this.getTable();
+
+    // Search-specific SQL — plugged into the shared list-query executor as
+    // extra conditions (soft-delete + filters + count + order + pagination
+    // all run through `executeDrizzleListQuery`, identical to List/Export).
     const conditions: DrizzleSql[] = [];
-
-    // Apply soft delete filter
-    const softDeleteConfig = this.getSoftDeleteConfig();
-    if (softDeleteConfig.enabled) {
-      if (filters.options.onlyDeleted) {
-        conditions.push(isNotNull(this.getColumn(softDeleteConfig.field)));
-      } else if (!filters.options.withDeleted) {
-        conditions.push(isNull(this.getColumn(softDeleteConfig.field)));
-      }
-    }
-
-    // Apply filters
-    for (const filter of filters.filters) {
-      const condition = buildWhereCondition(table, filter, this.dialect);
-      if (condition) {
-        conditions.push(condition);
-      }
-    }
 
     // Build search conditions
     const searchableFields = this.getSearchableFields();
@@ -777,32 +765,20 @@ export abstract class DrizzleSearchEndpoint<
       }
     }
 
-    const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+    // Execute the common query block (soft-delete + filters + count +
+    // sorting + offset pagination) with the search SQL as extra conditions.
+    const queryResult = await executeDrizzleListQuery<ModelObject<M['model']>>({
+      db: this.getDb(),
+      table,
+      filters,
+      dialect: this.dialect,
+      softDeleteConfig: this.getSoftDeleteConfig(),
+      defaultPerPage: this.defaultPerPage,
+      extraConditions: conditions,
+    });
 
-    // Get total count
-    const countResult = await cast<ModelObject<M['model']>>(this.getDb())
-      .select({ count: sql<number>`count(*)` })
-      .from(table)
-      .where(whereClause);
-
-    const totalCount = readCount(countResult);
-
-    // Build main query
-    let query = cast<ModelObject<M['model']>>(this.getDb()).select().from(table).where(whereClause);
-
-    // Apply sorting
-    if (filters.options.order_by) {
-      const orderColumn = this.getColumn(filters.options.order_by);
-      const orderFn = filters.options.order_by_direction === 'desc' ? desc : asc;
-      query = query.orderBy(orderFn(orderColumn));
-    }
-
-    // Apply pagination
-    const page = filters.options.page || 1;
-    const perPage = filters.options.per_page || this.defaultPerPage;
-    query = query.limit(perPage).offset((page - 1) * perPage);
-
-    const records = await query;
+    const records = queryResult.records;
+    const totalCount = queryResult.totalCount;
 
     // Score results in memory and generate highlights.
     //
@@ -871,88 +847,27 @@ export abstract class DrizzleExportEndpoint<
   }
 
   override async list(filters: ListFilters): Promise<PaginatedResult<ModelObject<M['model']>>> {
-    const table = this.getTable();
-    const conditions: DrizzleSql[] = [];
-    const softDeleteConfig = this.getSoftDeleteConfig();
-
-    // Apply soft delete filter
-    if (softDeleteConfig.enabled) {
-      const deletedAtColumn = this.getColumn(softDeleteConfig.field);
-
-      if (filters.options.onlyDeleted) {
-        conditions.push(isNotNull(deletedAtColumn));
-      } else if (!filters.options.withDeleted) {
-        conditions.push(isNull(deletedAtColumn));
-      }
-    }
-
-    // Apply filters
-    for (const filter of filters.filters) {
-      const condition = buildWhereCondition(table, filter, this.dialect);
-      if (condition) {
-        conditions.push(condition);
-      }
-    }
-
-    // Apply search
-    if (filters.options.search && this.searchFields.length > 0) {
-      const needle = filters.options.search;
-      const searchConditions = this.searchFields.map((field) => {
-        const column = this.getColumn(field);
-        return substringMatch(column, needle, this.dialect);
-      });
-      conditions.push(or(...searchConditions)!);
-    }
-
-    const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
-
-    // Get total count
-    const countResult = await cast<ModelObject<M['model']>>(this.getDb())
-      .select({ count: sql<number>`count(*)` })
-      .from(table)
-      .where(whereClause);
-
-    const totalCount = readCount(countResult);
-
-    // Build main query
-    let query = cast<ModelObject<M['model']>>(this.getDb()).select().from(table).where(whereClause);
-
-    // Apply sorting
-    if (filters.options.order_by) {
-      const orderColumn = this.getColumn(filters.options.order_by);
-      const orderFn = filters.options.order_by_direction === 'desc' ? desc : asc;
-      query = query.orderBy(orderFn(orderColumn));
-    }
-
-    // Apply pagination
-    const page = filters.options.page || 1;
-    const perPage = filters.options.per_page || this.defaultPerPage;
-    query = query.limit(perPage).offset((page - 1) * perPage);
-
-    const result = await query;
+    // Execute common query logic (filters, search, sorting, pagination)
+    const queryResult = await executeDrizzleListQuery<ModelObject<M['model']>>({
+      db: this.getDb(),
+      table: this.getTable(),
+      filters,
+      dialect: this.dialect,
+      searchFields: this.searchFields,
+      softDeleteConfig: this.getSoftDeleteConfig(),
+      defaultPerPage: this.defaultPerPage,
+    });
 
     // Load relations if requested using batch loading to avoid N+1 queries
     const includeOptions: IncludeOptions = { relations: filters.options.include || [] };
     const itemsWithRelations = await batchLoadDrizzleRelations(
       this.getDb(),
-      result,
+      queryResult.records,
       this._meta,
       includeOptions,
     );
 
-    const totalPages = Math.ceil(totalCount / perPage);
-
-    return {
-      result: itemsWithRelations,
-      result_info: {
-        page,
-        per_page: perPage,
-        total_count: totalCount,
-        total_pages: totalPages,
-        has_next_page: page < totalPages,
-        has_prev_page: page > 1,
-      },
-    };
+    return buildPaginatedResult(itemsWithRelations, queryResult);
   }
 }
 

--- a/packages/drizzle/src/crud.ts
+++ b/packages/drizzle/src/crud.ts
@@ -1,6 +1,6 @@
-import { asc, desc, eq, isNotNull, isNull, sql } from 'drizzle-orm';
+import { eq, isNotNull, isNull, sql } from 'drizzle-orm';
 import type { Env } from 'hono';
-import { getLogger } from 'hono-crud/internal';
+import { buildCursorPage, getLogger } from 'hono-crud/internal';
 import { CreateEndpoint } from 'hono-crud/internal';
 import { ReadEndpoint } from 'hono-crud/internal';
 import { UpdateEndpoint } from 'hono-crud/internal';
@@ -17,7 +17,6 @@ import type {
   RelationConfig,
 } from 'hono-crud/internal';
 import type { ModelObject } from 'hono-crud/internal';
-import { substringMatch } from './advanced';
 import { getDrizzleDb } from './connection';
 import {
   type DrizzleColumn,
@@ -27,12 +26,12 @@ import {
   type DrizzleTable,
   and,
   batchLoadDrizzleRelations,
-  buildWhereCondition,
+  buildPaginatedResult,
   cast,
+  executeDrizzleListQuery,
   getColumn,
   getTable,
   loadDrizzleRelations,
-  or,
   readCount,
 } from './helpers';
 
@@ -776,6 +775,9 @@ export abstract class DrizzleListEndpoint<
    */
   protected dialect: DrizzleDialect = 'sqlite';
 
+  /** Keyset cursor pagination is implemented (`WHERE cursorField > decoded`). */
+  protected override supportsCursorPagination = true;
+
   /** Gets the database instance from property or context */
   protected getDb(): DB {
     return getDrizzleDb(this) as DB;
@@ -790,99 +792,48 @@ export abstract class DrizzleListEndpoint<
   }
 
   override async list(filters: ListFilters): Promise<PaginatedResult<ModelObject<M['model']>>> {
-    const table = this.getTable();
-    const conditions: DrizzleSql[] = [];
-    const softDeleteConfig = this.getSoftDeleteConfig();
+    // Execute common query logic (filters, search, sorting, pagination)
+    const queryResult = await executeDrizzleListQuery<ModelObject<M['model']>>({
+      db: this.getDb(),
+      table: this.getTable(),
+      filters,
+      dialect: this.dialect,
+      searchFields: this.searchFields,
+      softDeleteConfig: this.getSoftDeleteConfig(),
+      defaultPerPage: this.defaultPerPage,
+      cursorField: this.isCursorPaginationActive() ? this.cursorField || 'id' : undefined,
+    });
 
-    // Apply soft delete filter
-    if (softDeleteConfig.enabled) {
-      const deletedAtColumn = this.getColumn(softDeleteConfig.field);
+    const includeOptions: IncludeOptions = { relations: filters.options.include || [] };
 
-      if (filters.options.onlyDeleted) {
-        // Show only deleted records
-        conditions.push(isNotNull(deletedAtColumn));
-      } else if (!filters.options.withDeleted) {
-        // Default: exclude deleted records
-        conditions.push(isNull(deletedAtColumn));
-      }
-      // If withDeleted=true, don't add any condition (show all)
-    }
-
-    // Apply filters
-    for (const filter of filters.filters) {
-      const condition = buildWhereCondition(table, filter, this.dialect);
-      if (condition) {
-        conditions.push(condition);
-      }
-    }
-
-    // Apply search
-    if (filters.options.search && this.searchFields.length > 0) {
-      const needle = filters.options.search;
-      const searchConditions = this.searchFields.map((field) => {
-        const column = this.getColumn(field);
-        // Dialect-native substring match (INSTR/POSITION/LOCATE). The needle
-        // is never injected into a LIKE pattern, so user-supplied `%` and `_`
-        // are inert literal characters — no wildcard surface, no escape
-        // sequence needed. Mirrors the dedicated search endpoint
-        // (`DrizzleSearchEndpoint`) and the export endpoint, and aligns
-        // with memory/Prisma which already use literal substring matching.
-        return substringMatch(column, needle, this.dialect);
+    // Keyset cursor page: trim the has-more sentinel row before loading
+    // relations, then return the canonical cursor-mode envelope.
+    if (queryResult.cursor) {
+      const { items, result_info } = buildCursorPage({
+        rows: queryResult.records,
+        limit: queryResult.cursor.limit,
+        totalCount: queryResult.totalCount,
+        cursorField: this.cursorField || 'id',
+        cursorApplied: queryResult.cursor.applied,
       });
-      conditions.push(or(...searchConditions)!);
+      const itemsWithRelations = await batchLoadDrizzleRelations(
+        this.getDb(),
+        items,
+        this._meta,
+        includeOptions,
+      );
+      return { result: itemsWithRelations, result_info };
     }
-
-    // Build where clause
-    const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
-
-    // Get total count using COUNT(*)
-    const db = this.getDb();
-    const countResult = await cast(db)
-      .select({ count: sql<number>`count(*)` })
-      .from(table)
-      .where(whereClause);
-
-    const totalCount = readCount(countResult);
-
-    // Build main query
-    let query = cast<ModelObject<M['model']>>(db).select().from(table).where(whereClause);
-
-    // Apply sorting
-    if (filters.options.order_by) {
-      const orderColumn = this.getColumn(filters.options.order_by);
-      const orderFn = filters.options.order_by_direction === 'desc' ? desc : asc;
-      query = query.orderBy(orderFn(orderColumn));
-    }
-
-    // Apply pagination
-    const page = filters.options.page || 1;
-    const perPage = filters.options.per_page || this.defaultPerPage;
-    query = query.limit(perPage).offset((page - 1) * perPage);
-
-    const result = await query;
 
     // Load relations if requested using batch loading to avoid N+1 queries
-    const includeOptions: IncludeOptions = { relations: filters.options.include || [] };
     const itemsWithRelations = await batchLoadDrizzleRelations(
       this.getDb(),
-      result,
+      queryResult.records,
       this._meta,
       includeOptions,
     );
 
-    const totalPages = Math.ceil(totalCount / perPage);
-
-    return {
-      result: itemsWithRelations,
-      result_info: {
-        page,
-        per_page: perPage,
-        total_count: totalCount,
-        total_pages: totalPages,
-        has_next_page: page < totalPages,
-        has_prev_page: page > 1,
-      },
-    };
+    return buildPaginatedResult(itemsWithRelations, queryResult);
   }
 }
 

--- a/packages/drizzle/src/helpers.ts
+++ b/packages/drizzle/src/helpers.ts
@@ -1,7 +1,9 @@
 import {
   and as _and,
   or as _or,
+  asc,
   between,
+  desc,
   eq,
   getTableColumns,
   gt,
@@ -18,7 +20,9 @@ import {
 import type {
   FilterCondition,
   IncludeOptions,
+  ListFilters,
   MetaInput,
+  PaginatedResult,
   RelatedRecord,
   RelationConfig,
   RelationLoaderAdapter,
@@ -26,6 +30,7 @@ import type {
 import {
   assertNever,
   batchLoadRelations,
+  decodeCursor,
   loadRelationsForItem,
   resolveRelationValueAsync,
 } from 'hono-crud/internal';
@@ -389,6 +394,216 @@ export interface CountRow {
  */
 export function readCount(result: unknown): number {
   return Number((result as CountRow[])[0]?.count) || 0;
+}
+
+/**
+ * Options for executing a Drizzle list query.
+ */
+export interface DrizzleListQueryOptions {
+  /** Database (or transaction) handle. */
+  db: unknown;
+  /** The Drizzle table to query. */
+  table: DrizzleTable;
+  /** List filters from the request. */
+  filters: ListFilters;
+  /** SQL dialect (drives the substring-match SQL on the `?search=` path). */
+  dialect: DrizzleDialect;
+  /** Search fields for the generic `?search=` needle (optional). */
+  searchFields?: string[];
+  /** Soft delete configuration (optional). */
+  softDeleteConfig?: { enabled: boolean; field: string };
+  /** Default items per page. */
+  defaultPerPage?: number;
+  /**
+   * Pre-built conditions ANDed into the WHERE clause — the search endpoint's
+   * custom search SQL (tsvector or substring-position) plugs in here.
+   */
+  extraConditions?: DrizzleSql[];
+  /**
+   * Keyset (cursor) pagination field. When set, a request carrying
+   * `cursor`/`limit` options runs the keyset window (`WHERE cursorField >
+   * decoded` + `LIMIT n+1`) instead of offset pagination. Only the List
+   * endpoint passes this.
+   */
+  cursorField?: string;
+}
+
+/**
+ * Result of a Drizzle list query.
+ */
+export interface DrizzleListQueryResult<Row = Record<string, unknown>> {
+  /** The fetched records (in cursor mode: up to `limit + 1` rows). */
+  records: Row[];
+  /** Total count of matching records (never includes the cursor window condition). */
+  totalCount: number;
+  /** Current page number. */
+  page: number;
+  /** Items per page. */
+  perPage: number;
+  /** Total number of pages. */
+  totalPages: number;
+  /**
+   * Present when the keyset (cursor) window ran instead of offset
+   * pagination. The offset fields above are then not meaningful — build the
+   * envelope with core's `buildCursorPage`.
+   */
+  cursor?: { limit: number; applied: boolean };
+}
+
+/**
+ * Executes the common Drizzle list query with filtering, search, sorting, and
+ * pagination — the drizzle mirror of the prisma adapter's
+ * `executePrismaQuery`. Shared by the List, Search, and Export endpoints so
+ * the query semantics cannot drift.
+ *
+ * Cursor mode (when `cursorField` is set and the request carries
+ * `cursor`/`limit` options) applies a strictly-greater keyset predicate on
+ * the cursor column and overfetches one row as the has-more sentinel. The
+ * ordering is already forced to the cursor field ascending by core's
+ * `parseListFilters`, so the regular `order_by` block emits the correct
+ * ORDER BY. An invalid cursor starts from the beginning. Unlike Prisma's
+ * native cursor, the keyset predicate tolerates a deleted boundary row.
+ */
+export async function executeDrizzleListQuery<Row = Record<string, unknown>>(
+  options: DrizzleListQueryOptions,
+): Promise<DrizzleListQueryResult<Row>> {
+  const {
+    db,
+    table,
+    filters,
+    dialect,
+    searchFields = [],
+    softDeleteConfig,
+    defaultPerPage = 20,
+    extraConditions = [],
+    cursorField,
+  } = options;
+
+  const conditions: DrizzleSql[] = [];
+
+  // Apply soft delete filter
+  if (softDeleteConfig?.enabled) {
+    const deletedAtColumn = getColumn(table, softDeleteConfig.field);
+
+    if (filters.options.onlyDeleted) {
+      // Show only deleted records
+      conditions.push(isNotNull(deletedAtColumn));
+    } else if (!filters.options.withDeleted) {
+      // Default: exclude deleted records
+      conditions.push(isNull(deletedAtColumn));
+    }
+    // If withDeleted=true, don't add any condition (show all)
+  }
+
+  // Apply filters
+  for (const filter of filters.filters) {
+    const condition = buildWhereCondition(table, filter, dialect);
+    if (condition) {
+      conditions.push(condition);
+    }
+  }
+
+  // Apply search. Dialect-native substring match (INSTR/POSITION/LOCATE) —
+  // the needle is never injected into a LIKE pattern, so user-supplied `%`
+  // and `_` are inert literal characters, aligning with memory/Prisma which
+  // use literal substring matching.
+  if (filters.options.search && searchFields.length > 0) {
+    const needle = filters.options.search;
+    const searchConditions = searchFields.map((field) =>
+      substringMatch(getColumn(table, field), needle, dialect),
+    );
+    conditions.push(or(...searchConditions)!);
+  }
+
+  conditions.push(...extraConditions);
+
+  // Build where clause
+  const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+  // Get total count using COUNT(*). The keyset window condition is
+  // intentionally NOT part of the count — total_count always reflects the
+  // full filtered set.
+  const countResult = await cast(db)
+    .select({ count: sql<number>`count(*)` })
+    .from(table)
+    .where(whereClause);
+
+  const totalCount = readCount(countResult);
+
+  // Keyset (cursor) window: strictly after the boundary value.
+  const cursorMode =
+    cursorField !== undefined &&
+    (filters.options.cursor !== undefined || filters.options.limit !== undefined);
+
+  let fetchWhere = whereClause;
+  let cursorApplied = false;
+  if (cursorMode && filters.options.cursor) {
+    const decoded = decodeCursor(filters.options.cursor);
+    if (decoded !== null) {
+      fetchWhere = and(whereClause, gt(getColumn(table, cursorField), decoded));
+      cursorApplied = true;
+    }
+  }
+
+  // Build main query
+  let query = cast<Row>(db).select().from(table).where(fetchWhere);
+
+  // Apply sorting (cursor mode arrives here already forced to cursorField asc)
+  if (filters.options.order_by) {
+    const orderColumn = getColumn(table, filters.options.order_by);
+    const orderFn = filters.options.order_by_direction === 'desc' ? desc : asc;
+    query = query.orderBy(orderFn(orderColumn));
+  }
+
+  if (cursorMode) {
+    const limit = filters.options.limit || filters.options.per_page || defaultPerPage;
+    const records = await query.limit(limit + 1);
+    return {
+      records,
+      totalCount,
+      page: 0,
+      perPage: limit,
+      totalPages: 0,
+      cursor: { limit, applied: cursorApplied },
+    };
+  }
+
+  // Apply offset pagination
+  const page = filters.options.page || 1;
+  const perPage = filters.options.per_page || defaultPerPage;
+  const records = await query.limit(perPage).offset((page - 1) * perPage);
+
+  const totalPages = Math.ceil(totalCount / perPage);
+
+  return {
+    records,
+    totalCount,
+    page,
+    perPage,
+    totalPages,
+  };
+}
+
+/**
+ * Builds a PaginatedResult from offset-mode query results (mirrors the
+ * prisma adapter's `buildPaginatedResult`). Cursor-mode results go through
+ * core's `buildCursorPage` instead.
+ */
+export function buildPaginatedResult<T>(
+  items: T[],
+  queryResult: DrizzleListQueryResult<unknown>,
+): PaginatedResult<T> {
+  return {
+    result: items,
+    result_info: {
+      page: queryResult.page,
+      per_page: queryResult.perPage,
+      total_count: queryResult.totalCount,
+      total_pages: queryResult.totalPages,
+      has_next_page: queryResult.page < queryResult.totalPages,
+      has_prev_page: queryResult.page > 1,
+    },
+  };
 }
 
 /**

--- a/packages/memory/src/advanced.ts
+++ b/packages/memory/src/advanced.ts
@@ -28,7 +28,7 @@ import type {
 import type { ModelObject } from 'hono-crud/internal';
 import { applyUpsertRestore, isFilterOperator } from 'hono-crud/internal';
 import { matchesFilter } from './filter';
-import { findByUpsertKeys, getStore, loadRelations } from './helpers';
+import { findByUpsertKeys, getStore, loadRelations, queryMemoryStore } from './helpers';
 import { isVisible } from './visibility';
 
 /**
@@ -579,59 +579,8 @@ export abstract class MemoryExportEndpoint<
 > extends ExportEndpoint<E, M> {
   async list(filters: ListFilters): Promise<PaginatedResult<ModelObject<M['model']>>> {
     const store = getStore<ModelObject<M['model']>>(this._meta.model.tableName);
-    let items = Array.from(store.values());
-    const softDeleteConfig = this.getSoftDeleteConfig();
-
-    // Apply soft delete filter
-    if (softDeleteConfig.enabled) {
-      if (filters.options.onlyDeleted) {
-        items = items.filter((item) => {
-          const deletedAt = (item as Record<string, unknown>)[softDeleteConfig.field];
-          return deletedAt !== null && deletedAt !== undefined;
-        });
-      } else if (!filters.options.withDeleted) {
-        items = items.filter((item) => {
-          const deletedAt = (item as Record<string, unknown>)[softDeleteConfig.field];
-          return deletedAt === null || deletedAt === undefined;
-        });
-      }
-    }
-
-    // Apply filters
-    for (const filter of filters.filters) {
-      items = items.filter((item) => {
-        const value = (item as Record<string, unknown>)[filter.field];
-        return matchesFilter(value, filter);
-      });
-    }
-
-    // Apply search
-    if (filters.options.search && this.searchFields.length > 0) {
-      const searchTerm = filters.options.search.toLowerCase();
-      items = items.filter((item) =>
-        this.searchFields.some((field) => {
-          const value = (item as Record<string, unknown>)[field];
-          return String(value).toLowerCase().includes(searchTerm);
-        }),
-      );
-    }
-
+    const items = queryMemoryStore(store, filters, this.searchFields, this.getSoftDeleteConfig());
     const totalCount = items.length;
-
-    // Apply sorting
-    if (filters.options.order_by) {
-      const orderBy = filters.options.order_by;
-      const direction = filters.options.order_by_direction === 'desc' ? -1 : 1;
-
-      items.sort((a, b) => {
-        const aVal = (a as Record<string, unknown>)[orderBy] as string | number;
-        const bVal = (b as Record<string, unknown>)[orderBy] as string | number;
-
-        if (aVal < bVal) return -1 * direction;
-        if (aVal > bVal) return 1 * direction;
-        return 0;
-      });
-    }
 
     // Apply pagination
     const page = filters.options.page || 1;

--- a/packages/memory/src/crud.ts
+++ b/packages/memory/src/crud.ts
@@ -5,7 +5,7 @@ import { UpdateEndpoint } from 'hono-crud/internal';
 import { DeleteEndpoint } from 'hono-crud/internal';
 import { ListEndpoint } from 'hono-crud/internal';
 import { RestoreEndpoint } from 'hono-crud/internal';
-import { decodeCursor, encodeCursor } from 'hono-crud/internal';
+import { buildCursorPage, decodeCursor } from 'hono-crud/internal';
 import type {
   IncludeOptions,
   ListFilters,
@@ -16,8 +16,7 @@ import type {
   RelationConfig,
 } from 'hono-crud/internal';
 import type { ModelObject } from 'hono-crud/internal';
-import { matchesFilter } from './filter';
-import { getStore, loadRelations } from './helpers';
+import { getStore, loadRelations, queryMemoryStore } from './helpers';
 import { isVisible } from './visibility';
 
 /**
@@ -455,124 +454,50 @@ export abstract class MemoryListEndpoint<
   E extends Env = Env,
   M extends MetaInput = MetaInput,
 > extends ListEndpoint<E, M> {
+  protected override supportsCursorPagination = true;
+
   async list(filters: ListFilters): Promise<PaginatedResult<ModelObject<M['model']>>> {
     const store = getStore<ModelObject<M['model']>>(this._meta.model.tableName);
-    let items = Array.from(store.values());
-    const softDeleteConfig = this.getSoftDeleteConfig();
-
-    // Apply soft delete filter
-    if (softDeleteConfig.enabled) {
-      if (filters.options.onlyDeleted) {
-        // Show only deleted records
-        items = items.filter((item) => {
-          const deletedAt = (item as Record<string, unknown>)[softDeleteConfig.field];
-          return deletedAt !== null && deletedAt !== undefined;
-        });
-      } else if (!filters.options.withDeleted) {
-        // Default: exclude deleted records
-        items = items.filter((item) => {
-          const deletedAt = (item as Record<string, unknown>)[softDeleteConfig.field];
-          return deletedAt === null || deletedAt === undefined;
-        });
-      }
-      // If withDeleted=true, don't filter (show all)
-    }
-
-    // Apply filters
-    for (const filter of filters.filters) {
-      items = items.filter((item) => {
-        const value = (item as Record<string, unknown>)[filter.field];
-        return matchesFilter(value, filter);
-      });
-    }
-
-    // Apply search
-    if (filters.options.search && this.searchFields.length > 0) {
-      const searchTerm = filters.options.search.toLowerCase();
-      items = items.filter((item) =>
-        this.searchFields.some((field) => {
-          const value = (item as Record<string, unknown>)[field];
-          return String(value).toLowerCase().includes(searchTerm);
-        }),
-      );
-    }
-
+    const items = queryMemoryStore(store, filters, this.searchFields, this.getSoftDeleteConfig());
     const totalCount = items.length;
+    const includeOptions: IncludeOptions = { relations: filters.options.include || [] };
 
-    // Apply sorting
-    if (filters.options.order_by) {
-      const orderBy = filters.options.order_by;
-      const direction = filters.options.order_by_direction === 'desc' ? -1 : 1;
+    const loadItemRelations = (item: ModelObject<M['model']>) =>
+      loadRelations(item as Record<string, unknown>, this._meta, includeOptions) as ModelObject<
+        M['model']
+      >;
 
-      items.sort((a, b) => {
-        const aVal = (a as Record<string, unknown>)[orderBy] as string | number;
-        const bVal = (b as Record<string, unknown>)[orderBy] as string | number;
-
-        if (aVal < bVal) return -1 * direction;
-        if (aVal > bVal) return 1 * direction;
-        return 0;
-      });
-    }
-
-    // Cursor-based pagination
-    if (this.cursorPaginationEnabled && (filters.options.cursor || filters.options.limit)) {
+    // Keyset cursor pagination (next-only). `cursor`/`limit` options only
+    // exist when cursor pagination is enabled AND supported; rows are already
+    // ordered by the cursor field ascending — core forces `order_by` during a
+    // cursor walk.
+    if (filters.options.cursor !== undefined || filters.options.limit !== undefined) {
       const cursorField = this.cursorField || 'id';
       const limit = filters.options.limit || filters.options.per_page || this.defaultPerPage;
+      const decoded = filters.options.cursor ? decodeCursor(filters.options.cursor) : null;
 
-      // If cursor is provided, find the starting position
-      let startIndex = 0;
-      if (filters.options.cursor) {
-        const cursorValue = decodeCursor(filters.options.cursor);
-        if (cursorValue !== null) {
-          const cursorIdx = items.findIndex(
-            (item) => String((item as Record<string, unknown>)[cursorField]) === cursorValue,
-          );
-          if (cursorIdx !== -1) {
-            startIndex = cursorIdx + 1; // Start after the cursor item
-          }
-        }
-      }
+      // Strictly-after-the-boundary keyset window (the memory equivalent of
+      // `WHERE cursorField > decoded`, tolerant of a deleted boundary row).
+      // An invalid cursor starts from the beginning, matching the SQL
+      // adapters. Numeric cursor fields compare numerically; everything else
+      // compares as strings.
+      const windowItems =
+        decoded === null
+          ? items
+          : items.filter((item) => {
+              const value = (item as Record<string, unknown>)[cursorField];
+              return typeof value === 'number' ? value > Number(decoded) : String(value) > decoded;
+            });
 
-      const paginatedItems = items.slice(startIndex, startIndex + limit);
+      const { items: pageItems, result_info } = buildCursorPage({
+        rows: windowItems.slice(0, limit + 1),
+        limit,
+        totalCount,
+        cursorField,
+        cursorApplied: decoded !== null,
+      });
 
-      // Load relations if requested
-      const includeOptions: IncludeOptions = { relations: filters.options.include || [] };
-      const itemsWithRelations = paginatedItems.map(
-        (item) =>
-          loadRelations(item as Record<string, unknown>, this._meta, includeOptions) as ModelObject<
-            M['model']
-          >,
-      );
-
-      const hasNextPage = startIndex + limit < items.length;
-      const hasPrevPage = startIndex > 0;
-
-      // Build cursors from last/first items
-      let nextCursor: string | undefined;
-      let prevCursor: string | undefined;
-
-      if (hasNextPage && paginatedItems.length > 0) {
-        const lastItem = paginatedItems[paginatedItems.length - 1] as Record<string, unknown>;
-        nextCursor = encodeCursor(lastItem[cursorField] as string | number);
-      }
-
-      if (hasPrevPage && startIndex > 0) {
-        const prevItem = items[startIndex - 1] as Record<string, unknown>;
-        prevCursor = encodeCursor(prevItem[cursorField] as string | number);
-      }
-
-      return {
-        result: itemsWithRelations,
-        result_info: {
-          page: 0,
-          per_page: limit,
-          total_count: totalCount,
-          has_next_page: hasNextPage,
-          has_prev_page: hasPrevPage,
-          next_cursor: nextCursor,
-          prev_cursor: prevCursor,
-        },
-      };
+      return { result: pageItems.map(loadItemRelations), result_info };
     }
 
     // Offset-based pagination (default)
@@ -581,19 +506,10 @@ export abstract class MemoryListEndpoint<
     const start = (page - 1) * perPage;
     const paginatedItems = items.slice(start, start + perPage);
 
-    // Load relations if requested
-    const includeOptions: IncludeOptions = { relations: filters.options.include || [] };
-    const itemsWithRelations = paginatedItems.map(
-      (item) =>
-        loadRelations(item as Record<string, unknown>, this._meta, includeOptions) as ModelObject<
-          M['model']
-        >,
-    );
-
     const totalPages = Math.ceil(totalCount / perPage);
 
     return {
-      result: itemsWithRelations,
+      result: paginatedItems.map(loadItemRelations),
       result_info: {
         page,
         per_page: perPage,

--- a/packages/memory/src/helpers.ts
+++ b/packages/memory/src/helpers.ts
@@ -1,10 +1,12 @@
 import {
   type IncludeOptions,
+  type ListFilters,
   type MetaInput,
   type RelatedRecord,
   type SyncRelationLoaderAdapter,
   loadRelationsForItemSync,
 } from 'hono-crud/internal';
+import { matchesFilter } from './filter';
 
 /**
  * Module-level in-memory storage.
@@ -65,6 +67,79 @@ export function loadRelations<T extends Record<string, unknown>, M extends MetaI
  */
 export function clearStorage(): void {
   storage.clear();
+}
+
+/**
+ * Runs the shared list-query block against a per-table store: soft-delete
+ * visibility (`withDeleted`/`onlyDeleted`), the `matchesFilter` filter loop,
+ * the generic `?search=` substring needle, and `order_by` sorting. Shared by
+ * the List and Export endpoints so the query semantics cannot drift;
+ * pagination (offset slice or keyset cursor window) stays with the caller.
+ *
+ * The returned array's length is the query's total count.
+ */
+export function queryMemoryStore<T>(
+  store: Map<string, T>,
+  filters: ListFilters,
+  searchFields: string[],
+  softDeleteConfig: { enabled: boolean; field: string },
+): T[] {
+  let items = Array.from(store.values());
+
+  // Apply soft delete filter
+  if (softDeleteConfig.enabled) {
+    if (filters.options.onlyDeleted) {
+      // Show only deleted records
+      items = items.filter((item) => {
+        const deletedAt = (item as Record<string, unknown>)[softDeleteConfig.field];
+        return deletedAt !== null && deletedAt !== undefined;
+      });
+    } else if (!filters.options.withDeleted) {
+      // Default: exclude deleted records
+      items = items.filter((item) => {
+        const deletedAt = (item as Record<string, unknown>)[softDeleteConfig.field];
+        return deletedAt === null || deletedAt === undefined;
+      });
+    }
+    // If withDeleted=true, don't filter (show all)
+  }
+
+  // Apply filters
+  for (const filter of filters.filters) {
+    items = items.filter((item) => {
+      const value = (item as Record<string, unknown>)[filter.field];
+      return matchesFilter(value, filter);
+    });
+  }
+
+  // Apply search (literal substring, case-insensitive — see the like/ilike
+  // contract: user `%`/`_` are inert characters, never wildcards)
+  if (filters.options.search && searchFields.length > 0) {
+    const searchTerm = filters.options.search.toLowerCase();
+    items = items.filter((item) =>
+      searchFields.some((field) => {
+        const value = (item as Record<string, unknown>)[field];
+        return String(value).toLowerCase().includes(searchTerm);
+      }),
+    );
+  }
+
+  // Apply sorting
+  if (filters.options.order_by) {
+    const orderBy = filters.options.order_by;
+    const direction = filters.options.order_by_direction === 'desc' ? -1 : 1;
+
+    items.sort((a, b) => {
+      const aVal = (a as Record<string, unknown>)[orderBy] as string | number;
+      const bVal = (b as Record<string, unknown>)[orderBy] as string | number;
+
+      if (aVal < bVal) return -1 * direction;
+      if (aVal > bVal) return 1 * direction;
+      return 0;
+    });
+  }
+
+  return items;
 }
 
 /**

--- a/packages/prisma/src/crud.ts
+++ b/packages/prisma/src/crud.ts
@@ -4,6 +4,7 @@ import { ReadEndpoint } from 'hono-crud/internal';
 import { UpdateEndpoint } from 'hono-crud/internal';
 import { DeleteEndpoint } from 'hono-crud/internal';
 import { ListEndpoint } from 'hono-crud/internal';
+import { buildCursorPage } from 'hono-crud/internal';
 import type { IncludeOptions, ListFilters, MetaInput, PaginatedResult } from 'hono-crud/internal';
 import type { ModelObject } from 'hono-crud/internal';
 import { getPrismaClient } from './connection';
@@ -319,6 +320,9 @@ export abstract class PrismaListEndpoint<
 > extends ListEndpoint<E, M> {
   declare prisma?: PrismaClient;
 
+  /** Cursor pagination is implemented via Prisma's native `cursor` window. */
+  protected override supportsCursorPagination = true;
+
   protected async getModel(): Promise<PrismaModelOperations<ModelObject<M['model']>>> {
     return getPrismaModel<ModelObject<M['model']>>(
       getPrismaClient(this),
@@ -334,10 +338,31 @@ export abstract class PrismaListEndpoint<
       searchFields: this.searchFields,
       softDeleteConfig: this.getSoftDeleteConfig(),
       defaultPerPage: this.defaultPerPage,
+      cursorField: this.isCursorPaginationActive() ? this.cursorField || 'id' : undefined,
     });
 
-    // Load relations if requested using batch loading to avoid N+1 queries
     const includeOptions: IncludeOptions = { relations: filters.options.include || [] };
+
+    // Keyset cursor page: trim the has-more sentinel row before loading
+    // relations, then return the canonical cursor-mode envelope.
+    if (queryResult.cursor) {
+      const { items, result_info } = buildCursorPage({
+        rows: queryResult.records,
+        limit: queryResult.cursor.limit,
+        totalCount: queryResult.totalCount,
+        cursorField: this.cursorField || 'id',
+        cursorApplied: queryResult.cursor.applied,
+      });
+      const itemsWithRelations = await batchLoadPrismaRelations(
+        getPrismaClient(this),
+        items,
+        this._meta,
+        includeOptions,
+      );
+      return { result: itemsWithRelations, result_info };
+    }
+
+    // Load relations if requested using batch loading to avoid N+1 queries
     const itemsWithRelations = await batchLoadPrismaRelations(
       getPrismaClient(this),
       queryResult.records,

--- a/packages/prisma/src/helpers.ts
+++ b/packages/prisma/src/helpers.ts
@@ -14,7 +14,12 @@ import type {
   PaginatedResult,
   RelationLoaderAdapter,
 } from 'hono-crud/internal';
-import { assertNever, batchLoadRelations, loadRelationsForItem } from 'hono-crud/internal';
+import {
+  assertNever,
+  batchLoadRelations,
+  decodeCursor,
+  loadRelationsForItem,
+} from 'hono-crud/internal';
 import { inlineSingular, levenshteinDistance } from './pluralize';
 
 /**
@@ -34,6 +39,7 @@ export interface PrismaModelOperations<Row = Record<string, unknown>> {
     orderBy?: unknown;
     skip?: number;
     take?: number;
+    cursor?: Record<string, unknown>;
   }) => Promise<Row[]>;
   update: (args: { where: unknown; data: unknown }) => Promise<Row>;
   updateMany: (args: { where: unknown; data: unknown }) => Promise<{ count: number }>;
@@ -445,17 +451,24 @@ export interface PrismaQueryOptions<Row = Record<string, unknown>> {
   defaultPerPage?: number;
   /** Additional WHERE conditions to merge (optional) */
   additionalWhere?: Record<string, unknown>;
+  /**
+   * Keyset (cursor) pagination field. When set, a request carrying
+   * `cursor`/`limit` options runs Prisma's native cursor window
+   * (`cursor: { [field]: decoded }` + `skip: 1` + `take: n+1`) instead of
+   * offset pagination. Only the List endpoint passes this.
+   */
+  cursorField?: string;
 }
 
 /**
  * Result of a Prisma list query.
  */
 export interface PrismaQueryResult<Row = Record<string, unknown>> {
-  /** The fetched records */
+  /** The fetched records (in cursor mode: up to `limit + 1` rows) */
   records: Row[];
   /** The WHERE clause used */
   where: Record<string, unknown>;
-  /** Total count of matching records */
+  /** Total count of matching records (never includes the cursor window) */
   totalCount: number;
   /** Current page number */
   page: number;
@@ -463,11 +476,31 @@ export interface PrismaQueryResult<Row = Record<string, unknown>> {
   perPage: number;
   /** Total number of pages */
   totalPages: number;
+  /**
+   * Present when the native cursor window ran instead of offset pagination.
+   * The offset fields above are then not meaningful — build the envelope
+   * with core's `buildCursorPage`.
+   */
+  cursor?: { limit: number; applied: boolean };
 }
 
 /**
  * Executes a common Prisma list query with filtering, sorting, and pagination.
- * This helper reduces code duplication across List, Search, and Export endpoints.
+ * This helper reduces code duplication across the List and Export endpoints
+ * (Search assembles its own search-specific WHERE and stays separate).
+ *
+ * Cursor mode (when `cursorField` is set and the request carries
+ * `cursor`/`limit` options) uses Prisma's NATIVE cursor: `cursor: { [field]:
+ * decoded }` + `skip: 1` + `take: limit + 1` (the surplus row is the
+ * has-more sentinel). The ordering is already forced to the cursor field
+ * ascending by core's `parseListFilters`. An invalid cursor starts from the
+ * beginning.
+ *
+ * Native-cursor divergence from the drizzle/memory keyset predicates
+ * (`WHERE cursorField > decoded`): Prisma requires the boundary row to still
+ * EXIST — a cursor pointing at a since-deleted row yields an empty page
+ * (documented Prisma behavior). This is a native-API limitation, documented
+ * rather than papered over.
  *
  * @param options - Query configuration options
  * @returns Query result with records and pagination info
@@ -482,6 +515,7 @@ export async function executePrismaQuery<Row = Record<string, unknown>>(
     softDeleteConfig,
     defaultPerPage = 20,
     additionalWhere = {},
+    cursorField,
   } = options;
 
   // Build base WHERE clause from filters
@@ -517,11 +551,40 @@ export async function executePrismaQuery<Row = Record<string, unknown>>(
   // Get total count
   const totalCount = await model.count({ where });
 
-  // Build orderBy
+  // Build orderBy (cursor mode arrives here already forced to cursorField asc)
   let orderBy: Record<string, string> | undefined;
   if (filters.options.order_by) {
     orderBy = {
       [filters.options.order_by]: filters.options.order_by_direction || 'asc',
+    };
+  }
+
+  // Native cursor (keyset) window
+  const cursorMode =
+    cursorField !== undefined &&
+    (filters.options.cursor !== undefined || filters.options.limit !== undefined);
+
+  if (cursorMode) {
+    const limit = filters.options.limit || filters.options.per_page || defaultPerPage;
+    const decoded = filters.options.cursor ? decodeCursor(filters.options.cursor) : null;
+
+    const records = await model.findMany({
+      where,
+      orderBy,
+      take: limit + 1,
+      // `skip: 1` skips the boundary row itself; `coerceValue` restores the
+      // field's native type (cursors round-trip through strings).
+      ...(decoded !== null ? { cursor: { [cursorField]: coerceValue(decoded) }, skip: 1 } : {}),
+    });
+
+    return {
+      records,
+      where,
+      totalCount,
+      page: 0,
+      perPage: limit,
+      totalPages: 0,
+      cursor: { limit, applied: decoded !== null },
     };
   }
 
@@ -550,7 +613,8 @@ export async function executePrismaQuery<Row = Record<string, unknown>>(
 }
 
 /**
- * Builds a PaginatedResult from query results.
+ * Builds a PaginatedResult from offset-mode query results. Cursor-mode
+ * results go through core's `buildCursorPage` instead.
  */
 export function buildPaginatedResult<T>(
   items: T[],

--- a/tests/__snapshots__/openapi-snapshot.test.ts.snap
+++ b/tests/__snapshots__/openapi-snapshot.test.ts.snap
@@ -112,17 +112,11 @@ exports[`OpenAPI output snapshot > toOpenApiPaths output is stable (byte-for-byt
                       "has_prev_page": {
                         "type": "boolean",
                       },
-                      "next_cursor": {
-                        "type": "string",
-                      },
                       "page": {
                         "type": "number",
                       },
                       "per_page": {
                         "type": "number",
-                      },
-                      "prev_cursor": {
-                        "type": "string",
                       },
                       "total_count": {
                         "type": "number",

--- a/tests/conformance/adapters/drizzle.ts
+++ b/tests/conformance/adapters/drizzle.ts
@@ -161,6 +161,13 @@ class ItemBatchUpsert extends DrizzleBatchUpsertEndpoint {
   db = DB;
   protected override upsertKeys = ['email'];
 }
+class CursorItemList extends DrizzleListEndpoint {
+  _meta = baseMeta;
+  db = DB;
+  protected override cursorPaginationEnabled = true;
+  protected override cursorField = 'id';
+  protected override sortFields = ['email'];
+}
 
 class TenantCreate extends DrizzleCreateEndpoint {
   _meta = tenantMeta;
@@ -294,6 +301,7 @@ async function setup(): Promise<AdapterContext> {
     batchCreate: FinalizeBatchCreate,
     batchDelete: FinalizeBatchDelete,
   });
+  registerCrud(app, '/cursor-items', { create: ItemCreate, list: CursorItemList });
   registerCrud(app, '/hook-items', { create: HookItemCreate });
 
   return {

--- a/tests/conformance/adapters/memory.ts
+++ b/tests/conformance/adapters/memory.ts
@@ -113,6 +113,12 @@ class ItemBatchUpsert extends MemoryBatchUpsertEndpoint {
   _meta = baseMeta;
   protected override upsertKeys = ['email'];
 }
+class CursorItemList extends MemoryListEndpoint {
+  _meta = baseMeta;
+  protected override cursorPaginationEnabled = true;
+  protected override cursorField = 'id';
+  protected override sortFields = ['email'];
+}
 
 class TenantCreate extends MemoryCreateEndpoint {
   _meta = tenantMeta;
@@ -221,6 +227,7 @@ async function setup(): Promise<AdapterContext> {
     batchCreate: FinalizeBatchCreate,
     batchDelete: FinalizeBatchDelete,
   });
+  registerCrud(app, '/cursor-items', { create: ItemCreate, list: CursorItemList });
   registerCrud(app, '/hook-items', { create: HookItemCreate });
 
   return {

--- a/tests/conformance/adapters/prisma.ts
+++ b/tests/conformance/adapters/prisma.ts
@@ -182,6 +182,13 @@ async function setup(): Promise<AdapterContext> {
     prisma = crudClient;
     protected override upsertKeys = ['email'];
   }
+  class CursorItemList extends PrismaListEndpoint {
+    _meta = baseMeta;
+    prisma = crudClient;
+    protected override cursorPaginationEnabled = true;
+    protected override cursorField = 'id';
+    protected override sortFields = ['email'];
+  }
 
   class TenantCreate extends PrismaCreateEndpoint {
     _meta = tenantMeta;
@@ -293,6 +300,7 @@ async function setup(): Promise<AdapterContext> {
     batchCreate: FinalizeBatchCreate,
     batchDelete: FinalizeBatchDelete,
   });
+  registerCrud(app, '/cursor-items', { create: ItemCreate, list: CursorItemList });
   registerCrud(app, '/hook-items', { create: HookItemCreate });
 
   return {

--- a/tests/conformance/cells/cursor-pagination.ts
+++ b/tests/conformance/cells/cursor-pagination.ts
@@ -1,0 +1,140 @@
+/**
+ * Cell 11 — Keyset cursor pagination: next_cursor-only walk + exact
+ * cursor-mode result_info shape + forced cursor-field ordering.
+ *
+ * Cursor pagination used to be implemented only by the memory adapter while
+ * core advertised it for every adapter (audit findings 45/75) — Drizzle and
+ * Prisma silently fell back to offset pagination. This cell pins the real
+ * keyset behavior on all three adapters:
+ *
+ * - the walk visits every record exactly once, ordered by the cursor field
+ *   (`id`) ascending;
+ * - the cursor-mode envelope is exactly `{ page: 0, per_page, total_count,
+ *   has_next_page, has_prev_page, next_cursor? }` — no `total_pages`, and no
+ *   `prev_cursor` anywhere (walks are next-only, Stripe-style);
+ * - the last page carries no `next_cursor`;
+ * - user `sort`/`order` are IGNORED during a cursor walk (ORDER BY is forced
+ *   to the cursor field — keyset pagination is only correct on that order);
+ * - plain page/per_page requests on a cursor-enabled endpoint still use
+ *   offset pagination with the canonical 6-field result_info.
+ *
+ * The companion loud-failure contract (ConfigurationException when
+ * `cursorPaginationEnabled` is set on an adapter without support) is pinned
+ * as a unit test in tests/new-features.test.ts, where an endpoint subclass
+ * can override `supportsCursorPagination = false`.
+ */
+import { expect, test } from 'vitest';
+import type {
+  AdapterDescriptor,
+  ConformanceApp,
+  ConformanceRecord,
+  CtxGetter,
+  CursorListEnvelope,
+  CursorResultInfo,
+} from '../contract';
+import { createRecord, expectList, readJson } from '../contract';
+
+const BASE = '/cursor-items';
+
+/** Seeds 7 rows and returns their ids in ascending (cursor-field) order. */
+async function seedCursorRows(app: ConformanceApp): Promise<string[]> {
+  const ids: string[] = [];
+  for (let i = 0; i < 7; i++) {
+    const created = await createRecord(app, BASE, {
+      name: `Cursor Row ${i}`,
+      email: `cursor-${i}@conformance.test`,
+      role: 'user',
+      age: 20 + i,
+    });
+    ids.push(created.id);
+  }
+  return ids.sort();
+}
+
+async function fetchCursorPage(
+  app: ConformanceApp,
+  query: string,
+): Promise<CursorListEnvelope<ConformanceRecord>> {
+  const response = await app.request(`${BASE}?${query}`);
+  expect(response.status).toBe(200);
+  const body = await readJson<CursorListEnvelope<ConformanceRecord>>(response);
+  expect(body.success).toBe(true);
+  expect(Array.isArray(body.result)).toBe(true);
+  return body;
+}
+
+/** Cursors are base64 and may contain `+`/`=` — always URL-encode them. */
+function cursorQuery(info: CursorResultInfo, extra = ''): string {
+  expect(info.next_cursor).toBeDefined();
+  return `cursor=${encodeURIComponent(info.next_cursor as string)}&limit=3${extra}`;
+}
+
+export function registerCursorPaginationCells(_descriptor: AdapterDescriptor, ctx: CtxGetter): void {
+  test('cursor pagination: next-only walk visits every record in cursor-field order with exact result_info', async () => {
+    const { app } = ctx();
+    const idsSorted = await seedCursorRows(app);
+
+    const infoFor = (hasNext: boolean, hasPrev: boolean) => ({
+      page: 0,
+      per_page: 3,
+      total_count: 7,
+      has_next_page: hasNext,
+      has_prev_page: hasPrev,
+    });
+
+    const page1 = await fetchCursorPage(app, 'limit=3');
+    expect(page1.result.map((record) => record.id)).toEqual(idsSorted.slice(0, 3));
+    expect(page1.result_info).toEqual({ ...infoFor(true, false), next_cursor: expect.any(String) });
+    expect('prev_cursor' in page1.result_info).toBe(false);
+    expect('total_pages' in page1.result_info).toBe(false);
+
+    const page2 = await fetchCursorPage(app, cursorQuery(page1.result_info));
+    expect(page2.result.map((record) => record.id)).toEqual(idsSorted.slice(3, 6));
+    expect(page2.result_info).toEqual({ ...infoFor(true, true), next_cursor: expect.any(String) });
+    expect('prev_cursor' in page2.result_info).toBe(false);
+
+    const page3 = await fetchCursorPage(app, cursorQuery(page2.result_info));
+    expect(page3.result.map((record) => record.id)).toEqual(idsSorted.slice(6));
+    expect(page3.result_info).toEqual(infoFor(false, true));
+    expect('next_cursor' in page3.result_info).toBe(false);
+    expect('prev_cursor' in page3.result_info).toBe(false);
+
+    // The walk covers every record exactly once, in cursor-field order.
+    const walked = [...page1.result, ...page2.result, ...page3.result].map(
+      (record) => record.id,
+    );
+    expect(walked).toEqual(idsSorted);
+  });
+
+  test('cursor pagination: user sort/order are ignored during a cursor walk (ORDER BY forced to cursor field)', async () => {
+    const { app } = ctx();
+    const idsSorted = await seedCursorRows(app);
+
+    // `sort=email&order=desc` would reverse the seed order; with a cursor
+    // walk in play the results MUST come back ordered by the cursor field
+    // (`id`) ascending — on the first page and on cursor-following pages.
+    const page1 = await fetchCursorPage(app, 'limit=3&sort=email&order=desc');
+    expect(page1.result.map((record) => record.id)).toEqual(idsSorted.slice(0, 3));
+
+    const page2 = await fetchCursorPage(app, cursorQuery(page1.result_info, '&sort=email&order=desc'));
+    expect(page2.result.map((record) => record.id)).toEqual(idsSorted.slice(3, 6));
+  });
+
+  test('cursor pagination: plain page/per_page requests on a cursor-enabled endpoint stay offset-paginated', async () => {
+    const { app } = ctx();
+    await seedCursorRows(app);
+
+    const offset = await expectList(await app.request(`${BASE}?page=2&per_page=3`));
+    expect(offset.result).toHaveLength(3);
+    expect(offset.result_info).toEqual({
+      page: 2,
+      per_page: 3,
+      total_count: 7,
+      total_pages: 3,
+      has_next_page: true,
+      has_prev_page: true,
+    });
+    expect('next_cursor' in offset.result_info).toBe(false);
+    expect('prev_cursor' in offset.result_info).toBe(false);
+  });
+}

--- a/tests/conformance/cells/index.ts
+++ b/tests/conformance/cells/index.ts
@@ -7,6 +7,7 @@
  */
 import { afterAll, beforeAll, beforeEach } from 'vitest';
 import type { AdapterContext, AdapterDescriptor, CtxGetter } from '../contract';
+import { registerCursorPaginationCells } from './cursor-pagination';
 import { registerEtagConcurrencyCells } from './etag-concurrency';
 import { registerFilterOperatorCells } from './filter-operators';
 import { registerFinalizePipelineCells } from './finalize-pipeline';
@@ -50,4 +51,5 @@ export function registerConformanceCells(descriptor: AdapterDescriptor): void {
   registerFinalizePipelineCells(descriptor, ctx);
   registerUpsertRestoreCells(descriptor, ctx);
   registerTransactionalHookCells(descriptor, ctx);
+  registerCursorPaginationCells(descriptor, ctx);
 }

--- a/tests/conformance/contract.ts
+++ b/tests/conformance/contract.ts
@@ -134,6 +134,26 @@ export interface ListEnvelope<T> {
   result_info: ResultInfo;
 }
 
+/**
+ * Cursor-mode pagination metadata (keyset walks, next-only / Stripe-style).
+ * Exact shape pinned by the cursor-pagination cell: `page` is always 0, no
+ * `total_pages`, no `prev_cursor` — `next_cursor` only while more rows exist.
+ */
+export interface CursorResultInfo {
+  page: 0;
+  per_page: number;
+  total_count: number;
+  has_next_page: boolean;
+  has_prev_page: boolean;
+  next_cursor?: string;
+}
+
+export interface CursorListEnvelope<T> {
+  success: true;
+  result: T[];
+  result_info: CursorResultInfo;
+}
+
 /** Single upsert: `{ success, result, created }`, 201 created / 200 updated. */
 export interface UpsertEnvelope<T> {
   success: true;

--- a/tests/new-features.test.ts
+++ b/tests/new-features.test.ts
@@ -73,6 +73,15 @@ class UserClone extends MemoryCloneEndpoint<any, UserMeta> {
   _meta = userMeta;
 }
 
+// Simulates an adapter List endpoint that never implemented the keyset
+// window: enabling cursorPaginationEnabled on it must throw loudly instead
+// of silently falling back to offset pagination.
+class UnsupportedCursorUserList extends MemoryListEndpoint<any, UserMeta> {
+  _meta = userMeta;
+  cursorPaginationEnabled = true;
+  protected override supportsCursorPagination = false;
+}
+
 // ============================================================================
 // Cursor Pagination Tests
 // ============================================================================
@@ -112,8 +121,11 @@ describe('Cursor-Based Pagination', () => {
     const data = (await res.json()) as any;
     expect(data.success).toBe(true);
     expect(data.result.length).toBe(2);
+    expect(data.result_info.page).toBe(0);
     expect(data.result_info.has_next_page).toBe(true);
     expect(data.result_info.next_cursor).toBeDefined();
+    // Cursor walks are next-only (Stripe-style): prev_cursor never exists.
+    expect('prev_cursor' in data.result_info).toBe(false);
   });
 
   it('should paginate through results with cursor', async () => {
@@ -150,6 +162,30 @@ describe('Cursor-Based Pagination', () => {
     expect(data.result.length).toBe(2);
     expect(data.result_info.page).toBe(1);
     expect(data.result_info.total_count).toBe(4);
+  });
+
+  it('should ignore user sort during a cursor walk (ORDER BY forced to cursor field)', async () => {
+    // ?sort=name&order=desc would reverse the name order; cursor mode must
+    // come back ordered by the cursor field (id) ascending instead.
+    const res = await app.request('/users?limit=4&sort=name&order=desc');
+    const data = (await res.json()) as any;
+    const ids = data.result.map((r: any) => r.id);
+    expect(ids).toEqual([...ids].sort());
+  });
+
+  it('should throw a loud CONFIGURATION_ERROR when cursorPaginationEnabled is set without adapter support', async () => {
+    const unsupportedApp = fromHono(new Hono());
+    registerCrud(unsupportedApp, '/unsupported-users', {
+      create: UserCreate as any,
+      list: UnsupportedCursorUserList as any,
+    });
+
+    const res = await unsupportedApp.request('/unsupported-users');
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as any;
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe('CONFIGURATION_ERROR');
+    expect(body.error.message).toContain('supportsCursorPagination');
   });
 });
 


### PR DESCRIPTION
## Summary

Batch 4 of the 2026-06-12 audit roadmap (B1 #64, B2 #65, B3 #67+#68). Findings 45/47/50/75.

Core advertised cursor pagination but only memory implemented it — Drizzle/Prisma **silently fell back to offset** while still documenting `next_cursor`. The audit called silent degradation the one unacceptable state; owner decision was to make the feature real.

- **Drizzle**: keyset `WHERE cursorField > decoded ORDER BY cursorField LIMIT n+1`. **Prisma**: native `cursor` + `skip:1` + `take:n+1`. One shared core helper builds the cursor-mode `result_info`, so all three adapters return byte-identical envelopes.
- **`prev_cursor` removed** (breaking, sanctioned): next-only walks, Stripe-style.
- **`order_by` forced to the cursor field** during cursor walks (documented on the param) — no mid-walk sort divergence.
- **Capability-gated docs + loud failure**: cursor params/`next_cursor` appear in OpenAPI only when enabled AND supported; enabling on an unsupporting adapter throws `ConfigurationException`.
- List-query dedup per adapter (mirrors Prisma's `executePrismaQuery`); batch OpenAPI scaffolding shared by the three id-keyed batch verbs.

## Verification

`pnpm -r build` / `-r typecheck` / `typecheck:examples` / lint 0 errors / `test:unit` 1166 / `test:workers` 42 / `example:local` green. Conformance: **102 cells** (9 new cursor cells), 98 pass + 4 capability skips, **including the Prisma leg against real Postgres 16**. OpenAPI byte-for-byte snapshot updated deliberately (the diff is exactly the gated cursor fields).