### PR TITLE
refactor: storage & middleware family unification

### DIFF
--- a/.changeset/storage-family-unification.md
+++ b/.changeset/storage-family-unification.md
@@ -1,0 +1,19 @@
+---
+"hono-crud": patch
+"@hono-crud/cache": patch
+"@hono-crud/rate-limit": patch
+"@hono-crud/idempotency": patch
+"@hono-crud/prisma": patch
+---
+
+Storage & middleware-family unification:
+
+- **RedisIdempotencyStorage** (`@hono-crud/idempotency`): production idempotency backend whose lock acquisition is ONE atomic `SET key value NX PX ttl` round-trip; compatible with `@upstash/redis` (edge-safe) out of the box. Deliberately no Cloudflare KV backend — KV lacks compare-and-swap, so a KV lock would be advisory only (documented in the package README and the `IdempotencyStorage.lock` contract).
+- **Breaking — idempotency error shape**: the middleware now throws `IdempotencyKeyRequiredException` (400 `IDEMPOTENCY_KEY_REQUIRED`) and `IdempotencyConflictException` (409 `IDEMPOTENCY_CONFLICT`) instead of hand-returning `ctx.json` envelopes, so idempotency errors flow through `createErrorHandler` (ErrorMappers / ErrorHooks / custom `responseEnvelope` / requestId injection) like every sibling middleware. Bodies are unchanged under the default envelope on bare Hono apps; with `createErrorHandler` they now honor your envelope and gain `error.requestId`.
+- **Breaking — Prisma model-mapping registry removed**: `registerPrismaModelMapping` / `registerPrismaModelMappings` / `clearPrismaModelMappings` (module-global mutable state, per-isolate on Workers) are deleted. Set the delegate name statically instead: `defineModel({ tableName: 'people', table: 'person', ... })` or `RelationConfig.table` for relations; the camelCase+singularize derivation remains the fallback.
+- **Missing-storage posture unified**: cache mixins and the idempotency middleware now log a once-per-isolate warning when no storage resolves (rate-limit's existing warning gained the same once-guard); idempotency with `required: true` and no storage throws `ConfigurationException` instead of silently voiding replay protection.
+- **Cache default removed**: `getCacheStorage()` no longer lazily installs a global `MemoryCacheStorage` on read (`lazyDefaultOnGet` retired for cache) — it returns honest `null` until storage is configured. Docs no longer claim a memory default exists.
+- **Approval storage joins the unified injection system**: `CONTEXT_KEYS.approvalStorage` slot, `createStorageMiddleware({ approvalStorage })` / `createApprovalStorageMiddleware()`, and the `setApprovalStorage` / `getApprovalStorage` / `getApprovalStorageRequired` / `resolveApprovalStorage` quartet on `hono-crud/auth`. `requireApproval` resolves storage per request (explicit > context > global > warned in-memory default). **Breaking**: `ApprovalConfig.approvalStorage` renamed to `storage` (matching every sibling config).
+- **Quartet uniformity**: every storage feature now exports its full set/get/getRequired/resolve quartet plus registry from its package/subpath barrel (`resolveRateLimitStorage`, `resolveCacheStorage`, `cacheStorageRegistry`, `rateLimitStorageRegistry`, `idempotencyStorageRegistry`, `eventEmitterRegistry`, `getAPIKeyStorageRequired`, `resolveAPIKeyStorage`, logging's Required/resolve pair on `hono-crud/logging`, …).
+- **ConfigurationException sweep**: request-time misconfiguration (audit/versioning manager without storage, `getDrizzleDb` / `getPrismaClient` resolution, `resetRateLimit`, Prisma `$transaction` capability check, `StorageRegistry.getRequired` / `resolveRequired`) now throws `ConfigurationException` (500 `CONFIGURATION_ERROR`) instead of plain `Error`.
+- `MemoryCacheStorageOptions` and `MemoryIdempotencyStorageOptions` are exported; docs now lead every storage-backed feature with `createStorageMiddleware` (the in-code recommended path) and present `set*Storage` as the long-lived-server option.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,34 @@ This pattern avoids coupling to specific Drizzle versions while maintaining inte
    `%` stripped, `_` inert, never live SQL wildcards. `like` follows database collation case
    behavior (strict in memory); `ilike` is always case-insensitive.
 
+## Error-Split Doctrine
+
+**Request-time misconfiguration → `ConfigurationException`** (500 `CONFIGURATION_ERROR`,
+flows through createErrorHandler); **setup-time factory validation → plain `Error`**
+(fail-fast at boot, e.g. `multiTenant`'s custom-source-without-extractor check). A throw
+site picks by WHEN it fires, not what it complains about.
+
+## Confirmed-Intentional Asymmetries
+
+Adjudicated differences between sibling packages — never "fix" these for symmetry:
+
+1. **No Cloudflare KV idempotency backend** (cache and rate-limit ship `cloudflare-kv.ts`;
+   idempotency ships only memory + redis). The in-flight lock MUST be atomic
+   compare-and-set (`SET NX PX`); KV has no CAS, so a KV lock would be advisory only — a
+   correctness footgun for the one feature whose failure mode is duplicate side effects.
+   Workers users go through Upstash Redis; Durable Objects (not KV) is the primitive for a
+   possible future first-party backend.
+2. **Key-prefix ownership differs between cache and rate-limit.** Cache storage adapters own
+   a non-empty default prefix (`'cache:'`) because `clear()`, `deletePattern()`, and tag
+   indices are keyspace-scoped operations on a possibly shared physical store (with `''`,
+   `RedisCacheStorage.clear()` would wipe the whole DB). Rate-limit's middleware owns the
+   `'rl'` prefix and its adapters default to `''`. Rule: a storage adapter owns a non-empty
+   default prefix iff it performs keyspace-scoped operations on a shareable physical store.
+3. **`MemoryRateLimitStorage` has no `maxEntries` knob** (its memory/cache/idempotency
+   siblings are capacity-bounded). Capacity eviction of a live window would silently reset
+   its counter, weakening limits exactly under key-flood pressure; memory stays bounded via
+   the `cleanupInterval` sweep of expired windows.
+
 ## Naming Doctrine
 
 1. `create<Feature>Middleware()` — app.use-style cross-cutting middleware factories.

--- a/README.md
+++ b/README.md
@@ -292,12 +292,28 @@ See [docs/authentication.md](./docs/authentication.md) for JWT, API Key, guards,
 ### Caching
 
 ```typescript
-import { withCache, withCacheInvalidation, setCacheStorage, MemoryCacheStorage } from '@hono-crud/cache';
+import { withCache, MemoryCacheStorage } from '@hono-crud/cache';
 import { MemoryReadEndpoint } from '@hono-crud/memory';
+import { createStorageMiddleware } from 'hono-crud/storage';
+
+// Wire storage (recommended: per-request injection, edge-safe)
+app.use('*', createStorageMiddleware({ cacheStorage: new MemoryCacheStorage() }));
 
 class UserRead extends withCache(MemoryReadEndpoint) {
   _meta = userMeta;
   cacheConfig = { ttl: 300, perUser: false };
+
+  async handle(ctx) {
+    this.setContext(ctx);
+    const cached = await this.getCachedResponse();
+    if (cached) return this.successWithCache(cached);
+
+    const response = await super.handle(ctx);
+    if (response.status === 200) {
+      await this.setCachedResponse((await response.clone().json()).result);
+    }
+    return response;
+  }
 }
 ```
 
@@ -306,9 +322,10 @@ See [docs/caching.md](./docs/caching.md).
 ### Rate Limiting
 
 ```typescript
-import { createRateLimitMiddleware, setRateLimitStorage, MemoryRateLimitStorage } from '@hono-crud/rate-limit';
+import { createRateLimitMiddleware, MemoryRateLimitStorage } from '@hono-crud/rate-limit';
+import { createStorageMiddleware } from 'hono-crud/storage';
 
-setRateLimitStorage(new MemoryRateLimitStorage());
+app.use('*', createStorageMiddleware({ rateLimitStorage: new MemoryRateLimitStorage() }));
 
 app.use('/api/*', createRateLimitMiddleware({
   limit: 100,
@@ -322,9 +339,10 @@ See [docs/rate-limiting.md](./docs/rate-limiting.md).
 ### Logging
 
 ```typescript
-import { createLoggingMiddleware, setLoggingStorage, MemoryLoggingStorage } from 'hono-crud/logging';
+import { createLoggingMiddleware, MemoryLoggingStorage } from 'hono-crud/logging';
+import { createStorageMiddleware } from 'hono-crud/storage';
 
-setLoggingStorage(new MemoryLoggingStorage());
+app.use('*', createStorageMiddleware({ loggingStorage: new MemoryLoggingStorage() }));
 
 app.use('*', createLoggingMiddleware({
   redactHeaders: ['authorization', 'cookie'],

--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -253,12 +253,15 @@ import {
 } from 'hono-crud';
 import {
   createVersionManager,
-  setVersioningStorage,
   MemoryVersioningStorage,
 } from 'hono-crud/versioning';
+import { createStorageMiddleware } from 'hono-crud/storage';
 
-// Setup storage
-setVersioningStorage(new MemoryVersioningStorage());
+// Setup storage (recommended: per-request injection, edge-safe; on a
+// long-lived server, `setVersioningStorage()` once is the alternative)
+app.use('*', createStorageMiddleware({
+  versioningStorage: new MemoryVersioningStorage(),
+}));
 
 // Enable in model
 const UserModel = defineModel({
@@ -303,12 +306,15 @@ Track who changed what and when.
 ```typescript
 import {
   createAuditLogger,
-  setAuditStorage,
   MemoryAuditLogStorage,
 } from 'hono-crud/audit';
+import { createStorageMiddleware } from 'hono-crud/storage';
 
-// Setup storage
-setAuditStorage(new MemoryAuditLogStorage());
+// Setup storage (recommended: per-request injection, edge-safe; on a
+// long-lived server, `setAuditStorage()` once is the alternative)
+app.use('*', createStorageMiddleware({
+  auditStorage: new MemoryAuditLogStorage(),
+}));
 
 // Enable in model
 const UserModel = defineModel({
@@ -483,10 +489,13 @@ Event emitter for CRUD operations with webhook delivery.
 ### Event Emitter
 
 ```typescript
-import { CrudEventEmitter, setEventEmitter, getEventEmitter } from 'hono-crud/events';
+import { CrudEventEmitter } from 'hono-crud/events';
+import { createStorageMiddleware } from 'hono-crud/storage';
 
+// Inject per-request (recommended on edge runtimes; `setEventEmitter()` is the
+// long-lived-server compatibility option)
 const events = new CrudEventEmitter();
-setEventEmitter(events);
+app.use('*', createStorageMiddleware({ eventEmitter: events }));
 
 // Subscribe to specific events
 events.on('users', 'created', (event) => {
@@ -573,11 +582,14 @@ Prevent duplicate operations via idempotency keys.
 ```typescript
 import {
   createIdempotencyMiddleware,
-  setIdempotencyStorage,
   MemoryIdempotencyStorage,
 } from '@hono-crud/idempotency';
+import { createStorageMiddleware } from 'hono-crud/storage';
 
-setIdempotencyStorage(new MemoryIdempotencyStorage());
+// Wire storage (recommended: per-request injection, edge-safe)
+app.use('*', createStorageMiddleware({
+  idempotencyStorage: new MemoryIdempotencyStorage(),
+}));
 
 // Apply to mutation endpoints
 app.use('/api/*', createIdempotencyMiddleware({
@@ -588,20 +600,21 @@ app.use('/api/*', createIdempotencyMiddleware({
 
 Clients include `Idempotency-Key: <unique-key>` in the request header. If the same key is seen again within the TTL, the cached response is returned.
 
-### Context-scoped Storage
+For production use `RedisIdempotencyStorage` (Upstash works on edge runtimes) —
+`MemoryIdempotencyStorage` is per-isolate, so it cannot guarantee replay
+protection across instances. There is deliberately no Cloudflare KV backend:
+KV lacks compare-and-swap, so the in-flight lock cannot be made atomic (see the
+[package README](../packages/idempotency/README.md)).
 
-For multi-tenant or per-request storage, inject the storage through
-`createStorageMiddleware`. It writes the `idempotencyStorage` context var that
-the idempotency middleware resolves from (context storage takes priority over
-the global one):
+### Global Storage (long-lived servers)
+
+On a long-lived Node/Bun server you can set a module-global storage once
+instead. Resolution priority is explicit `config.storage` > context > global:
 
 ```typescript
-import { createStorageMiddleware } from 'hono-crud/storage';
-import { MemoryIdempotencyStorage } from '@hono-crud/idempotency';
+import { setIdempotencyStorage, MemoryIdempotencyStorage } from '@hono-crud/idempotency';
 
-app.use('*', createStorageMiddleware({
-  idempotencyStorage: new MemoryIdempotencyStorage(),
-}));
+setIdempotencyStorage(new MemoryIdempotencyStorage());
 ```
 
 ### Accessors

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -70,13 +70,13 @@ const decoded = decodeJWT(token); // { header, payload } | null
 import {
   createAPIKeyMiddleware,
   MemoryAPIKeyStorage,
-  setAPIKeyStorage,
   generateAPIKey,
 } from 'hono-crud/auth';
+import { createStorageMiddleware } from 'hono-crud/storage';
 
-// Setup storage
+// Setup storage (recommended: per-request injection, edge-safe)
 const apiKeyStorage = new MemoryAPIKeyStorage();
-setAPIKeyStorage(apiKeyStorage);
+app.use('*', createStorageMiddleware({ apiKeyStorage }));
 
 // Generate and store an API key
 const key = generateAPIKey();
@@ -106,10 +106,10 @@ order:
    bare lookup without a full storage backend.
 2. **`storage`** — an `APIKeyStorage` instance passed directly on the config.
    The middleware calls `storage.lookup()` and fires `storage.updateLastUsed()`.
-3. **Configured global / context `apiKeyStorage`** — set via
-   `setAPIKeyStorage()` (as above) or injected with
-   `createStorageMiddleware({ apiKeyStorage })`. `setAPIKeyStorage` is now wired
-   into the middleware path (it used to be ignored there).
+3. **Configured context / global `apiKeyStorage`** — injected with
+   `createStorageMiddleware({ apiKeyStorage })` (as above, recommended) or set
+   once via `setAPIKeyStorage()` on a long-lived server (context takes priority
+   over the global).
 
 If none of these resolve, the middleware throws a `ConfigurationException`.
 

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -8,29 +8,13 @@ Install: `npm install @hono-crud/cache`.
 
 ## Setup
 
-```typescript
-import { setCacheStorage, MemoryCacheStorage } from '@hono-crud/cache';
+Caching requires a storage backend — there is **no implicit default**. When no
+storage is configured, the mixins degrade to a no-op (every lookup is a miss)
+and log a once-per-isolate warning.
 
-// Use in-memory cache (default if not set)
-setCacheStorage(new MemoryCacheStorage());
-```
-
-### Redis Storage
-
-```typescript
-import { RedisCacheStorage, setCacheStorage } from '@hono-crud/cache';
-
-setCacheStorage(new RedisCacheStorage({
-  client: redisClient,     // Any Redis client with get/set/del/keys
-  prefix: 'cache:',        // Key prefix (default: 'cache:')
-}));
-```
-
-### Context-scoped Storage
-
-For multi-tenant or per-request storage, inject the storage through
-`createStorageMiddleware`. It writes the `cacheStorage` context var that the
-cache mixin resolves from (context storage takes priority over the global one):
+Inject the storage through `createStorageMiddleware` — the recommended path,
+especially on edge/serverless runtimes. It writes the `cacheStorage` context
+var that the cache mixin resolves from:
 
 ```typescript
 import { createStorageMiddleware } from 'hono-crud/storage';
@@ -39,6 +23,31 @@ import { MemoryCacheStorage } from '@hono-crud/cache';
 app.use('*', createStorageMiddleware({
   cacheStorage: new MemoryCacheStorage(),
 }));
+```
+
+### Redis Storage
+
+```typescript
+import { RedisCacheStorage } from '@hono-crud/cache';
+
+app.use('*', createStorageMiddleware({
+  cacheStorage: new RedisCacheStorage({
+    client: redisClient,   // Any Redis client with get/set/del/keys
+    prefix: 'cache:',      // Key prefix (default: 'cache:')
+  }),
+}));
+```
+
+### Global Storage (long-lived servers)
+
+On a long-lived Node/Bun server you can set a module-global storage once
+instead. Resolution priority is context > global, so the setter is a
+compatibility option, never a requirement:
+
+```typescript
+import { setCacheStorage, MemoryCacheStorage } from '@hono-crud/cache';
+
+setCacheStorage(new MemoryCacheStorage());
 ```
 
 ---

--- a/docs/database-adapters.md
+++ b/docs/database-adapters.md
@@ -368,15 +368,26 @@ registerCrud(app, '/users', {
 
 ### Model Name Mapping
 
-Prisma uses the model name to determine the table. If your model name differs from the `tableName`, register a mapping:
+The Prisma adapter derives the client delegate name from `tableName` (camelCase
++ singularize: `'users'` → `user`, `'blog_posts'` → `blogPost`). When the
+derivation doesn't match your Prisma model — irregular names, custom client
+naming — set the delegate name explicitly with the model meta's `table` field
+(a string for Prisma):
 
 ```typescript
-import { registerPrismaModelMapping } from '@hono-crud/prisma';
-
-// Map table name to Prisma model name
-registerPrismaModelMapping('users', 'User');
-registerPrismaModelMapping('blog_posts', 'BlogPost');
+// 'people' would derive to 'person'; this client's delegate is 'humanBeing'.
+const peopleModel = defineModel({
+  tableName: 'people',
+  table: 'humanBeing', // explicit Prisma delegate name
+  schema: PersonSchema,
+  primaryKeys: ['id'],
+});
 ```
+
+For relations, the same override lives on `RelationConfig.table` — a string
+delegate name beats the derivation from `relation.model`. The mapping is
+static wiring on the model meta (not a runtime registry), so it cannot
+silently diverge across edge isolates.
 
 ### Batch Operations
 

--- a/docs/hooks-and-approvals.md
+++ b/docs/hooks-and-approvals.md
@@ -315,13 +315,16 @@ The middleware intercepts BEFORE the handler runs:
 2. Detects no `_resume_` field → fresh request.
 3. Pulls actor identity from `c.var.*` (`userId`, `agentId`,
    `agentRunId`, `toolCallId`, optional `actionSource`).
-4. Persists a `PendingAction` to the configured `ApprovalStorage`. If
-   `approvalStorage` is omitted, the lib uses a process-local
-   `MemoryApprovalStorage` singleton — convenient for single-server
-   POCs and tutorials. **First use of the default emits a one-time
-   warning** via `getLogger()` so multi-instance / serverless / edge
-   deployments can't silently end up with process-local state. Pass an
-   explicit storage (Postgres / Durable Objects / etc.) for production:
+4. Persists a `PendingAction` to the resolved `ApprovalStorage`. Resolution
+   follows the standard storage priority chain: explicit `config.storage` >
+   context (`createStorageMiddleware({ approvalStorage })` — recommended,
+   edge-safe) > global (`setApprovalStorage()`). When nothing resolves, the
+   lib lazily materializes a process-local `MemoryApprovalStorage` default —
+   convenient for single-server POCs and tutorials. **First use of the
+   default emits a one-time warning** via `getLogger()` so multi-instance /
+   serverless / edge deployments can't silently end up with process-local
+   state. Provide a durable storage (Postgres / Durable Objects / etc.) for
+   production:
 
    ```ts
    {

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -6,36 +6,35 @@ hono-crud provides request/response logging middleware with automatic redaction 
 
 ## Setup
 
-```typescript
-import {
-  createLoggingMiddleware,
-  setLoggingStorage,
-  MemoryLoggingStorage,
-} from 'hono-crud/logging';
-
-// Set storage (required before middleware runs)
-setLoggingStorage(new MemoryLoggingStorage({ maxEntries: 10000 }));
-```
-
-### Context-scoped Storage
-
 Inject the storage through `createStorageMiddleware` (or the single-storage
-`createLoggingStorageMiddleware` helper). Both write the `loggingStorage`
-context var that the logging middleware resolves from (context storage takes
-priority over the global one):
+`createLoggingStorageMiddleware` helper) — the recommended path, especially on
+edge/serverless runtimes. Both write the `loggingStorage` context var that the
+logging middleware resolves from:
 
 ```typescript
 import { createStorageMiddleware } from 'hono-crud/storage';
 import { MemoryLoggingStorage } from 'hono-crud/logging';
 
 app.use('*', createStorageMiddleware({
-  loggingStorage: new MemoryLoggingStorage(),
+  loggingStorage: new MemoryLoggingStorage({ maxEntries: 10000 }),
 }));
 
 // Single-storage helper (takes a storage instance):
 import { createLoggingStorageMiddleware } from 'hono-crud/storage';
 
 app.use('*', createLoggingStorageMiddleware(new MemoryLoggingStorage()));
+```
+
+### Global Storage (long-lived servers)
+
+On a long-lived Node/Bun server you can set a module-global storage once
+instead. Resolution priority is context > global, so the setter is a
+compatibility option, never a requirement:
+
+```typescript
+import { setLoggingStorage, MemoryLoggingStorage } from 'hono-crud/logging';
+
+setLoggingStorage(new MemoryLoggingStorage({ maxEntries: 10000 }));
 ```
 
 ---

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -8,24 +8,27 @@ Install: `npm install @hono-crud/rate-limit`.
 
 ## Setup
 
-```typescript
-import {
-  createRateLimitMiddleware,
-  setRateLimitStorage,
-  MemoryRateLimitStorage,
-} from '@hono-crud/rate-limit';
+Inject the storage through `createStorageMiddleware` — the recommended path,
+especially on edge/serverless runtimes where backends are built from
+per-request bindings. It writes the `rateLimitStorage` context var that the
+rate-limit middleware resolves from:
 
-// Set storage (required before middleware runs)
-setRateLimitStorage(new MemoryRateLimitStorage());
+```typescript
+import { createStorageMiddleware } from 'hono-crud/storage';
+import { createRateLimitMiddleware, MemoryRateLimitStorage } from '@hono-crud/rate-limit';
+
+app.use('*', createStorageMiddleware({
+  rateLimitStorage: new MemoryRateLimitStorage(),
+}));
 ```
 
 ### Redis Storage
 
 ```typescript
-import { RedisRateLimitStorage, setRateLimitStorage } from '@hono-crud/rate-limit';
+import { RedisRateLimitStorage } from '@hono-crud/rate-limit';
 
-setRateLimitStorage(new RedisRateLimitStorage({
-  client: redisClient,
+app.use('*', createStorageMiddleware({
+  rateLimitStorage: new RedisRateLimitStorage({ client: redisClient }),
 }));
 ```
 
@@ -33,20 +36,16 @@ The optional `prefix` adds extra namespacing on top of the keys the middleware
 produces; it defaults to `''` because keys are already namespaced by the
 middleware's `keyPrefix` (default `'rl'`).
 
-### Context-scoped Storage
+### Global Storage (long-lived servers)
 
-For multi-tenant or per-request storage, inject the storage through
-`createStorageMiddleware`. It writes the `rateLimitStorage` context var that the
-rate-limit middleware resolves from (context storage takes priority over the
-global one):
+On a long-lived Node/Bun server you can set a module-global storage once
+instead. Resolution priority is explicit `config.storage` > context > global,
+so the setter is a compatibility option, never a requirement:
 
 ```typescript
-import { createStorageMiddleware } from 'hono-crud/storage';
-import { MemoryRateLimitStorage } from '@hono-crud/rate-limit';
+import { setRateLimitStorage, MemoryRateLimitStorage } from '@hono-crud/rate-limit';
 
-app.use('*', createStorageMiddleware({
-  rateLimitStorage: new MemoryRateLimitStorage(),
-}));
+setRateLimitStorage(new MemoryRateLimitStorage());
 ```
 
 ---

--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -11,7 +11,7 @@ npm install @hono-crud/cache hono-crud hono
 ## Usage
 
 ```ts
-import { createStorageMiddleware } from 'hono-crud';
+import { createStorageMiddleware } from 'hono-crud/storage';
 import { MemoryCacheStorage } from '@hono-crud/cache';
 
 // Inject the storage into context so cache-enabled endpoints / mixins resolve it.

--- a/packages/cache/src/index.ts
+++ b/packages/cache/src/index.ts
@@ -22,17 +22,20 @@ export {
 
 // Storage implementations
 export { MemoryCacheStorage } from './storage/memory';
+export type { MemoryCacheStorageOptions } from './storage/memory';
 export { RedisCacheStorage } from './storage/redis';
 export type { RedisClient, RedisCacheStorageOptions } from './storage/redis';
 export { KVCacheStorage } from './storage/cloudflare-kv';
 export type { KVCacheStorageOptions } from './storage/cloudflare-kv';
 
-// Mixins and global storage
+// Mixins and global storage (set/get/getRequired/resolve quartet + registry)
 export {
   withCache,
   withCacheInvalidation,
+  cacheStorageRegistry,
   setCacheStorage,
   getCacheStorage,
   getCacheStorageRequired,
+  resolveCacheStorage,
 } from './mixin';
 export type { CacheEndpointMethods, CacheInvalidationMethods } from './mixin';

--- a/packages/cache/src/mixin.ts
+++ b/packages/cache/src/mixin.ts
@@ -16,7 +16,6 @@ import {
   createRelatedPatterns,
   generateCacheKey,
 } from './key-generator';
-import { MemoryCacheStorage } from './storage/memory';
 import type {
   CacheConfig,
   CacheInvalidationConfig,
@@ -46,17 +45,12 @@ function getTableName(self: unknown): string {
 
 /**
  * Cache storage feature.
- *
- * `lazyDefaultOnGet: true` preserves the legacy never-null runtime behavior of
- * `getCacheStorage()` (it lazy-creates a `MemoryCacheStorage` default) while the
- * declared return type is honest `CacheStorage | null`. The request path uses
- * `resolveCacheStorage`, which never materializes a default (edge-safe no-op
- * when no storage is configured).
+ * Nullable — no default storage is created unless explicitly set. The request
+ * path uses `resolveCacheStorage` and emits a once-per-isolate warning when no
+ * storage resolves (caching silently disabled is a mis-wiring worth surfacing).
  */
 const cacheStorageFeature = createStorageFeature<CacheStorage>({
   contextKey: CONTEXT_KEYS.cacheStorage,
-  defaultFactory: () => new MemoryCacheStorage(),
-  lazyDefaultOnGet: true,
 });
 
 /**
@@ -80,17 +74,14 @@ export const cacheStorageRegistry = cacheStorageFeature.registry;
 export const setCacheStorage = cacheStorageFeature.set;
 
 /**
- * Get the global cache storage instance, or `null` when none is configured.
- *
- * The declared type is honest-nullable, but at runtime this never returns null:
- * the feature lazy-creates a `MemoryCacheStorage` default on first access. Use
- * {@link getCacheStorageRequired} when a non-null type is needed.
+ * Get the explicitly-configured global cache storage, or `null` when none is
+ * configured. Never throws and never creates a hidden default. Use
+ * {@link getCacheStorageRequired} when a non-null storage is required.
  */
 export const getCacheStorage = cacheStorageFeature.get;
 
 /**
- * Get the global cache storage instance, throwing if unset (or lazy-creating
- * the configured `MemoryCacheStorage` default).
+ * Get the global cache storage instance, throwing if not configured.
  */
 export const getCacheStorageRequired = cacheStorageFeature.getRequired;
 
@@ -102,6 +93,28 @@ export const getCacheStorageRequired = cacheStorageFeature.getRequired;
  * @returns The resolved storage, or null when no storage was configured
  */
 export const resolveCacheStorage = cacheStorageFeature.resolve;
+
+/** Once-per-isolate guard for the missing-storage warning (dedup, not request state). */
+let warnedMissingCacheStorage = false;
+
+/**
+ * Resolve cache storage for the request path, emitting a once-per-isolate
+ * warning when nothing resolves. Caching then degrades to a no-op — correct
+ * for an optimization-only feature, but loud enough that a mis-wired app
+ * (forgotten `createStorageMiddleware` / `setCacheStorage`) is observable.
+ */
+function resolveCacheStorageOrWarn(ctx?: Context<Env>): CacheStorage | null {
+  const storage = cacheStorageFeature.resolve(ctx);
+  if (!storage && !warnedMissingCacheStorage) {
+    warnedMissingCacheStorage = true;
+    getLogger().warn(
+      'Cache storage not configured — caching is disabled. Inject cacheStorage with ' +
+        'createStorageMiddleware() (recommended) or call setCacheStorage(). ' +
+        'This warning is logged once per isolate.',
+    );
+  }
+  return storage;
+}
 
 // ============================================================================
 // Type Helpers
@@ -258,7 +271,7 @@ export function withCache<TBase extends Constructor<OpenAPIRoute>>(
 
       const key = await this.generateCacheKey();
       const ctx = this.getContext();
-      const storage = resolveCacheStorage(ctx);
+      const storage = resolveCacheStorageOrWarn(ctx);
       if (!storage) {
         this._cacheHit = false;
         return null;
@@ -324,7 +337,7 @@ export function withCache<TBase extends Constructor<OpenAPIRoute>>(
 
       const key = await this.generateCacheKey();
       const ctx = this.getContext();
-      const storage = resolveCacheStorage(ctx);
+      const storage = resolveCacheStorageOrWarn(ctx);
       if (!storage) {
         return;
       }
@@ -349,7 +362,7 @@ export function withCache<TBase extends Constructor<OpenAPIRoute>>(
      */
     async invalidateCache(options?: { pattern?: string; tags?: string[] }): Promise<void> {
       const ctx = this.getContext();
-      const storage = resolveCacheStorage(ctx);
+      const storage = resolveCacheStorageOrWarn(ctx);
       if (!storage) {
         return;
       }
@@ -420,7 +433,7 @@ export function withCacheInvalidation<TBase extends Constructor<OpenAPIRoute>>(
     async performCacheInvalidation(recordId?: string | number): Promise<void> {
       const config = this.getCacheInvalidationConfig();
       const ctx = this.getContext();
-      const storage = resolveCacheStorage(ctx);
+      const storage = resolveCacheStorageOrWarn(ctx);
       if (!storage) {
         return;
       }

--- a/packages/cache/src/storage/cloudflare-kv.ts
+++ b/packages/cache/src/storage/cloudflare-kv.ts
@@ -16,7 +16,13 @@ async function runBatched<T>(items: T[], fn: (item: T) => Promise<unknown>): Pro
 export interface KVCacheStorageOptions {
   /** KV namespace binding. */
   kv: KVNamespace;
-  /** Key prefix for all cache entries. @default 'cache:' */
+  /**
+   * Key prefix for all cache entries. The storage owns this namespace —
+   * unlike rate-limit (whose middleware owns the `'rl'` prefix) — because
+   * `clear()`, `deletePattern()`, and the tag indices are scoped by it and
+   * the physical store may be shared with other data.
+   * @default 'cache:'
+   */
   prefix?: string;
   /** Default TTL in milliseconds. @default 300_000 */
   defaultTtlMs?: number;

--- a/packages/cache/src/storage/memory.ts
+++ b/packages/cache/src/storage/memory.ts
@@ -4,6 +4,16 @@ import { matchesPattern } from '../key-generator';
 import type { CacheEntry, CacheSetOptions, CacheStats, CacheStorage } from '../types';
 
 /**
+ * Options for MemoryCacheStorage.
+ */
+export interface MemoryCacheStorageOptions {
+  /** Default TTL in milliseconds. @default 300_000 (5 minutes) */
+  defaultTtlMs?: number;
+  /** Maximum entries before oldest-first eviction (0 = unlimited). @default 10_000 */
+  maxEntries?: number;
+}
+
+/**
  * In-memory cache storage implementation.
  * Ideal for development, testing, and single-instance deployments.
  *
@@ -15,14 +25,10 @@ import type { CacheEntry, CacheSetOptions, CacheStats, CacheStorage } from '../t
  *
  * @example
  * ```ts
- * import { MemoryCacheStorage, setCacheStorage } from '@hono-crud/cache';
+ * import { MemoryCacheStorage } from '@hono-crud/cache';
+ * import { createStorageMiddleware } from 'hono-crud/storage';
  *
- * const cache = new MemoryCacheStorage();
- * setCacheStorage(cache);
- *
- * // Get stats
- * const stats = cache.getStats();
- * console.log(`Hit rate: ${stats.hits / (stats.hits + stats.misses)}`);
+ * app.use('*', createStorageMiddleware({ cacheStorage: new MemoryCacheStorage() }));
  * ```
  */
 export class MemoryCacheStorage implements CacheStorage {
@@ -45,7 +51,7 @@ export class MemoryCacheStorage implements CacheStorage {
   /** Maximum entries (0 = unlimited) */
   private maxEntries: number;
 
-  constructor(options?: { defaultTtlMs?: number; maxEntries?: number }) {
+  constructor(options?: MemoryCacheStorageOptions) {
     this.defaultTtlMs = options?.defaultTtlMs ?? 300_000; // 5 minutes
     this.maxEntries = options?.maxEntries ?? 10_000;
     this.store = new MemoryTtlStore<CacheEntry>({

--- a/packages/cache/src/storage/redis.ts
+++ b/packages/cache/src/storage/redis.ts
@@ -36,7 +36,14 @@ export interface RedisClient {
 export interface RedisCacheStorageOptions {
   /** Redis client instance. */
   client: RedisClient;
-  /** Key prefix for all cache entries. @default 'cache:' */
+  /**
+   * Key prefix for all cache entries. The storage owns this namespace —
+   * unlike rate-limit (whose middleware owns the `'rl'` prefix) — because
+   * `clear()`, `deletePattern()`, and the tag indices are scoped by it and
+   * the physical store may be shared (with prefix `''`, `clear()` would wipe
+   * every key in the Redis DB).
+   * @default 'cache:'
+   */
   prefix?: string;
   /** Default TTL in milliseconds. @default 300_000 */
   defaultTtlMs?: number;

--- a/packages/core/src/audit/index.ts
+++ b/packages/core/src/audit/index.ts
@@ -1,5 +1,6 @@
-import type { Context } from 'hono';
+import type { Context, Env } from 'hono';
 import { CONTEXT_KEYS } from '../core/context-keys';
+import { ConfigurationException } from '../core/exceptions';
 import type { AuditAction, AuditConfig, AuditLogEntry, NormalizedAuditConfig } from '../core/types';
 import { createStorageFeature } from '../storage/feature';
 import { calculateChanges, getAuditConfig } from './config';
@@ -146,6 +147,21 @@ export const getAuditStorage = auditStorageFeature.get;
 export const getAuditStorageRequired = auditStorageFeature.getRequired;
 
 /**
+ * Resolves audit storage with priority: explicit param > context > global.
+ * Never creates a default — returns null when nothing is configured.
+ *
+ * @param ctx - Optional Hono context
+ * @param explicitStorage - Optional explicit storage instance
+ * @returns The resolved storage, or null when no storage was configured
+ */
+export function resolveAuditStorage<E extends Env>(
+  ctx?: Context<E>,
+  explicitStorage?: AuditLogStorage,
+): AuditLogStorage | null {
+  return auditStorageFeature.resolve(ctx, explicitStorage);
+}
+
+/**
  * Audit logger class for creating audit log entries.
  */
 export class AuditLogger {
@@ -159,7 +175,9 @@ export class AuditLogger {
 
   private getStorage(): AuditLogStorage {
     if (!this.storage) {
-      throw new Error(
+      // Request-time misconfiguration: the feature is enabled but no storage
+      // was wired — surface as 500 CONFIGURATION_ERROR, not generic INTERNAL.
+      throw new ConfigurationException(
         'Audit storage not configured. Pass storage explicitly or inject auditStorage with createStorageMiddleware().',
       );
     }

--- a/packages/core/src/auth/guards.ts
+++ b/packages/core/src/auth/guards.ts
@@ -2,14 +2,12 @@ import type { MiddlewareHandler } from 'hono';
 import { z } from 'zod';
 import { CONTEXT_KEYS } from '../core/context-keys';
 import { ForbiddenException, UnauthorizedException } from '../core/exceptions';
-import { getLogger } from '../core/logger';
 import type { ModelPolicies } from '../core/types';
 import { getContextVar, setContextVar } from '../utils/context';
-import { MemoryApprovalStorage } from './storage/approval-memory';
+import { getApprovalStorageRequired, resolveApprovalStorage } from './storage/approval-memory';
 import type {
   ActionSource,
   ApprovalConfig,
-  ApprovalStorage,
   AuthEnv,
   AuthorizationCheck,
   Guard,
@@ -24,30 +22,6 @@ import { parseIso8601Duration } from './utils/duration';
  */
 function isObjectRecord(x: unknown): x is Record<string, unknown> {
   return x !== null && typeof x === 'object' && !Array.isArray(x);
-}
-
-/**
- * Process-local fallback storage used when `requireApproval(...)` is
- * called without an explicit `approvalStorage`. Lazy-instantiated so
- * apps that always pass storage never construct it.
- */
-let _defaultApprovalStorage: MemoryApprovalStorage | undefined;
-let _warnedAboutDefaultApprovalStorage = false;
-
-function getDefaultApprovalStorage(): MemoryApprovalStorage {
-  if (!_defaultApprovalStorage) {
-    _defaultApprovalStorage = new MemoryApprovalStorage();
-  }
-  if (!_warnedAboutDefaultApprovalStorage) {
-    _warnedAboutDefaultApprovalStorage = true;
-    getLogger().warn(
-      'requireApproval: no approvalStorage configured — using process-local in-memory storage. ' +
-        'NOT safe for multi-instance / serverless / edge-isolate deployments where phase 1 and ' +
-        'phase 2 may hit different processes. Pass an explicit approvalStorage (e.g. ' +
-        'PostgresApprovalStorage) for production. This warning is logged once per process.',
-    );
-  }
-  return _defaultApprovalStorage;
 }
 
 /**
@@ -464,7 +438,6 @@ export function requirePolicy<T = unknown, E extends AuthEnv = AuthEnv>(
 export function requireApproval<E extends AuthEnv = AuthEnv>(
   config: ApprovalConfig,
 ): MiddlewareHandler<E> {
-  const storage: ApprovalStorage = config.approvalStorage ?? getDefaultApprovalStorage();
   const resumeMarker = config.resumeMarker ?? '_resume_';
   const expireMs = parseIso8601Duration(config.expiresAfter ?? 'P1D');
 
@@ -475,6 +448,12 @@ export function requireApproval<E extends AuthEnv = AuthEnv>(
   const ResumeBodySchema = z.object({ [resumeMarker]: z.string() }).loose();
 
   return async (ctx, next) => {
+    // Resolve storage INSIDE the handler (explicit > context > global) so
+    // per-request backends injected via createStorageMiddleware (KV / D1 /
+    // Durable Object bindings only reachable at request time on Workers) are
+    // honored. Only when nothing resolves does the warned process-local
+    // in-memory default materialize (zero-config POC path).
+    const storage = resolveApprovalStorage(ctx, config.storage) ?? getApprovalStorageRequired();
     let body: Record<string, unknown> = {};
     try {
       const parsed: unknown = await ctx.req.json();

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -86,8 +86,15 @@ export {
   requireApproval,
 } from './guards';
 
-// Approval storage
-export { MemoryApprovalStorage } from './storage/approval-memory';
+// Approval storage (set/get/getRequired/resolve quartet + registry)
+export {
+  MemoryApprovalStorage,
+  approvalStorageRegistry,
+  setApprovalStorage,
+  getApprovalStorage,
+  getApprovalStorageRequired,
+  resolveApprovalStorage,
+} from './storage/approval-memory';
 export { parseIso8601Duration } from './utils/duration';
 
 // ============================================================================
@@ -135,8 +142,11 @@ export {
   MemoryAPIKeyStorage,
   generateAPIKey,
   isValidAPIKeyFormat,
-  getAPIKeyStorage,
+  apiKeyStorageRegistry,
   setAPIKeyStorage,
+  getAPIKeyStorage,
+  getAPIKeyStorageRequired,
+  resolveAPIKeyStorage,
 } from './storage/memory';
 
 // ============================================================================

--- a/packages/core/src/auth/middleware/api-key.ts
+++ b/packages/core/src/auth/middleware/api-key.ts
@@ -1,9 +1,9 @@
 import type { Context, MiddlewareHandler } from 'hono';
 import { CONTEXT_KEYS } from '../../core/context-keys';
 import { ConfigurationException, UnauthorizedException } from '../../core/exceptions';
-import { resolveAPIKeyStorage } from '../../storage/helpers';
 import { getWaitUntil } from '../../utils/wait-until';
 import { hashAPIKey } from '../hash';
+import { resolveAPIKeyStorage } from '../storage/memory';
 import type { APIKeyConfig, APIKeyEntry, APIKeyLookupResult, AuthEnv, AuthUser } from '../types';
 import { validateAPIKeyEntry } from '../validators/api-key';
 

--- a/packages/core/src/auth/storage/approval-memory.ts
+++ b/packages/core/src/auth/storage/approval-memory.ts
@@ -12,6 +12,10 @@
  * Not suitable for production cross-isolate state — wire a Postgres /
  * Durable Object backed `ApprovalStorage` in those scenarios.
  */
+import type { Context, Env } from 'hono';
+import { CONTEXT_KEYS } from '../../core/context-keys';
+import { getLogger } from '../../core/logger';
+import { createStorageFeature } from '../../storage/feature';
 import type { ApprovalStorage, PendingAction } from '../types';
 
 export class MemoryApprovalStorage implements ApprovalStorage {
@@ -75,4 +79,68 @@ export class MemoryApprovalStorage implements ApprovalStorage {
   clear(): void {
     this.store.clear();
   }
+}
+
+// ============================================================================
+// Global Storage Feature
+// ============================================================================
+
+/**
+ * Global approval storage feature.
+ *
+ * `getApprovalStorageRequired()` lazy-creates a process-local
+ * `MemoryApprovalStorage` default (with a one-time warning) so zero-config
+ * POCs keep working; `getApprovalStorage()` and request-time resolution only
+ * return explicit, context, or configured global storage (no hidden default).
+ */
+const approvalStorageFeature = createStorageFeature<ApprovalStorage>({
+  contextKey: CONTEXT_KEYS.approvalStorage,
+  defaultFactory: () => {
+    // The factory runs at most once per isolate (per registry reset), so the
+    // warning is naturally once-per-isolate.
+    getLogger().warn(
+      'requireApproval: no approval storage configured — using process-local in-memory storage. ' +
+        'NOT safe for multi-instance / serverless / edge-isolate deployments where phase 1 and ' +
+        'phase 2 may hit different processes. Pass an explicit storage (config.storage) or ' +
+        'inject approvalStorage with createStorageMiddleware() for production.',
+    );
+    return new MemoryApprovalStorage();
+  },
+});
+
+/**
+ * Global approval storage registry (exported for advanced use / tests).
+ */
+export const approvalStorageRegistry = approvalStorageFeature.registry;
+
+/**
+ * Set the global approval storage.
+ */
+export const setApprovalStorage = approvalStorageFeature.set;
+
+/**
+ * Get the explicitly-configured global approval storage, or null. Never throws
+ * and never materializes the in-memory default.
+ */
+export const getApprovalStorage = approvalStorageFeature.get;
+
+/**
+ * Get the global approval storage, lazily creating the warned process-local
+ * `MemoryApprovalStorage` default when none was configured.
+ */
+export const getApprovalStorageRequired = approvalStorageFeature.getRequired;
+
+/**
+ * Resolves approval storage with priority: explicit param > context > global.
+ * Never creates a default — returns null when nothing is configured.
+ *
+ * @param ctx - Optional Hono context
+ * @param explicitStorage - Optional explicit storage instance
+ * @returns The resolved storage, or null when no storage was configured
+ */
+export function resolveApprovalStorage<E extends Env>(
+  ctx?: Context<E>,
+  explicitStorage?: ApprovalStorage,
+): ApprovalStorage | null {
+  return approvalStorageFeature.resolve(ctx, explicitStorage);
 }

--- a/packages/core/src/auth/storage/memory.ts
+++ b/packages/core/src/auth/storage/memory.ts
@@ -1,3 +1,4 @@
+import type { Context, Env } from 'hono';
 import { CONTEXT_KEYS } from '../../core/context-keys';
 import { createStorageFeature } from '../../storage/feature';
 import { hashAPIKey } from '../hash';
@@ -261,3 +262,17 @@ export const getAPIKeyStorageRequired = apiKeyStorageFeature.getRequired;
  * Sets the global API key storage.
  */
 export const setAPIKeyStorage = apiKeyStorageFeature.set;
+
+/**
+ * Resolves API key storage with priority: explicit param > context > global.
+ *
+ * @param ctx - Optional Hono context
+ * @param explicitStorage - Optional explicit storage instance
+ * @returns The resolved storage, or null when no storage was configured
+ */
+export function resolveAPIKeyStorage<E extends Env>(
+  ctx?: Context<E>,
+  explicitStorage?: APIKeyStorage,
+): APIKeyStorage | null {
+  return apiKeyStorageFeature.resolve(ctx, explicitStorage);
+}

--- a/packages/core/src/auth/types.ts
+++ b/packages/core/src/auth/types.ts
@@ -576,16 +576,18 @@ export interface ApprovalConfig {
   /** ISO 8601 duration string (e.g. `'P1D'`, `'PT2H'`). @default 'P1D' */
   expiresAfter?: string;
   /**
-   * Storage backend. Optional — when omitted, the lib uses a
-   * process-local `MemoryApprovalStorage` singleton so single-server
-   * POCs and tutorials work zero-config. **First use of the default
-   * emits a one-time warning via `getLogger()`** to surface the fact
-   * that pending actions live in process memory and won't survive a
-   * restart or load-balancer hop. For production multi-instance
-   * deployments, pass a durable `ApprovalStorage` (Postgres, D1,
-   * Durable Objects, etc.) explicitly.
+   * Storage backend. Optional — resolution happens per request with the
+   * standard priority chain: this explicit instance > context
+   * (`createStorageMiddleware({ approvalStorage })`) > global
+   * (`setApprovalStorage()`). When nothing resolves, the lib lazily
+   * materializes a process-local `MemoryApprovalStorage` default so
+   * single-server POCs and tutorials work zero-config. **First use of the
+   * default emits a one-time warning via `getLogger()`** to surface the fact
+   * that pending actions live in process memory and won't survive a restart
+   * or load-balancer hop. For production multi-instance deployments, provide
+   * a durable `ApprovalStorage` (Postgres, D1, Durable Objects, etc.).
    */
-  approvalStorage?: ApprovalStorage;
+  storage?: ApprovalStorage;
   /**
    * Body field whose presence flags a resume call. The value is the
    * actionId to look up. @default '_resume_'

--- a/packages/core/src/core/context-keys.ts
+++ b/packages/core/src/core/context-keys.ts
@@ -58,6 +58,7 @@ export const CONTEXT_KEYS = {
   auditStorage: 'auditStorage',
   versioningStorage: 'versioningStorage',
   apiKeyStorage: 'apiKeyStorage',
+  approvalStorage: 'approvalStorage',
   cacheStorage: 'cacheStorage',
   rateLimitStorage: 'rateLimitStorage',
   idempotencyStorage: 'idempotencyStorage',

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -225,7 +225,12 @@ export interface RelationConfig<TTable = unknown> {
   localKey?: string;
   /** Related model's schema for response typing */
   schema?: ZodObject<ZodRawShape>;
-  /** ORM table reference for the related model (required for Drizzle) */
+  /**
+   * ORM table reference for the related model (required for Drizzle).
+   * For Prisma, a string naming the related model's client delegate
+   * (e.g. `'person'`) — overrides the camelCase+singularize derivation
+   * from `model` for irregular names.
+   */
   table?: TTable;
   /**
    * Configuration for nested write operations.
@@ -868,7 +873,13 @@ export interface Model<
   primaryKeys: Array<SchemaKeys<T> & string>;
   /** Optional serializer to transform objects before response */
   serializer?: (obj: z.infer<T>) => unknown;
-  /** ORM table reference (Drizzle Table, etc.) */
+  /**
+   * ORM table reference (Drizzle Table, etc.).
+   * For Prisma, a string naming the client delegate explicitly
+   * (e.g. `defineModel({ tableName: 'people', table: 'person', ... })`) —
+   * overrides the camelCase+singularize derivation from `tableName` for
+   * irregular names.
+   */
   table?: TTable;
   /**
    * Enable soft delete for this model.

--- a/packages/core/src/events/index.ts
+++ b/packages/core/src/events/index.ts
@@ -1,4 +1,10 @@
-export { CrudEventEmitter, getEventEmitter, setEventEmitter, resolveEventEmitter } from './emitter';
+export {
+  CrudEventEmitter,
+  eventEmitterRegistry,
+  getEventEmitter,
+  setEventEmitter,
+  resolveEventEmitter,
+} from './emitter';
 export { registerWebhooks } from './webhook';
 export { CRUD_EVENT_TYPES } from './types';
 export type {

--- a/packages/core/src/logging/index.ts
+++ b/packages/core/src/logging/index.ts
@@ -34,11 +34,14 @@ export {
   getUserId as extractUserId,
 } from '../utils/request-info';
 
-// Middleware
+// Middleware + storage feature (set/get/getRequired/resolve quartet + registry)
 export {
   createLoggingMiddleware,
+  loggingStorageRegistry,
   setLoggingStorage,
   getLoggingStorage,
+  getLoggingStorageRequired,
+  resolveLoggingStorage,
   getRequestId,
   getRequestStartTime,
 } from './middleware';

--- a/packages/core/src/logging/middleware.ts
+++ b/packages/core/src/logging/middleware.ts
@@ -2,7 +2,6 @@ import type { Context, Env, MiddlewareHandler } from 'hono';
 import { CONTEXT_KEYS } from '../core/context-keys';
 import { getLogger } from '../core/logger';
 import { createStorageFeature } from '../storage/feature';
-import { resolveLoggingStorage } from '../storage/helpers';
 import {
   generateRequestId as defaultGenerateRequestId,
   getContextVar,
@@ -68,6 +67,20 @@ export const getLoggingStorage = loggingStorageFeature.get;
  * Get the global logging storage, throwing if not configured.
  */
 export const getLoggingStorageRequired = loggingStorageFeature.getRequired;
+
+/**
+ * Resolves logging storage with priority: explicit param > context > global.
+ *
+ * @param ctx - Optional Hono context
+ * @param explicitStorage - Optional explicit storage instance
+ * @returns The resolved storage, or null when no storage was configured
+ */
+export function resolveLoggingStorage<E extends Env>(
+  ctx?: Context<E>,
+  explicitStorage?: LoggingStorage,
+): LoggingStorage | null {
+  return loggingStorageFeature.resolve(ctx, explicitStorage);
+}
 
 // ============================================================================
 // Default Configuration

--- a/packages/core/src/storage/contracts.ts
+++ b/packages/core/src/storage/contracts.ts
@@ -239,6 +239,12 @@ export interface IdempotencyStorage {
   /**
    * Acquire a lock for a key being processed.
    * Returns true if the lock was acquired, false if already locked.
+   *
+   * MUST be atomic (compare-and-set, e.g. Redis `SET NX PX`). This is why
+   * there is deliberately no Cloudflare KV backend for idempotency: KV has no
+   * compare-and-swap, so a KV lock would be advisory only — a correctness
+   * footgun for the one feature whose failure mode is duplicate side effects.
+   * Workers users should use Upstash Redis (or a future Durable Objects backend).
    */
   lock(key: string, ttlMs: number): Promise<boolean>;
 

--- a/packages/core/src/storage/feature.ts
+++ b/packages/core/src/storage/feature.ts
@@ -16,7 +16,8 @@ export interface StorageFeature<T> {
   /**
    * Get the explicitly-configured global storage, or null. Never throws.
    * When the feature was created with `lazyDefaultOnGet: true`, this may
-   * lazy-create the default (legacy never-null path; cache only).
+   * lazy-create the default (legacy never-null path; see
+   * {@link StorageFeatureOptions.lazyDefaultOnGet} for who opts in).
    */
   get(): T | null;
   /**
@@ -43,7 +44,10 @@ export interface StorageFeatureOptions<T> {
    * When true (and a defaultFactory exists), `get()` ALSO lazy-creates the
    * default, preserving a legacy never-null getter. When false/omitted, `get()`
    * returns only explicitly-configured storage (honest `T | null`). Default: false.
-   * Only cache sets this true; audit/versioning leave it false.
+   *
+   * Intentional exceptions only — currently the event-emitter feature is the
+   * sole opt-in; every other storage feature leaves it false. Each opt-in must
+   * document its justification at the call site (see `core/src/events/emitter.ts`).
    */
   lazyDefaultOnGet?: boolean;
 }

--- a/packages/core/src/storage/helpers.ts
+++ b/packages/core/src/storage/helpers.ts
@@ -1,22 +1,26 @@
-import type { Context, Env } from 'hono';
-import type { AuditLogStorage } from '../audit';
-import { auditStorageRegistry } from '../audit';
-import { apiKeyStorageRegistry } from '../auth/storage/memory';
-import type { APIKeyStorage } from '../auth/types';
-import { loggingStorageRegistry } from '../logging/middleware';
-import type { LoggingStorage } from '../logging/types';
-import type { VersioningStorage } from '../versioning';
-import { versioningStorageRegistry } from '../versioning';
+import type { Context } from 'hono';
 import type { StorageEnv } from './types';
 
-// Re-export getters for backward compatibility (used by other modules).
-// The `*Required` variants are created by the audit/versioning/logging/auth
-// migrations (a later work package); the re-export lines are wired here ahead
-// of those implementations.
-export { getLoggingStorage, getLoggingStorageRequired } from '../logging/middleware';
-export { getAuditStorage, getAuditStorageRequired } from '../audit';
-export { getVersioningStorage, getVersioningStorageRequired } from '../versioning';
-export { getAPIKeyStorage } from '../auth/storage/memory';
+// Re-export the storage-feature getters/resolvers from their home feature
+// modules. Each feature module is the single canonical definition site (the
+// quartet lives next to its `createStorageFeature` call); this barrel keeps
+// the storage subpath offering the whole family in one place.
+export {
+  getLoggingStorage,
+  getLoggingStorageRequired,
+  resolveLoggingStorage,
+} from '../logging/middleware';
+export { getAuditStorage, getAuditStorageRequired, resolveAuditStorage } from '../audit';
+export {
+  getVersioningStorage,
+  getVersioningStorageRequired,
+  resolveVersioningStorage,
+} from '../versioning';
+export {
+  getAPIKeyStorage,
+  getAPIKeyStorageRequired,
+  resolveAPIKeyStorage,
+} from '../auth/storage/memory';
 
 // ============================================================================
 // Type-Safe Context Variable Access
@@ -53,66 +57,4 @@ export function getStorage<K extends StorageKey>(
   key: K,
 ): StorageEnv['Variables'][K] {
   return ctx.var[key];
-}
-
-// ============================================================================
-// Storage Resolution Functions
-// All delegate to their respective StorageRegistry.resolve() method which
-// implements the priority chain: explicit param > context variable > global.
-// ============================================================================
-
-/**
- * Resolves logging storage with priority: explicit param > context > global.
- *
- * @param ctx - Optional Hono context
- * @param explicitStorage - Optional explicit storage instance
- * @returns The resolved storage or null if none available
- */
-export function resolveLoggingStorage<E extends Env>(
-  ctx?: Context<E>,
-  explicitStorage?: LoggingStorage,
-): LoggingStorage | null {
-  return loggingStorageRegistry.resolve(ctx, explicitStorage);
-}
-
-/**
- * Resolves audit storage with priority: explicit param > context > global.
- *
- * @param ctx - Optional Hono context
- * @param explicitStorage - Optional explicit storage instance
- * @returns The resolved storage, or null when no storage was configured
- */
-export function resolveAuditStorage<E extends Env>(
-  ctx?: Context<E>,
-  explicitStorage?: AuditLogStorage,
-): AuditLogStorage | null {
-  return auditStorageRegistry.resolve(ctx, explicitStorage);
-}
-
-/**
- * Resolves versioning storage with priority: explicit param > context > global.
- *
- * @param ctx - Optional Hono context
- * @param explicitStorage - Optional explicit storage instance
- * @returns The resolved storage, or null when no storage was configured
- */
-export function resolveVersioningStorage<E extends Env>(
-  ctx?: Context<E>,
-  explicitStorage?: VersioningStorage,
-): VersioningStorage | null {
-  return versioningStorageRegistry.resolve(ctx, explicitStorage);
-}
-
-/**
- * Resolves API key storage with priority: explicit param > context > global.
- *
- * @param ctx - Optional Hono context
- * @param explicitStorage - Optional explicit storage instance
- * @returns The resolved storage, or null when no storage was configured
- */
-export function resolveAPIKeyStorage<E extends Env>(
-  ctx?: Context<E>,
-  explicitStorage?: APIKeyStorage,
-): APIKeyStorage | null {
-  return apiKeyStorageRegistry.resolve(ctx, explicitStorage);
 }

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -22,6 +22,7 @@ export {
   createAuditStorageMiddleware,
   createVersioningStorageMiddleware,
   createAPIKeyStorageMiddleware,
+  createApprovalStorageMiddleware,
   createCacheStorageMiddleware,
   createRateLimitStorageMiddleware,
   createIdempotencyStorageMiddleware,
@@ -45,6 +46,7 @@ export {
   getLoggingStorageRequired,
   getAuditStorageRequired,
   getVersioningStorageRequired,
+  getAPIKeyStorageRequired,
 } from './helpers';
 
 // Registry

--- a/packages/core/src/storage/middleware.ts
+++ b/packages/core/src/storage/middleware.ts
@@ -11,6 +11,7 @@ const STORAGE_SLOTS: Record<keyof StorageMiddlewareConfig, ContextKey> = {
   auditStorage: CONTEXT_KEYS.auditStorage,
   versioningStorage: CONTEXT_KEYS.versioningStorage,
   apiKeyStorage: CONTEXT_KEYS.apiKeyStorage,
+  approvalStorage: CONTEXT_KEYS.approvalStorage,
   cacheStorage: CONTEXT_KEYS.cacheStorage,
   rateLimitStorage: CONTEXT_KEYS.rateLimitStorage,
   idempotencyStorage: CONTEXT_KEYS.idempotencyStorage,
@@ -127,6 +128,18 @@ export function createAPIKeyStorageMiddleware<E extends Env = Env>(
   storage: NonNullable<StorageMiddlewareConfig['apiKeyStorage']>,
 ): MiddlewareHandler<E & StorageEnv> {
   return createStorageMiddleware({ apiKeyStorage: storage });
+}
+
+/**
+ * Creates middleware that injects only approval storage.
+ *
+ * @param storage - Approval storage instance
+ * @returns Middleware handler
+ */
+export function createApprovalStorageMiddleware<E extends Env = Env>(
+  storage: NonNullable<StorageMiddlewareConfig['approvalStorage']>,
+): MiddlewareHandler<E & StorageEnv> {
+  return createStorageMiddleware({ approvalStorage: storage });
 }
 
 /**

--- a/packages/core/src/storage/registry.ts
+++ b/packages/core/src/storage/registry.ts
@@ -1,4 +1,5 @@
 import type { Context, Env } from 'hono';
+import { ConfigurationException } from '../core/exceptions';
 import { getContextVar } from '../utils/context';
 
 /**
@@ -91,12 +92,13 @@ export class StorageRegistry<T> {
    * Gets the global storage instance, throwing if not set.
    * Use this when storage is required.
    *
-   * @throws Error if storage is not configured
+   * @throws ConfigurationException if storage is not configured (request-time
+   *   misconfiguration — surfaces as 500 CONFIGURATION_ERROR, not generic INTERNAL)
    */
   getRequired(): T {
     this.ensureDefault();
     if (this.globalStorage === null) {
-      throw new Error(`Storage not configured for '${this.contextKey}'`);
+      throw new ConfigurationException(`Storage not configured for '${this.contextKey}'`);
     }
     return this.globalStorage;
   }
@@ -146,12 +148,13 @@ export class StorageRegistry<T> {
    * @param ctx - Optional Hono context for context-based resolution
    * @param explicit - Optional explicitly provided storage instance
    * @returns The resolved storage
-   * @throws Error if no storage is configured
+   * @throws ConfigurationException if no storage is configured (request-time
+   *   misconfiguration — surfaces as 500 CONFIGURATION_ERROR, not generic INTERNAL)
    */
   resolveRequired<E extends Env>(ctx?: Context<E>, explicit?: T): T {
     const storage = this.resolve(ctx, explicit);
     if (storage === null) {
-      throw new Error(`Storage not configured for '${this.contextKey}'`);
+      throw new ConfigurationException(`Storage not configured for '${this.contextKey}'`);
     }
     return storage;
   }

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -1,6 +1,6 @@
 import type { Env } from 'hono';
 import type { AuditLogStorage } from '../audit';
-import type { APIKeyStorage } from '../auth/types';
+import type { APIKeyStorage, ApprovalStorage } from '../auth/types';
 import type { CrudEventEmitter } from '../events/emitter';
 import type { LoggingStorage } from '../logging/types';
 import type { VersioningStorage } from '../versioning';
@@ -33,6 +33,7 @@ export interface StorageEnv extends Env {
     auditStorage?: AuditLogStorage;
     versioningStorage?: VersioningStorage;
     apiKeyStorage?: APIKeyStorage;
+    approvalStorage?: ApprovalStorage;
     cacheStorage?: CacheStorage;
     rateLimitStorage?: RateLimitStorage;
     idempotencyStorage?: IdempotencyStorage;
@@ -76,6 +77,12 @@ export interface StorageMiddlewareConfig {
    * If provided, will be available as `ctx.var.apiKeyStorage`.
    */
   apiKeyStorage?: APIKeyStorage;
+
+  /**
+   * Approval (human-in-the-loop pending-action) storage instance.
+   * If provided, will be available as `ctx.var.approvalStorage`.
+   */
+  approvalStorage?: ApprovalStorage;
 
   /**
    * Cache storage instance.

--- a/packages/core/src/versioning/index.ts
+++ b/packages/core/src/versioning/index.ts
@@ -1,6 +1,7 @@
-import type { Context } from 'hono';
+import type { Context, Env } from 'hono';
 import { calculateChanges } from '../audit/config';
 import { CONTEXT_KEYS } from '../core/context-keys';
+import { ConfigurationException } from '../core/exceptions';
 import type {
   AuditFieldChange,
   NormalizedVersioningConfig,
@@ -200,6 +201,21 @@ export const getVersioningStorage = versioningStorageFeature.get;
 export const getVersioningStorageRequired = versioningStorageFeature.getRequired;
 
 /**
+ * Resolves versioning storage with priority: explicit param > context > global.
+ * Never creates a default — returns null when nothing is configured.
+ *
+ * @param ctx - Optional Hono context
+ * @param explicitStorage - Optional explicit storage instance
+ * @returns The resolved storage, or null when no storage was configured
+ */
+export function resolveVersioningStorage<E extends Env>(
+  ctx?: Context<E>,
+  explicitStorage?: VersioningStorage,
+): VersioningStorage | null {
+  return versioningStorageFeature.resolve(ctx, explicitStorage);
+}
+
+/**
  * Version manager class for handling versioning operations.
  */
 export class VersionManager {
@@ -220,7 +236,9 @@ export class VersionManager {
 
   private getStorage(): VersioningStorage {
     if (!this.storage) {
-      throw new Error(
+      // Request-time misconfiguration: the feature is enabled but no storage
+      // was wired — surface as 500 CONFIGURATION_ERROR, not generic INTERNAL.
+      throw new ConfigurationException(
         'Versioning storage not configured. Pass storage explicitly or inject versioningStorage with createStorageMiddleware().',
       );
     }

--- a/packages/drizzle/src/connection.ts
+++ b/packages/drizzle/src/connection.ts
@@ -13,7 +13,7 @@
  * implementation and stay in sync.
  */
 
-import { CONTEXT_KEYS } from 'hono-crud/internal';
+import { CONTEXT_KEYS, ConfigurationException } from 'hono-crud/internal';
 import type { DrizzleDatabaseConstraint } from './helpers';
 
 interface DrizzleEndpointShape {
@@ -34,7 +34,8 @@ export function getDrizzleDb(self: unknown): DrizzleDatabaseConstraint {
   if (s.db) return s.db;
   const contextDb = s.context?.get?.(CONTEXT_KEYS.db as never);
   if (contextDb) return contextDb as DrizzleDatabaseConstraint;
-  throw new Error(
+  // Request-time misconfiguration — surface as 500 CONFIGURATION_ERROR.
+  throw new ConfigurationException(
     'Database not configured. Either:\n' +
       '1. Set db property: db = myDb;\n' +
       '2. Use middleware: c.set(CONTEXT_KEYS.db, myDb);\n' +

--- a/packages/idempotency/README.md
+++ b/packages/idempotency/README.md
@@ -11,16 +11,49 @@ npm install @hono-crud/idempotency hono-crud hono
 ## Usage
 
 ```ts
+import { createStorageMiddleware } from 'hono-crud/storage';
 import {
   createIdempotencyMiddleware,
-  setIdempotencyStorage,
   MemoryIdempotencyStorage,
 } from '@hono-crud/idempotency';
 
-setIdempotencyStorage(new MemoryIdempotencyStorage());
+// Wire storage (recommended: per-request injection, edge-safe)
+app.use('*', createStorageMiddleware({
+  idempotencyStorage: new MemoryIdempotencyStorage(),
+}));
 
 // Replays the original response for repeated requests carrying the same Idempotency-Key.
 app.use('/api/*', createIdempotencyMiddleware());
 ```
 
-Exports `createIdempotencyMiddleware`, `setIdempotencyStorage`, and `MemoryIdempotencyStorage`.
+On a long-lived server, `setIdempotencyStorage(new MemoryIdempotencyStorage())` once at boot is the module-global alternative (resolution priority: explicit `config.storage` > context > global).
+
+## Production storage
+
+`MemoryIdempotencyStorage` is per-process / per-isolate: on Cloudflare Workers (or any multi-instance deployment) a retry may hit a different isolate with an empty store, so replay protection is not guaranteed exactly where it matters. Use `RedisIdempotencyStorage` in production — compatible with `@upstash/redis` (edge-safe) out of the box:
+
+```ts
+import { Redis } from '@upstash/redis';
+import { RedisIdempotencyStorage } from '@hono-crud/idempotency';
+import { createStorageMiddleware } from 'hono-crud/storage';
+
+app.use('*', async (c, next) => {
+  const idempotencyStorage = new RedisIdempotencyStorage({
+    client: new Redis({ url: c.env.REDIS_URL, token: c.env.REDIS_TOKEN }),
+  });
+  return createStorageMiddleware({ idempotencyStorage })(c, next);
+});
+```
+
+### Why there is no Cloudflare KV backend
+
+The in-flight lock that prevents two concurrent requests with the same key from both executing must be **atomic** (compare-and-set). Redis expresses it as a single `SET key value NX PX ttl` round-trip. Cloudflare KV has no compare-and-swap, so a KV "lock" would be a read-then-write race — advisory only. For the one feature whose failure mode is duplicate side effects (double charges), an advisory lock is a correctness footgun, so the KV backend is deliberately omitted. Cloudflare-native users should use Upstash Redis today; Durable Objects (not KV) is the correct Cloudflare primitive for a possible future first-party backend.
+
+## Errors
+
+The middleware throws `ApiException` subclasses that flow through `createErrorHandler` (ErrorMappers / ErrorHooks / custom `responseEnvelope`) like every sibling middleware:
+
+- `IdempotencyKeyRequiredException` — 400 `IDEMPOTENCY_KEY_REQUIRED` (header missing under `required: true`)
+- `IdempotencyConflictException` — 409 `IDEMPOTENCY_CONFLICT` (same key already in flight)
+
+Exports `createIdempotencyMiddleware`, the storage quartet (`setIdempotencyStorage` / `getIdempotencyStorage` / `getIdempotencyStorageRequired` / `resolveIdempotencyStorage`), `MemoryIdempotencyStorage`, `RedisIdempotencyStorage`, and the exception classes.

--- a/packages/idempotency/src/exceptions.ts
+++ b/packages/idempotency/src/exceptions.ts
@@ -1,0 +1,47 @@
+import { ApiException } from 'hono-crud/internal';
+
+/**
+ * Exception thrown when `required: true` is configured and a mutating request
+ * arrives without the idempotency key header.
+ *
+ * Flows through `createErrorHandler` (ErrorMappers / ErrorHooks / custom
+ * `responseEnvelope`) like every other middleware exception; on bare Hono apps
+ * it still serializes to the canonical envelope via `ApiException.getResponse()`.
+ *
+ * @example
+ * ```ts
+ * throw new IdempotencyKeyRequiredException('Idempotency-Key', 'POST');
+ * ```
+ */
+export class IdempotencyKeyRequiredException extends ApiException {
+  constructor(headerName = 'Idempotency-Key', method?: string) {
+    super(
+      `${headerName} header is required${method ? ` for ${method} requests` : ''}`,
+      400,
+      'IDEMPOTENCY_KEY_REQUIRED',
+      { headerName, ...(method ? { method } : {}) },
+    );
+    this.name = 'IdempotencyKeyRequiredException';
+  }
+}
+
+/**
+ * Exception thrown when a request carries an idempotency key that is already
+ * being processed by an in-flight request (lock held).
+ *
+ * @example
+ * ```ts
+ * throw new IdempotencyConflictException('my-key');
+ * ```
+ */
+export class IdempotencyConflictException extends ApiException {
+  constructor(idempotencyKey?: string) {
+    super(
+      'A request with this idempotency key is already being processed',
+      409,
+      'IDEMPOTENCY_CONFLICT',
+      idempotencyKey !== undefined ? { idempotencyKey } : undefined,
+    );
+    this.name = 'IdempotencyConflictException';
+  }
+}

--- a/packages/idempotency/src/index.ts
+++ b/packages/idempotency/src/index.ts
@@ -1,9 +1,21 @@
+// Middleware + storage feature (set/get/getRequired/resolve quartet + registry)
 export {
   createIdempotencyMiddleware,
+  idempotencyStorageRegistry,
   setIdempotencyStorage,
   getIdempotencyStorage,
   getIdempotencyStorageRequired,
   resolveIdempotencyStorage,
 } from './middleware';
+
+// Exceptions
+export { IdempotencyKeyRequiredException, IdempotencyConflictException } from './exceptions';
+
+// Storage implementations
 export { MemoryIdempotencyStorage } from './storage/memory';
+export type { MemoryIdempotencyStorageOptions } from './storage/memory';
+export { RedisIdempotencyStorage } from './storage/redis';
+export type { RedisIdempotencyClient, RedisIdempotencyStorageOptions } from './storage/redis';
+
+// Types
 export type { IdempotencyConfig, IdempotencyStorage, IdempotencyEntry } from './types';

--- a/packages/idempotency/src/middleware.ts
+++ b/packages/idempotency/src/middleware.ts
@@ -1,17 +1,13 @@
 import type { Context, Env, MiddlewareHandler } from 'hono';
-import { CONTEXT_KEYS, createStorageFeature, getContextVar } from 'hono-crud/internal';
-import type { ErrorResponse } from 'hono-crud/internal';
+import {
+  CONTEXT_KEYS,
+  ConfigurationException,
+  createStorageFeature,
+  getContextVar,
+  getLogger,
+} from 'hono-crud/internal';
+import { IdempotencyConflictException, IdempotencyKeyRequiredException } from './exceptions';
 import type { IdempotencyConfig, IdempotencyEntry, IdempotencyStorage } from './types';
-
-/**
- * Build a standard error envelope. Typed as the shared {@link ErrorResponse} so
- * these bodies stay in lockstep with the framework's canonical error contract
- * (`{ success: false, error: { code, message } }`) instead of being re-declared
- * inline at each return site.
- */
-function idempotencyError(code: string, message: string): ErrorResponse {
-  return { success: false, error: { code, message } };
-}
 
 // ============================================================================
 // Global Storage
@@ -71,6 +67,9 @@ export function resolveIdempotencyStorage<E extends Env>(
 // Middleware
 // ============================================================================
 
+/** Once-per-isolate guard for the missing-storage warning (dedup, not request state). */
+let warnedMissingIdempotencyStorage = false;
+
 /**
  * Creates idempotency middleware for safe request retries.
  *
@@ -121,13 +120,7 @@ export function createIdempotencyMiddleware<E extends Env = Env>(
     // If no key provided
     if (!idempotencyKey) {
       if (required) {
-        return ctx.json(
-          idempotencyError(
-            'IDEMPOTENCY_KEY_REQUIRED',
-            `${headerName} header is required for ${method} requests`,
-          ),
-          400,
-        );
+        throw new IdempotencyKeyRequiredException(headerName, method);
       }
       return next();
     }
@@ -135,7 +128,24 @@ export function createIdempotencyMiddleware<E extends Env = Env>(
     // Resolve storage (explicit config.storage > context > global, single tier)
     const storage = resolveIdempotencyStorage(ctx, config.storage);
     if (!storage) {
-      // No storage configured, pass through
+      if (required) {
+        // The consumer declared the idempotency guarantee mandatory; a
+        // mis-wired storage must fail loudly rather than silently void the
+        // replay-protection guarantee (duplicate charges).
+        throw new ConfigurationException(
+          'Idempotency storage not configured but `required: true` was set. Inject ' +
+            'idempotencyStorage with createStorageMiddleware() (recommended) or call ' +
+            'setIdempotencyStorage().',
+        );
+      }
+      if (!warnedMissingIdempotencyStorage) {
+        warnedMissingIdempotencyStorage = true;
+        getLogger().warn(
+          'Idempotency storage not configured — requests pass through WITHOUT replay ' +
+            'protection. Inject idempotencyStorage with createStorageMiddleware() ' +
+            '(recommended) or call setIdempotencyStorage(). This warning is logged once per isolate.',
+        );
+      }
       return next();
     }
 
@@ -158,28 +168,20 @@ export function createIdempotencyMiddleware<E extends Env = Env>(
       });
     }
 
-    // Check for in-flight request with same key
+    // Check for in-flight request with same key.
+    // Lock safety: both 409 throws below happen BEFORE this request holds the
+    // lock (a failed `lock()` did not acquire it), so throwing here can never
+    // leak a held lock — the try/finally that releases it starts only after a
+    // successful acquire.
     const locked = await storage.isLocked(scopedKey);
     if (locked) {
-      return ctx.json(
-        idempotencyError(
-          'IDEMPOTENCY_CONFLICT',
-          'A request with this idempotency key is already being processed',
-        ),
-        409,
-      );
+      throw new IdempotencyConflictException(idempotencyKey);
     }
 
     // Acquire lock
     const acquired = await storage.lock(scopedKey, lockTimeoutMs);
     if (!acquired) {
-      return ctx.json(
-        idempotencyError(
-          'IDEMPOTENCY_CONFLICT',
-          'A request with this idempotency key is already being processed',
-        ),
-        409,
-      );
+      throw new IdempotencyConflictException(idempotencyKey);
     }
 
     try {

--- a/packages/idempotency/src/storage/memory.ts
+++ b/packages/idempotency/src/storage/memory.ts
@@ -2,16 +2,42 @@ import { MemoryTtlStore } from 'hono-crud/internal';
 import type { IdempotencyEntry, IdempotencyStorage } from '../types';
 
 /**
+ * Options for MemoryIdempotencyStorage.
+ */
+export interface MemoryIdempotencyStorageOptions {
+  /**
+   * Minimum interval between lazy cleanup runs (ms). Cleanup happens on
+   * access, not via background timers (edge-safe). Set 0 to disable.
+   * @default 60_000 (1 minute)
+   */
+  cleanupInterval?: number;
+  /** Maximum response entries before oldest-first eviction (0 = unlimited). @default 10_000 */
+  maxEntries?: number;
+}
+
+/**
  * In-memory idempotency storage.
  * Ideal for development, testing, and single-instance deployments.
  *
  * Uses lazy cleanup-on-access (edge-safe: no background timers).
  *
+ * **Caveats — not safe for multi-isolate production:**
+ * - State is per process / per isolate. On Cloudflare Workers (and any
+ *   multi-instance deployment) a retry may hit a DIFFERENT isolate with an
+ *   empty store, so replay protection is NOT guaranteed exactly where it
+ *   matters (duplicate charges). Use `RedisIdempotencyStorage` (Upstash is
+ *   edge-compatible) for production.
+ * - There is deliberately no Cloudflare KV backend: KV lacks compare-and-swap,
+ *   so an atomic `lock()` cannot be implemented (see the package README).
+ *
  * @example
  * ```ts
- * import { MemoryIdempotencyStorage, setIdempotencyStorage } from '@hono-crud/idempotency';
+ * import { MemoryIdempotencyStorage } from '@hono-crud/idempotency';
+ * import { createStorageMiddleware } from 'hono-crud/storage';
  *
- * setIdempotencyStorage(new MemoryIdempotencyStorage());
+ * app.use('*', createStorageMiddleware({
+ *   idempotencyStorage: new MemoryIdempotencyStorage(),
+ * }));
  * ```
  */
 export class MemoryIdempotencyStorage implements IdempotencyStorage {
@@ -25,7 +51,7 @@ export class MemoryIdempotencyStorage implements IdempotencyStorage {
   /** Timestamp of last cleanup run */
   private lastCleanup = 0;
 
-  constructor(options?: { cleanupInterval?: number; maxEntries?: number }) {
+  constructor(options?: MemoryIdempotencyStorageOptions) {
     this.cleanupInterval = options?.cleanupInterval ?? 60000;
     const maxEntries = options?.maxEntries ?? 10_000;
     // Both inner stores keep `cleanupInterval: 0` so their built-in

--- a/packages/idempotency/src/storage/redis.ts
+++ b/packages/idempotency/src/storage/redis.ts
@@ -1,0 +1,131 @@
+import type { IdempotencyEntry, IdempotencyStorage } from '../types';
+
+/**
+ * Minimal structural Redis client interface for idempotency storage.
+ *
+ * Deliberately NOT the cache package's `RedisClient`: idempotency locks need
+ * `set()` to accept `{ nx, px }` (the object-options form used by
+ * `@upstash/redis`) so lock acquisition is ONE atomic `SET key value NX PX ttl`
+ * round-trip — cache's client cannot express `NX`. Compatible with
+ * `@upstash/redis` natively; for `ioredis` (positional `'PX', ttl, 'NX'` args)
+ * wrap the client with a 3-line adapter.
+ */
+export interface RedisIdempotencyClient {
+  /** Get a string value (null when the key does not exist / expired). */
+  get(key: string): Promise<string | null>;
+  /**
+   * Set a string value. `px` = TTL in milliseconds; `nx` = only set if the
+   * key does NOT already exist (the atomic compare-and-set the lock relies
+   * on). Must resolve to a non-null value (`'OK'`) on success and `null`
+   * when `nx` prevented the write.
+   */
+  set(key: string, value: string, options?: { px?: number; nx?: boolean }): Promise<unknown>;
+  /** Delete keys; returns the number deleted. */
+  del(...keys: string[]): Promise<number>;
+  /** Count how many of the given keys exist. */
+  exists(...keys: string[]): Promise<number>;
+}
+
+/**
+ * Options for Redis idempotency storage.
+ */
+export interface RedisIdempotencyStorageOptions {
+  /** Redis client instance. */
+  client: RedisIdempotencyClient;
+  /**
+   * Key prefix for all entries and locks. The storage owns this namespace:
+   * the idempotency middleware adds no feature prefix of its own (keys arrive
+   * as `<userId>:<idempotencyKey>`), the physical store may be shared, and
+   * the adapter must segregate response entries from lock keys
+   * (`<prefix><key>` vs `<prefix>lock:<key>`).
+   * @default 'idem:'
+   */
+  prefix?: string;
+}
+
+/**
+ * Redis idempotency storage implementation.
+ * Compatible with `@upstash/redis` (edge) out of the box.
+ *
+ * Semantics:
+ * - Entries: `SET <prefix><key> <json> PX <ttlMs>` — Redis owns expiry.
+ * - Locks: `SET <prefix>lock:<key> '1' NX PX <ttlMs>` — a single atomic
+ *   compare-and-set round-trip. This is the reason there is no Cloudflare KV
+ *   backend: KV has no compare-and-swap, so a KV "lock" would be advisory
+ *   only — a correctness footgun for the one feature whose failure mode is
+ *   duplicate side effects (double charges).
+ *
+ * @example
+ * ```ts
+ * import { Redis } from '@upstash/redis';
+ * import { RedisIdempotencyStorage } from '@hono-crud/idempotency';
+ * import { createStorageMiddleware } from 'hono-crud/storage';
+ *
+ * app.use('*', async (c, next) => {
+ *   const idempotencyStorage = new RedisIdempotencyStorage({
+ *     client: new Redis({ url: c.env.REDIS_URL, token: c.env.REDIS_TOKEN }),
+ *   });
+ *   return createStorageMiddleware({ idempotencyStorage })(c, next);
+ * });
+ * ```
+ */
+export class RedisIdempotencyStorage implements IdempotencyStorage {
+  private client: RedisIdempotencyClient;
+  private prefix: string;
+
+  constructor(options: RedisIdempotencyStorageOptions) {
+    this.client = options.client;
+    this.prefix = options.prefix ?? 'idem:';
+  }
+
+  /** Response-entry key. */
+  private entryKey(key: string): string {
+    return `${this.prefix}${key}`;
+  }
+
+  /** In-flight lock key (segregated from entries within the prefix). */
+  private lockKey(key: string): string {
+    return `${this.prefix}lock:${key}`;
+  }
+
+  async get(key: string): Promise<IdempotencyEntry | null> {
+    const raw = await this.client.get(this.entryKey(key));
+    if (raw === null) return null;
+    try {
+      return JSON.parse(raw) as IdempotencyEntry;
+    } catch {
+      // Corrupted payload — treat as absent rather than failing the request.
+      return null;
+    }
+  }
+
+  async set(key: string, entry: IdempotencyEntry, ttlMs: number): Promise<void> {
+    const value = JSON.stringify(entry);
+    if (ttlMs > 0) {
+      await this.client.set(this.entryKey(key), value, { px: Math.ceil(ttlMs) });
+    } else {
+      await this.client.set(this.entryKey(key), value);
+    }
+  }
+
+  async isLocked(key: string): Promise<boolean> {
+    return (await this.client.exists(this.lockKey(key))) > 0;
+  }
+
+  /**
+   * Acquire the in-flight lock with ONE atomic `SET NX PX` round-trip.
+   * Returns true when the lock was acquired; false when another request
+   * holds it (Redis returns null for an NX miss).
+   */
+  async lock(key: string, ttlMs: number): Promise<boolean> {
+    const result = await this.client.set(this.lockKey(key), '1', {
+      nx: true,
+      px: Math.max(1, Math.ceil(ttlMs)),
+    });
+    return result !== null && result !== undefined;
+  }
+
+  async unlock(key: string): Promise<void> {
+    await this.client.del(this.lockKey(key));
+  }
+}

--- a/packages/idempotency/src/types.ts
+++ b/packages/idempotency/src/types.ts
@@ -31,9 +31,18 @@ export interface IdempotencyConfig {
   enforcedMethods?: string[];
 
   /**
-   * Whether to require the idempotency key header.
-   * If true, requests without the header will receive a 400 error.
-   * If false, requests without the header are passed through normally.
+   * Whether the idempotency guarantee is mandatory for enforced methods.
+   *
+   * If true:
+   * - requests without the header throw `IdempotencyKeyRequiredException`
+   *   (400 IDEMPOTENCY_KEY_REQUIRED), and
+   * - a missing/unresolvable storage throws `ConfigurationException` instead
+   *   of silently passing through (a mis-wired storage must not silently void
+   *   replay protection).
+   *
+   * If false (the default), requests without the header pass through
+   * normally, and a missing storage logs a once-per-isolate warning and
+   * passes through.
    * @default false
    */
   required?: boolean;

--- a/packages/prisma/src/advanced.ts
+++ b/packages/prisma/src/advanced.ts
@@ -50,10 +50,7 @@ export abstract class PrismaSearchEndpoint<
   declare prisma?: PrismaClient;
 
   protected async getModel(): Promise<PrismaModelOperations<ModelObject<M['model']>>> {
-    return getPrismaModel<ModelObject<M['model']>>(
-      getPrismaClient(this),
-      this._meta.model.tableName,
-    );
+    return getPrismaModel<ModelObject<M['model']>>(getPrismaClient(this), this._meta.model);
   }
 
   /**
@@ -197,10 +194,7 @@ export abstract class PrismaExportEndpoint<
   declare prisma?: PrismaClient;
 
   protected async getModel(): Promise<PrismaModelOperations<ModelObject<M['model']>>> {
-    return getPrismaModel<ModelObject<M['model']>>(
-      getPrismaClient(this),
-      this._meta.model.tableName,
-    );
+    return getPrismaModel<ModelObject<M['model']>>(getPrismaClient(this), this._meta.model);
   }
 
   override async list(filters: ListFilters): Promise<PaginatedResult<ModelObject<M['model']>>> {
@@ -237,10 +231,7 @@ export abstract class PrismaImportEndpoint<
   declare prisma?: PrismaClient;
 
   protected async getModel(): Promise<PrismaModelOperations<ModelObject<M['model']>>> {
-    return getPrismaModel<ModelObject<M['model']>>(
-      getPrismaClient(this),
-      this._meta.model.tableName,
-    );
+    return getPrismaModel<ModelObject<M['model']>>(getPrismaClient(this), this._meta.model);
   }
 
   /**
@@ -302,10 +293,7 @@ export abstract class PrismaUpsertEndpoint<
   protected useTransaction = false;
 
   protected async getModel(): Promise<PrismaModelOperations<ModelObject<M['model']>>> {
-    return getPrismaModel<ModelObject<M['model']>>(
-      getPrismaClient(this),
-      this._meta.model.tableName,
-    );
+    return getPrismaModel<ModelObject<M['model']>>(getPrismaClient(this), this._meta.model);
   }
 
   /**
@@ -416,10 +404,7 @@ export abstract class PrismaVersionHistoryEndpoint<
   declare prisma?: PrismaClient;
 
   protected async getModel(): Promise<PrismaModelOperations<ModelObject<M['model']>>> {
-    return getPrismaModel<ModelObject<M['model']>>(
-      getPrismaClient(this),
-      this._meta.model.tableName,
-    );
+    return getPrismaModel<ModelObject<M['model']>>(getPrismaClient(this), this._meta.model);
   }
 
   protected override async recordExists(lookupValue: string): Promise<boolean> {
@@ -462,10 +447,7 @@ export abstract class PrismaVersionRollbackEndpoint<
   declare prisma?: PrismaClient;
 
   protected async getModel(): Promise<PrismaModelOperations<ModelObject<M['model']>>> {
-    return getPrismaModel<ModelObject<M['model']>>(
-      getPrismaClient(this),
-      this._meta.model.tableName,
-    );
+    return getPrismaModel<ModelObject<M['model']>>(getPrismaClient(this), this._meta.model);
   }
 
   override async rollback(
@@ -517,10 +499,7 @@ export abstract class PrismaAggregateEndpoint<
   protected useNativeAggregation = true;
 
   protected async getModel(): Promise<PrismaModelOperations<ModelObject<M['model']>>> {
-    return getPrismaModel<ModelObject<M['model']>>(
-      getPrismaClient(this),
-      this._meta.model.tableName,
-    );
+    return getPrismaModel<ModelObject<M['model']>>(getPrismaClient(this), this._meta.model);
   }
 
   /**
@@ -895,10 +874,7 @@ export abstract class PrismaCloneEndpoint<
   declare prisma?: PrismaClient;
 
   protected async getModel(): Promise<PrismaModelOperations<ModelObject<M['model']>>> {
-    return getPrismaModel<ModelObject<M['model']>>(
-      getPrismaClient(this),
-      this._meta.model.tableName,
-    );
+    return getPrismaModel<ModelObject<M['model']>>(getPrismaClient(this), this._meta.model);
   }
 
   /** Generates the primary-key value for the cloned row. Defaults to UUIDv4. */

--- a/packages/prisma/src/batch.ts
+++ b/packages/prisma/src/batch.ts
@@ -12,10 +12,10 @@ import {
   type PrismaClient,
   type PrismaModelOperations,
   findByUpsertKeys,
-  getModelName,
   getPrismaModel,
   getPrismaModelByName,
   getPrismaTransaction,
+  resolvePrismaDelegateName,
 } from './helpers';
 
 /**
@@ -32,10 +32,7 @@ export abstract class PrismaRestoreEndpoint<
   protected useTransaction = false;
 
   protected async getModel(): Promise<PrismaModelOperations<ModelObject<M['model']>>> {
-    return getPrismaModel<ModelObject<M['model']>>(
-      getPrismaClient(this),
-      this._meta.model.tableName,
-    );
+    return getPrismaModel<ModelObject<M['model']>>(getPrismaClient(this), this._meta.model);
   }
 
   override async restore(
@@ -81,10 +78,7 @@ export abstract class PrismaBatchCreateEndpoint<
   declare prisma?: PrismaClient;
 
   protected async getModel(): Promise<PrismaModelOperations<ModelObject<M['model']>>> {
-    return getPrismaModel<ModelObject<M['model']>>(
-      getPrismaClient(this),
-      this._meta.model.tableName,
-    );
+    return getPrismaModel<ModelObject<M['model']>>(getPrismaClient(this), this._meta.model);
   }
 
   override async batchCreate(
@@ -102,7 +96,7 @@ export abstract class PrismaBatchCreateEndpoint<
     await getPrismaTransaction(getPrismaClient(this))(async (tx) => {
       const txModel = getPrismaModelByName<ModelObject<M['model']>>(
         tx,
-        await getModelName(this._meta.model.tableName),
+        await resolvePrismaDelegateName(this._meta.model),
       );
       if (!txModel) {
         throw new Error(
@@ -132,10 +126,7 @@ export abstract class PrismaBatchUpdateEndpoint<
   declare prisma?: PrismaClient;
 
   protected async getModel(): Promise<PrismaModelOperations<ModelObject<M['model']>>> {
-    return getPrismaModel<ModelObject<M['model']>>(
-      getPrismaClient(this),
-      this._meta.model.tableName,
-    );
+    return getPrismaModel<ModelObject<M['model']>>(getPrismaClient(this), this._meta.model);
   }
 
   override async batchUpdate(
@@ -204,10 +195,7 @@ export abstract class PrismaBatchDeleteEndpoint<
   declare prisma?: PrismaClient;
 
   protected async getModel(): Promise<PrismaModelOperations<ModelObject<M['model']>>> {
-    return getPrismaModel<ModelObject<M['model']>>(
-      getPrismaClient(this),
-      this._meta.model.tableName,
-    );
+    return getPrismaModel<ModelObject<M['model']>>(getPrismaClient(this), this._meta.model);
   }
 
   override async batchDelete(
@@ -285,10 +273,7 @@ export abstract class PrismaBatchRestoreEndpoint<
   declare prisma?: PrismaClient;
 
   protected async getModel(): Promise<PrismaModelOperations<ModelObject<M['model']>>> {
-    return getPrismaModel<ModelObject<M['model']>>(
-      getPrismaClient(this),
-      this._meta.model.tableName,
-    );
+    return getPrismaModel<ModelObject<M['model']>>(getPrismaClient(this), this._meta.model);
   }
 
   override async batchRestore(
@@ -353,10 +338,7 @@ export abstract class PrismaBatchUpsertEndpoint<
   protected useTransaction = true;
 
   protected async getModel(): Promise<PrismaModelOperations<ModelObject<M['model']>>> {
-    return getPrismaModel<ModelObject<M['model']>>(
-      getPrismaClient(this),
-      this._meta.model.tableName,
-    );
+    return getPrismaModel<ModelObject<M['model']>>(getPrismaClient(this), this._meta.model);
   }
 
   /**
@@ -432,7 +414,7 @@ export abstract class PrismaBatchUpsertEndpoint<
     const executeUpserts = async (prismaClient: PrismaClient) => {
       const model = getPrismaModelByName<ModelObject<M['model']>>(
         prismaClient,
-        await getModelName(this._meta.model.tableName),
+        await resolvePrismaDelegateName(this._meta.model),
       );
       if (!model) {
         throw new Error(`Model '${this._meta.model.tableName}' not found in Prisma client`);

--- a/packages/prisma/src/connection.ts
+++ b/packages/prisma/src/connection.ts
@@ -14,7 +14,7 @@
  * implementation and stay in sync (mirrors drizzle's `getDrizzleDb`).
  */
 
-import { CONTEXT_KEYS } from 'hono-crud/internal';
+import { CONTEXT_KEYS, ConfigurationException } from 'hono-crud/internal';
 import type { PrismaClient } from './helpers';
 
 interface PrismaEndpointShape {
@@ -35,7 +35,8 @@ export function getPrismaClient(self: unknown): PrismaClient {
   if (s.prisma) return s.prisma;
   const contextClient = s.context?.get?.(CONTEXT_KEYS.prismaClient as never);
   if (contextClient) return contextClient as PrismaClient;
-  throw new Error(
+  // Request-time misconfiguration — surface as 500 CONFIGURATION_ERROR.
+  throw new ConfigurationException(
     'Prisma client not configured. Either:\n' +
       '1. Set prisma property: prisma = prismaClient;\n' +
       '2. Use middleware: c.set(CONTEXT_KEYS.prismaClient, prismaClient);\n' +

--- a/packages/prisma/src/crud.ts
+++ b/packages/prisma/src/crud.ts
@@ -30,10 +30,7 @@ export abstract class PrismaCreateEndpoint<
   protected useTransaction = false;
 
   protected async getModel(): Promise<PrismaModelOperations<ModelObject<M['model']>>> {
-    return getPrismaModel<ModelObject<M['model']>>(
-      getPrismaClient(this),
-      this._meta.model.tableName,
-    );
+    return getPrismaModel<ModelObject<M['model']>>(getPrismaClient(this), this._meta.model);
   }
 
   /**
@@ -78,10 +75,7 @@ export abstract class PrismaReadEndpoint<
   declare prisma?: PrismaClient;
 
   protected async getModel(): Promise<PrismaModelOperations<ModelObject<M['model']>>> {
-    return getPrismaModel<ModelObject<M['model']>>(
-      getPrismaClient(this),
-      this._meta.model.tableName,
-    );
+    return getPrismaModel<ModelObject<M['model']>>(getPrismaClient(this), this._meta.model);
   }
 
   override async read(
@@ -131,10 +125,7 @@ export abstract class PrismaUpdateEndpoint<
   protected useTransaction = false;
 
   protected async getModel(): Promise<PrismaModelOperations<ModelObject<M['model']>>> {
-    return getPrismaModel<ModelObject<M['model']>>(
-      getPrismaClient(this),
-      this._meta.model.tableName,
-    );
+    return getPrismaModel<ModelObject<M['model']>>(getPrismaClient(this), this._meta.model);
   }
 
   /**
@@ -217,10 +208,7 @@ export abstract class PrismaDeleteEndpoint<
   protected useTransaction = false;
 
   protected async getModel(): Promise<PrismaModelOperations<ModelObject<M['model']>>> {
-    return getPrismaModel<ModelObject<M['model']>>(
-      getPrismaClient(this),
-      this._meta.model.tableName,
-    );
+    return getPrismaModel<ModelObject<M['model']>>(getPrismaClient(this), this._meta.model);
   }
 
   /**
@@ -324,10 +312,7 @@ export abstract class PrismaListEndpoint<
   protected override supportsCursorPagination = true;
 
   protected async getModel(): Promise<PrismaModelOperations<ModelObject<M['model']>>> {
-    return getPrismaModel<ModelObject<M['model']>>(
-      getPrismaClient(this),
-      this._meta.model.tableName,
-    );
+    return getPrismaModel<ModelObject<M['model']>>(getPrismaClient(this), this._meta.model);
   }
 
   override async list(filters: ListFilters): Promise<PaginatedResult<ModelObject<M['model']>>> {

--- a/packages/prisma/src/helpers.ts
+++ b/packages/prisma/src/helpers.ts
@@ -15,12 +15,13 @@ import type {
   RelationLoaderAdapter,
 } from 'hono-crud/internal';
 import {
+  ConfigurationException,
   assertNever,
   batchLoadRelations,
   decodeCursor,
   loadRelationsForItem,
 } from 'hono-crud/internal';
-import { inlineSingular, levenshteinDistance } from './pluralize';
+import { inlineSingular, levenshteinDistance } from './pluralize-util';
 
 /**
  * Structural shape of a Prisma model delegate, generic over the row type `Row`
@@ -92,7 +93,9 @@ export function getPrismaTransaction(
   prisma: PrismaClient,
 ): NonNullable<PrismaClient['$transaction']> {
   if (typeof prisma.$transaction !== 'function') {
-    throw new Error('Prisma client does not support $transaction');
+    // Request-time misconfiguration (capability check on the wired client) —
+    // surface as 500 CONFIGURATION_ERROR, not generic INTERNAL.
+    throw new ConfigurationException('Prisma client does not support $transaction');
   }
   return prisma.$transaction.bind(prisma);
 }
@@ -225,65 +228,13 @@ function cacheModelName(key: string, value: string): void {
 }
 
 /**
- * Custom model name mappings for irregular cases.
- * Users can register mappings via `registerPrismaModelMapping()`.
- */
-const customModelMappings = new Map<string, string>();
-
-/**
- * Registers a custom table name to Prisma model name mapping.
- * Use this for irregular cases where automatic conversion fails.
- *
- * @param tableName - The table name used in your model meta
- * @param modelName - The Prisma model name (camelCase, singular)
- *
- * @example
- * ```ts
- * // Register custom mapping for irregular plural
- * registerPrismaModelMapping('people', 'person');
- * registerPrismaModelMapping('user_addresses', 'userAddress');
- * ```
- */
-export function registerPrismaModelMapping(tableName: string, modelName: string): void {
-  customModelMappings.set(tableName.toLowerCase(), modelName);
-  // Also clear cache entry if it exists
-  modelNameCache.delete(tableName);
-}
-
-/**
- * Registers multiple custom table name to Prisma model name mappings.
- *
- * @param mappings - Object with table names as keys and model names as values
- *
- * @example
- * ```ts
- * registerPrismaModelMappings({
- *   'people': 'person',
- *   'user_addresses': 'userAddress',
- *   'order_items': 'orderItem',
- * });
- * ```
- */
-export function registerPrismaModelMappings(mappings: Record<string, string>): void {
-  for (const [tableName, modelName] of Object.entries(mappings)) {
-    registerPrismaModelMapping(tableName, modelName);
-  }
-}
-
-/**
- * Clears all custom model name mappings and cache.
- * Useful for testing or reconfiguration.
- */
-export function clearPrismaModelMappings(): void {
-  customModelMappings.clear();
-  modelNameCache.clear();
-}
-
-/**
  * Gets the model name for Prisma from the table name.
  * Prisma uses singular camelCase model names (e.g., 'users' -> 'user').
  *
- * Uses caching for performance and supports custom mappings for irregular cases.
+ * Pure derivation (camelCase + singularize) with a bounded memo cache. For
+ * irregular names, set an explicit delegate name instead:
+ * `defineModel({ tableName: 'people', table: 'person', ... })` (resolved by
+ * {@link resolvePrismaDelegateName}) or `RelationConfig.table` for relations.
  *
  * @param tableName - The table name (e.g., 'users', 'user_profiles', 'order-items')
  * @returns The Prisma model name (e.g., 'user', 'userProfile', 'orderItem')
@@ -294,12 +245,6 @@ export async function getModelName(tableName: string): Promise<string> {
     return cached;
   }
 
-  const custom = customModelMappings.get(tableName.toLowerCase());
-  if (custom) {
-    cacheModelName(tableName, custom);
-    return custom;
-  }
-
   // snake_case / kebab-case → camelCase, then plural → singular
   let name = tableName
     .replace(/[-_](.)/g, (_, char) => char.toUpperCase())
@@ -308,6 +253,34 @@ export async function getModelName(tableName: string): Promise<string> {
 
   cacheModelName(tableName, name);
   return name;
+}
+
+/**
+ * The slice of a model meta the Prisma adapter needs to resolve a client
+ * delegate: the table name plus the optional explicit `table` override
+ * (a string delegate name for Prisma — see `Model.table`).
+ */
+export interface PrismaModelRef {
+  tableName: string;
+  table?: unknown;
+}
+
+/**
+ * Resolve the Prisma delegate name for a model meta.
+ *
+ * Resolution order:
+ * 1. Explicit `Model.table` when it is a string (e.g.
+ *    `defineModel({ tableName: 'people', table: 'person', ... })`) — the
+ *    static wiring for irregular names. This replaced the old module-global
+ *    mapping registry, which was per-isolate mutable state that silently
+ *    diverged across Workers isolates.
+ * 2. The camelCase + singularize derivation from `tableName`.
+ */
+export async function resolvePrismaDelegateName(model: PrismaModelRef): Promise<string> {
+  if (typeof model.table === 'string' && model.table.length > 0) {
+    return model.table;
+  }
+  return getModelName(model.tableName);
 }
 
 /**
@@ -359,23 +332,23 @@ async function findSimilarModelNames(
  * Throws an error with helpful suggestions if the model is not found.
  *
  * @param prisma - The Prisma client
- * @param tableName - The table name from the model meta
+ * @param model - The model meta slice (`tableName` + optional explicit `table` delegate name)
  * @returns The Prisma model operations
  * @throws Error if the model is not found in the Prisma client
  */
 export async function getPrismaModel<Row = Record<string, unknown>>(
   prisma: PrismaClient,
-  tableName: string,
+  model: PrismaModelRef,
 ): Promise<PrismaModelOperations<Row>> {
-  const modelName = await getModelName(tableName);
-  const model = getPrismaModelByName<Row>(prisma, modelName);
+  const modelName = await resolvePrismaDelegateName(model);
+  const delegate = getPrismaModelByName<Row>(prisma, modelName);
 
-  if (!model) {
+  if (!delegate) {
     const availableModels = getAvailablePrismaModels(prisma);
     const suggestions = await findSimilarModelNames(modelName, availableModels);
 
     let errorMessage =
-      `Model '${modelName}' not found in Prisma client. ` + `Table name: '${tableName}'. `;
+      `Model '${modelName}' not found in Prisma client. ` + `Table name: '${model.tableName}'. `;
 
     if (suggestions.length > 0) {
       errorMessage += `Did you mean: ${suggestions.map((s) => `'${s}'`).join(', ')}? `;
@@ -385,27 +358,31 @@ export async function getPrismaModel<Row = Record<string, unknown>>(
       errorMessage += `Available models: ${availableModels.join(', ')}. `;
     }
 
-    errorMessage += `You can register a custom mapping with: registerPrismaModelMapping('${tableName}', 'yourModelName')`;
+    errorMessage += `You can set an explicit delegate name on the model meta: defineModel({ tableName: '${model.tableName}', table: '<prismaDelegateName>', ... })`;
 
     throw new Error(errorMessage);
   }
 
-  return model;
+  return delegate;
 }
 
 /**
  * Builds the Prisma relation-loader adapter for the core orchestrator.
  *
- * - `resolveRelation` resolves the related model delegate by name (async because
- *   `getModelName` is async), returning `null` to skip when the model is not
- *   found in the client.
+ * - `resolveRelation` resolves the related model delegate. An explicit string
+ *   `RelationConfig.table` wins (irregular names); otherwise the delegate name
+ *   derives from `config.model` (async because `getModelName` is async).
+ *   Returns `null` to skip when the model is not found in the client.
  * - `fetchRelated` issues the one-line `findMany({ where: { [keyField]: { in } } })`
  *   query the batch + single-item loaders share.
  */
 function prismaRelationAdapter(prisma: PrismaClient): RelationLoaderAdapter<PrismaModelOperations> {
   return {
     resolveRelation: async (config) =>
-      getPrismaModelByName(prisma, await getModelName(config.model)) ?? null,
+      getPrismaModelByName(
+        prisma,
+        await resolvePrismaDelegateName({ tableName: config.model, table: config.table }),
+      ) ?? null,
     fetchRelated: (model, keyField, values) =>
       model.findMany({ where: { [keyField]: { in: values } } }),
   };

--- a/packages/prisma/src/index.ts
+++ b/packages/prisma/src/index.ts
@@ -1,8 +1,3 @@
-export {
-  registerPrismaModelMapping,
-  registerPrismaModelMappings,
-  clearPrismaModelMappings,
-} from './helpers';
 export { getPrismaClient } from './connection';
 export { createPrismaCrud, type PrismaCrudClasses } from './factory';
 export * from './crud';

--- a/packages/prisma/src/pluralize.ts
+++ b/packages/prisma/src/pluralize.ts
@@ -1,5 +1,0 @@
-/**
- * @deprecated This module has moved to `src/utils/pluralize.ts` since it is
- * not Prisma-specific. Existing imports continue to work via this re-export shim.
- */
-export { inlineSingular, levenshteinDistance } from './pluralize-util';

--- a/packages/rate-limit/README.md
+++ b/packages/rate-limit/README.md
@@ -11,14 +11,17 @@ npm install @hono-crud/rate-limit hono-crud hono
 ## Usage
 
 ```ts
+import { createStorageMiddleware } from 'hono-crud/storage';
 import {
   createRateLimitMiddleware,
-  setRateLimitStorage,
   MemoryRateLimitStorage,
   type RateLimitEnv,
 } from '@hono-crud/rate-limit';
 
-setRateLimitStorage(new MemoryRateLimitStorage());
+// Wire storage (recommended: per-request injection, edge-safe)
+app.use('*', createStorageMiddleware({
+  rateLimitStorage: new MemoryRateLimitStorage(),
+}));
 
 app.use('/api/*', createRateLimitMiddleware<RateLimitEnv>({
   limit: 100,
@@ -26,4 +29,6 @@ app.use('/api/*', createRateLimitMiddleware<RateLimitEnv>({
 }));
 ```
 
-Exports `createRateLimitMiddleware`, `setRateLimitStorage`, `MemoryRateLimitStorage`, `RateLimitExceededException`, and the `RateLimitEnv` type.
+On a long-lived server, `setRateLimitStorage(new MemoryRateLimitStorage())` once at boot is the module-global alternative (resolution priority: explicit `config.storage` > context > global).
+
+Exports `createRateLimitMiddleware`, the storage quartet (`setRateLimitStorage` / `getRateLimitStorage` / `getRateLimitStorageRequired` / `resolveRateLimitStorage`), `MemoryRateLimitStorage` / `RedisRateLimitStorage` / `KVRateLimitStorage`, `RateLimitExceededException`, and the `RateLimitEnv` type.

--- a/packages/rate-limit/src/index.ts
+++ b/packages/rate-limit/src/index.ts
@@ -29,13 +29,15 @@ export {
   generateKey,
 } from './utils';
 
-// Middleware
+// Middleware + storage feature (set/get/getRequired/resolve quartet + registry)
 export {
   DEFAULT_RATE_LIMIT_KEY_PREFIX,
   createRateLimitMiddleware,
+  rateLimitStorageRegistry,
   setRateLimitStorage,
   getRateLimitStorage,
   getRateLimitStorageRequired,
+  resolveRateLimitStorage,
   resetRateLimit,
 } from './middleware';
 

--- a/packages/rate-limit/src/middleware.ts
+++ b/packages/rate-limit/src/middleware.ts
@@ -1,5 +1,11 @@
 import type { Context, Env, MiddlewareHandler } from 'hono';
-import { CONTEXT_KEYS, createStorageFeature, getLogger, setContextVar } from 'hono-crud/internal';
+import {
+  CONTEXT_KEYS,
+  ConfigurationException,
+  createStorageFeature,
+  getLogger,
+  setContextVar,
+} from 'hono-crud/internal';
 import { RateLimitExceededException } from './exceptions';
 import type {
   KeyExtractor,
@@ -226,6 +232,9 @@ async function checkSlidingWindow(
  */
 export const DEFAULT_RATE_LIMIT_KEY_PREFIX = 'rl';
 
+/** Once-per-isolate guard for the missing-storage warning (dedup, not request state). */
+let warnedMissingRateLimitStorage = false;
+
 /**
  * Creates rate limit middleware.
  *
@@ -300,7 +309,14 @@ export function createRateLimitMiddleware<E extends Env = Env>(
     // Get storage (priority: config > context > global)
     const storage = resolveRateLimitStorage(ctx, config.storage);
     if (!storage) {
-      getLogger().warn('Rate limit storage not configured. Skipping rate limiting.');
+      if (!warnedMissingRateLimitStorage) {
+        warnedMissingRateLimitStorage = true;
+        getLogger().warn(
+          'Rate limit storage not configured — skipping rate limiting. Inject rateLimitStorage ' +
+            'with createStorageMiddleware() (recommended) or call setRateLimitStorage(). ' +
+            'This warning is logged once per isolate.',
+        );
+      }
       return next();
     }
 
@@ -376,7 +392,8 @@ export function createRateLimitMiddleware<E extends Env = Env>(
 export async function resetRateLimit(key: string, storage?: RateLimitStorage): Promise<void> {
   const effectiveStorage = storage ?? rateLimitStorageFeature.get();
   if (!effectiveStorage) {
-    throw new Error('Rate limit storage not configured');
+    // Request-time misconfiguration — surface as 500 CONFIGURATION_ERROR.
+    throw new ConfigurationException('Rate limit storage not configured');
   }
   await effectiveStorage.reset(key);
 }

--- a/packages/rate-limit/src/storage/memory.ts
+++ b/packages/rate-limit/src/storage/memory.ts
@@ -61,6 +61,10 @@ export class MemoryRateLimitStorage implements RateLimitStorage {
     this.store = new MemoryTtlStore<RateLimitWrapper>({
       isExpired: (wrapper, now) => now > wrapper.expiresAt,
       cleanupInterval: options?.cleanupInterval ?? 60000,
+      // maxEntries: 0 (unbounded) is required for correctness, not an
+      // oversight: capacity eviction of a live window would silently reset
+      // its counter, weakening limits under key-flood pressure. Memory stays
+      // bounded via the cleanupInterval sweep of expired windows.
       maxEntries: 0,
     });
   }

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -1,6 +1,7 @@
 import {
   MemoryCacheStorage,
   RedisCacheStorage,
+  cacheStorageRegistry,
   createInvalidationPattern,
   createRelatedPatterns,
   generateCacheKey,
@@ -1004,9 +1005,11 @@ describe('withCacheInvalidation Mixin', () => {
 // ============================================================================
 
 describe('Global Cache Storage', () => {
-  it('should use default memory storage', () => {
-    const storage = getCacheStorage();
-    expect(storage).toBeInstanceOf(MemoryCacheStorage);
+  it('has NO hidden memory default — getCacheStorage() is null until configured', () => {
+    // The old lazyDefaultOnGet behavior silently installed a global
+    // MemoryCacheStorage on read; that footgun was removed.
+    cacheStorageRegistry.reset();
+    expect(getCacheStorage()).toBeNull();
   });
 
   it('should allow setting custom storage', () => {
@@ -1015,8 +1018,8 @@ describe('Global Cache Storage', () => {
 
     expect(getCacheStorage()).toBe(customStorage);
 
-    // Reset to default
-    setCacheStorage(new MemoryCacheStorage());
+    // Reset to unset so later tests see no global leakage.
+    cacheStorageRegistry.reset();
   });
 });
 

--- a/tests/idempotency-exceptions.test.ts
+++ b/tests/idempotency-exceptions.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Idempotency error-path tests (batch B5):
+ *
+ * 1. The middleware THROWS ApiExceptions (IdempotencyKeyRequiredException 400 /
+ *    IdempotencyConflictException 409) instead of hand-returning ctx.json
+ *    envelopes — so the errors flow through createErrorHandler (ErrorMappers /
+ *    ErrorHooks / responseEnvelope) like every sibling middleware.
+ * 2. A custom responseEnvelope shapes idempotency errors.
+ * 3. Missing-storage posture: `required: true` + null storage throws
+ *    ConfigurationException; default config warns once per isolate and passes
+ *    through.
+ */
+
+import {
+  IdempotencyConflictException,
+  IdempotencyKeyRequiredException,
+  MemoryIdempotencyStorage,
+  createIdempotencyMiddleware,
+} from '@hono-crud/idempotency';
+import { idempotencyStorageRegistry } from '@hono-crud/idempotency';
+import { Hono } from 'hono';
+import { ConfigurationException, createErrorHandler } from 'hono-crud';
+import type { ResponseEnvelope } from 'hono-crud';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+beforeEach(() => {
+  idempotencyStorageRegistry.reset();
+});
+afterEach(() => {
+  idempotencyStorageRegistry.reset();
+});
+
+interface ErrorBody {
+  success: false;
+  error: { code: string; message: string; details?: Record<string, unknown> };
+}
+
+describe('idempotency exceptions flow through createErrorHandler', () => {
+  function buildApp(required: boolean) {
+    const app = new Hono();
+    app.onError(createErrorHandler());
+    app.use(
+      '/*',
+      createIdempotencyMiddleware({
+        storage: new MemoryIdempotencyStorage(),
+        required,
+        lockTimeout: 60,
+      }),
+    );
+    app.post('/op', (c) => c.json({ ok: true }));
+    return app;
+  }
+
+  it('missing header with required:true → 400 IDEMPOTENCY_KEY_REQUIRED with details', async () => {
+    const app = buildApp(true);
+    const res = await app.request('/op', { method: 'POST' });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as ErrorBody;
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe('IDEMPOTENCY_KEY_REQUIRED');
+    expect(body.error.message).toContain('Idempotency-Key');
+    expect(body.error.details).toEqual({ headerName: 'Idempotency-Key', method: 'POST' });
+  });
+
+  it('in-flight key → 409 IDEMPOTENCY_CONFLICT with the client key in details', async () => {
+    const storage = new MemoryIdempotencyStorage();
+    const app = new Hono();
+    app.onError(createErrorHandler());
+    app.use('/*', createIdempotencyMiddleware({ storage }));
+    app.post('/op', (c) => c.json({ ok: true }));
+
+    // Simulate an in-flight request by holding the lock for the scoped key.
+    await storage.lock('anonymous:dup-key', 60_000);
+
+    const res = await app.request('/op', {
+      method: 'POST',
+      headers: { 'Idempotency-Key': 'dup-key' },
+    });
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as ErrorBody;
+    expect(body.error.code).toBe('IDEMPOTENCY_CONFLICT');
+    expect(body.error.details).toEqual({ idempotencyKey: 'dup-key' });
+  });
+
+  it('exceptions are instanceof targets for mappers/hooks', () => {
+    const required = new IdempotencyKeyRequiredException('Idempotency-Key', 'POST');
+    expect(required.status).toBe(400);
+    expect(required.code).toBe('IDEMPOTENCY_KEY_REQUIRED');
+    const conflict = new IdempotencyConflictException('k');
+    expect(conflict.status).toBe(409);
+    expect(conflict.code).toBe('IDEMPOTENCY_CONFLICT');
+  });
+
+  it('a bare Hono app (no onError) still emits the canonical envelope via getResponse()', async () => {
+    const app = new Hono();
+    app.use(
+      '/*',
+      createIdempotencyMiddleware({ required: true, storage: new MemoryIdempotencyStorage() }),
+    );
+    app.post('/op', (c) => c.json({ ok: true }));
+    const res = await app.request('/op', { method: 'POST' });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as ErrorBody;
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe('IDEMPOTENCY_KEY_REQUIRED');
+  });
+});
+
+describe('idempotency errors honor a custom responseEnvelope', () => {
+  it('shapes 400/409 through the configured envelope (no legacy envelope leak)', async () => {
+    const envelope: ResponseEnvelope = {
+      success: (result) => ({ data: result }),
+      error: (err) => ({ problems: [{ kind: err.code, detail: err.message }] }),
+    };
+
+    const storage = new MemoryIdempotencyStorage();
+    await storage.lock('anonymous:held', 60_000);
+
+    const app = new Hono();
+    app.onError(createErrorHandler({ responseEnvelope: envelope }));
+    app.use('/*', createIdempotencyMiddleware({ storage, required: true }));
+    app.post('/op', (c) => c.json({ ok: true }));
+
+    const missing = await app.request('/op', { method: 'POST' });
+    expect(missing.status).toBe(400);
+    expect(await missing.json()).toEqual({
+      problems: [
+        { kind: 'IDEMPOTENCY_KEY_REQUIRED', detail: expect.stringContaining('Idempotency-Key') },
+      ],
+    });
+
+    const conflict = await app.request('/op', {
+      method: 'POST',
+      headers: { 'Idempotency-Key': 'held' },
+    });
+    expect(conflict.status).toBe(409);
+    expect(await conflict.json()).toEqual({
+      problems: [{ kind: 'IDEMPOTENCY_CONFLICT', detail: expect.stringContaining('already') }],
+    });
+  });
+});
+
+describe('missing-storage posture', () => {
+  it('required:true + no storage anywhere → ConfigurationException (500 CONFIGURATION_ERROR)', async () => {
+    const app = new Hono();
+    app.onError(createErrorHandler());
+    app.use('/*', createIdempotencyMiddleware({ required: true }));
+    app.post('/op', (c) => c.json({ ok: true }));
+
+    const res = await app.request('/op', {
+      method: 'POST',
+      headers: { 'Idempotency-Key': 'k1' },
+    });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as ErrorBody;
+    expect(body.error.code).toBe('CONFIGURATION_ERROR');
+    expect(body.error.message).toContain('Idempotency storage not configured');
+  });
+
+  it('ConfigurationException is the thrown type (unit)', () => {
+    expect(new ConfigurationException('x').code).toBe('CONFIGURATION_ERROR');
+  });
+
+  it('default config + no storage → passes through (no replay protection)', async () => {
+    let calls = 0;
+    const app = new Hono();
+    app.use('/*', createIdempotencyMiddleware());
+    app.post('/op', (c) => {
+      calls++;
+      return c.json({ calls });
+    });
+
+    const headers = { 'Idempotency-Key': 'k2' };
+    await app.request('/op', { method: 'POST', headers });
+    const second = await app.request('/op', { method: 'POST', headers });
+    // No storage → both requests hit the handler (documented degraded mode).
+    expect(calls).toBe(2);
+    expect(second.headers.get('Idempotency-Replayed')).toBeNull();
+  });
+});

--- a/tests/idempotency-redis-storage.test.ts
+++ b/tests/idempotency-redis-storage.test.ts
@@ -1,0 +1,338 @@
+/**
+ * RedisIdempotencyStorage tests (batch B5).
+ *
+ * Asserts against a mock structural client:
+ * 1. Lock acquisition is ONE atomic `SET key value NX PX ttl` round-trip —
+ *    no read-then-write two-step (the reason the package ships a Redis
+ *    backend and deliberately no Cloudflare KV backend: KV lacks CAS).
+ * 2. Lock contention: a second concurrent request with the same key gets the
+ *    in-progress 409 conflict.
+ * 3. TTL expiry: entries and locks expire via `px` (Redis owns expiry).
+ * 4. Completed-response retrieval: the stored entry replays end-to-end.
+ */
+
+import {
+  type IdempotencyEntry,
+  MemoryIdempotencyStorage,
+  type RedisIdempotencyClient,
+  RedisIdempotencyStorage,
+  createIdempotencyMiddleware,
+} from '@hono-crud/idempotency';
+import { idempotencyStorageRegistry } from '@hono-crud/idempotency/middleware';
+import { Hono } from 'hono';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ============================================================================
+// Mock Redis client — in-memory map honoring `px` (TTL) and `nx`
+// (set-if-absent), with call recording so tests can assert wire semantics.
+// ============================================================================
+
+interface SetCall {
+  key: string;
+  value: string;
+  options?: { px?: number; nx?: boolean };
+}
+
+class MockRedisClient implements RedisIdempotencyClient {
+  store = new Map<string, { value: string; expiresAt: number | null }>();
+  setCalls: SetCall[] = [];
+
+  private isExpired(key: string): boolean {
+    const item = this.store.get(key);
+    if (!item) return true;
+    return item.expiresAt !== null && Date.now() >= item.expiresAt;
+  }
+
+  private liveGet(key: string): string | null {
+    if (this.isExpired(key)) {
+      this.store.delete(key);
+      return null;
+    }
+    const item = this.store.get(key);
+    return item ? item.value : null;
+  }
+
+  async get(key: string): Promise<string | null> {
+    return this.liveGet(key);
+  }
+
+  async set(key: string, value: string, options?: { px?: number; nx?: boolean }): Promise<unknown> {
+    this.setCalls.push({ key, value, options });
+    if (options?.nx && this.liveGet(key) !== null) {
+      // NX miss — Redis replies with a null bulk string.
+      return null;
+    }
+    this.store.set(key, {
+      value,
+      expiresAt: options?.px !== undefined ? Date.now() + options.px : null,
+    });
+    return 'OK';
+  }
+
+  async del(...keys: string[]): Promise<number> {
+    let deleted = 0;
+    for (const key of keys) {
+      if (this.store.delete(key)) deleted++;
+    }
+    return deleted;
+  }
+
+  async exists(...keys: string[]): Promise<number> {
+    let found = 0;
+    for (const key of keys) {
+      if (this.liveGet(key) !== null) found++;
+    }
+    return found;
+  }
+}
+
+function makeEntry(key: string): IdempotencyEntry {
+  return {
+    key,
+    statusCode: 201,
+    body: '{"ok":true}',
+    headers: { 'content-type': 'application/json' },
+    createdAt: Date.now(),
+  };
+}
+
+beforeEach(() => {
+  idempotencyStorageRegistry.reset();
+});
+afterEach(() => {
+  idempotencyStorageRegistry.reset();
+});
+
+// ============================================================================
+// Atomic SET NX PX lock semantics
+// ============================================================================
+
+describe('RedisIdempotencyStorage lock — atomic SET NX PX', () => {
+  it('acquires the lock with exactly ONE set call carrying nx + px', async () => {
+    const client = new MockRedisClient();
+    const storage = new RedisIdempotencyStorage({ client });
+
+    const acquired = await storage.lock('user:key-1', 30_000);
+    expect(acquired).toBe(true);
+
+    // ONE round-trip, with both NX and PX on the same command — no
+    // exists-then-set two-step that another isolate could race through.
+    expect(client.setCalls).toHaveLength(1);
+    expect(client.setCalls[0]).toEqual({
+      key: 'idem:lock:user:key-1',
+      value: '1',
+      options: { nx: true, px: 30_000 },
+    });
+  });
+
+  it('returns false on contention (NX miss → null reply), leaving the holder intact', async () => {
+    const client = new MockRedisClient();
+    const storage = new RedisIdempotencyStorage({ client });
+
+    expect(await storage.lock('user:key-1', 30_000)).toBe(true);
+    // Second concurrent acquire on the same key loses the race.
+    expect(await storage.lock('user:key-1', 30_000)).toBe(false);
+    // The losing attempt did not clobber the holder's lock value/TTL.
+    expect(await storage.isLocked('user:key-1')).toBe(true);
+  });
+
+  it('unlock deletes only the lock key (entry/lock keyspaces are segregated)', async () => {
+    const client = new MockRedisClient();
+    const storage = new RedisIdempotencyStorage({ client });
+
+    await storage.set('user:key-1', makeEntry('user:key-1'), 60_000);
+    await storage.lock('user:key-1', 30_000);
+    expect(client.store.has('idem:user:key-1')).toBe(true);
+    expect(client.store.has('idem:lock:user:key-1')).toBe(true);
+
+    await storage.unlock('user:key-1');
+    expect(await storage.isLocked('user:key-1')).toBe(false);
+    // The completed-response entry survives the unlock.
+    expect(await storage.get('user:key-1')).not.toBeNull();
+  });
+
+  it('honors a custom prefix for both entries and locks', async () => {
+    const client = new MockRedisClient();
+    const storage = new RedisIdempotencyStorage({ client, prefix: 'tenant-a:' });
+
+    await storage.set('k', makeEntry('k'), 60_000);
+    await storage.lock('k', 30_000);
+    expect(client.store.has('tenant-a:k')).toBe(true);
+    expect(client.store.has('tenant-a:lock:k')).toBe(true);
+  });
+});
+
+// ============================================================================
+// TTL expiry (px — Redis owns expiry)
+// ============================================================================
+
+describe('RedisIdempotencyStorage TTL expiry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('locks expire after their px TTL and become acquirable again', async () => {
+    const client = new MockRedisClient();
+    const storage = new RedisIdempotencyStorage({ client });
+
+    expect(await storage.lock('k', 1000)).toBe(true);
+    expect(await storage.isLocked('k')).toBe(true);
+
+    vi.advanceTimersByTime(1500);
+
+    expect(await storage.isLocked('k')).toBe(false);
+    // A crashed holder (lock never released) cannot deadlock the key forever.
+    expect(await storage.lock('k', 1000)).toBe(true);
+  });
+
+  it('entries expire after their px TTL', async () => {
+    const client = new MockRedisClient();
+    const storage = new RedisIdempotencyStorage({ client });
+
+    await storage.set('k', makeEntry('k'), 1000);
+    expect(await storage.get('k')).not.toBeNull();
+
+    vi.advanceTimersByTime(1500);
+    expect(await storage.get('k')).toBeNull();
+  });
+
+  it('a non-positive ttl stores the entry without expiry', async () => {
+    const client = new MockRedisClient();
+    const storage = new RedisIdempotencyStorage({ client });
+
+    await storage.set('k', makeEntry('k'), 0);
+    expect(client.setCalls[0]?.options).toBeUndefined();
+
+    vi.advanceTimersByTime(1_000_000);
+    expect(await storage.get('k')).not.toBeNull();
+  });
+});
+
+// ============================================================================
+// Entry round-trip + corrupted payloads
+// ============================================================================
+
+describe('RedisIdempotencyStorage entries', () => {
+  it('round-trips an IdempotencyEntry through JSON', async () => {
+    const client = new MockRedisClient();
+    const storage = new RedisIdempotencyStorage({ client });
+
+    const entry = makeEntry('user:key-9');
+    await storage.set('user:key-9', entry, 60_000);
+    expect(await storage.get('user:key-9')).toEqual(entry);
+  });
+
+  it('treats a corrupted payload as absent instead of failing the request', async () => {
+    const client = new MockRedisClient();
+    const storage = new RedisIdempotencyStorage({ client });
+
+    client.store.set('idem:bad', { value: 'not json {', expiresAt: null });
+    expect(await storage.get('bad')).toBeNull();
+  });
+});
+
+// ============================================================================
+// Middleware integration — contention 409 + completed-response replay
+// ============================================================================
+
+describe('RedisIdempotencyStorage through createIdempotencyMiddleware', () => {
+  function buildApp(storage: RedisIdempotencyStorage, gate?: Promise<void>) {
+    let calls = 0;
+    const app = new Hono();
+    app.use('/*', createIdempotencyMiddleware({ storage }));
+    app.post('/op', async (c) => {
+      calls++;
+      if (gate) await gate;
+      return c.json({ calls });
+    });
+    return { app, callCount: () => calls };
+  }
+
+  it('second concurrent request with the same key → 409 IDEMPOTENCY_CONFLICT', async () => {
+    const client = new MockRedisClient();
+    const storage = new RedisIdempotencyStorage({ client });
+
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const { app, callCount } = buildApp(storage, gate);
+
+    const headers = { 'Idempotency-Key': 'race-key' };
+    // First request acquires the SET NX PX lock and parks in the handler.
+    const first = app.request('/op', { method: 'POST', headers });
+    // Yield so the first request reaches the gate before the second starts.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Second request finds the lock held → in-progress conflict.
+    const second = await app.request('/op', { method: 'POST', headers });
+    expect(second.status).toBe(409);
+    const body = (await second.json()) as { error: { code: string } };
+    expect(body.error.code).toBe('IDEMPOTENCY_CONFLICT');
+
+    release();
+    expect((await first).status).toBe(200);
+    // The handler ran exactly once — the conflicting request never reached it.
+    expect(callCount()).toBe(1);
+  });
+
+  it('replays the completed response from Redis on retry (handler runs once)', async () => {
+    const client = new MockRedisClient();
+    const storage = new RedisIdempotencyStorage({ client });
+    const { app, callCount } = buildApp(storage);
+
+    const headers = { 'Idempotency-Key': 'replay-key' };
+    const first = await app.request('/op', { method: 'POST', headers });
+    const second = await app.request('/op', { method: 'POST', headers });
+
+    expect(callCount()).toBe(1);
+    expect(second.headers.get('Idempotency-Replayed')).toBe('true');
+    expect(await first.json()).toEqual({ calls: 1 });
+    expect(await second.json()).toEqual({ calls: 1 });
+    // The lock was released after completion; only the entry remains.
+    expect(await storage.isLocked('anonymous:replay-key')).toBe(false);
+  });
+
+  it('shares replay state across storage instances pointing at the same Redis (cross-isolate)', async () => {
+    // Two storage instances over ONE client simulate two Workers isolates —
+    // exactly the scenario MemoryIdempotencyStorage cannot cover.
+    const client = new MockRedisClient();
+    const isolateA = new RedisIdempotencyStorage({ client });
+    const isolateB = new RedisIdempotencyStorage({ client });
+
+    const appA = buildApp(isolateA);
+    const appB = buildApp(isolateB);
+
+    const headers = { 'Idempotency-Key': 'cross-isolate' };
+    await appA.app.request('/op', { method: 'POST', headers });
+    const replayed = await appB.app.request('/op', { method: 'POST', headers });
+
+    expect(replayed.headers.get('Idempotency-Replayed')).toBe('true');
+    expect(appB.callCount()).toBe(0);
+  });
+});
+
+// ============================================================================
+// Contract parity sanity — Redis backend honors the same contract the memory
+// backend does (both are IdempotencyStorage implementations).
+// ============================================================================
+
+describe('Redis/Memory backend parity', () => {
+  it('lock/isLocked/unlock agree across backends', async () => {
+    const backends = [
+      new RedisIdempotencyStorage({ client: new MockRedisClient() }),
+      new MemoryIdempotencyStorage(),
+    ];
+    for (const backend of backends) {
+      expect(await backend.isLocked('p')).toBe(false);
+      expect(await backend.lock('p', 30_000)).toBe(true);
+      expect(await backend.isLocked('p')).toBe(true);
+      expect(await backend.lock('p', 30_000)).toBe(false);
+      await backend.unlock('p');
+      expect(await backend.isLocked('p')).toBe(false);
+    }
+  });
+});

--- a/tests/per-endpoint-middlewares.test.ts
+++ b/tests/per-endpoint-middlewares.test.ts
@@ -49,7 +49,7 @@ describe('EndpointsConfig per-endpoint middlewares slot', () => {
           middlewares: [
             requireApproval({
               reason: 'destructive widget delete',
-              approvalStorage,
+              storage: approvalStorage,
             }),
           ],
         },
@@ -102,7 +102,7 @@ describe('EndpointsConfig per-endpoint middlewares slot', () => {
           middlewares: [
             requireApproval({
               reason: 'gated create',
-              approvalStorage,
+              storage: approvalStorage,
             }),
           ],
         },

--- a/tests/prisma.test.ts
+++ b/tests/prisma.test.ts
@@ -14,10 +14,12 @@ import {
   PrismaUpdateEndpoint,
   PrismaUpsertEndpoint,
   PrismaVersionRollbackEndpoint,
-  clearPrismaModelMappings,
-  registerPrismaModelMapping,
-  registerPrismaModelMappings,
 } from '@hono-crud/prisma';
+import {
+  type PrismaClient as PrismaClientShape,
+  getModelName,
+  resolvePrismaDelegateName,
+} from '@hono-crud/prisma/helpers';
 import { Hono } from 'hono';
 import { type AggregateOptions, defineModel, fromHono, registerCrud } from 'hono-crud';
 import {
@@ -1293,126 +1295,102 @@ describe('Prisma Adapter', () => {
 });
 
 // ============================================================================
-// Model Name Conversion Tests
+// Delegate Name Resolution Tests
 // ============================================================================
+// There is no mapping registry: module-global mutable state silently diverges
+// across Workers isolates. Irregular names are static wiring on the model
+// meta — an explicit string `Model.table` (or `RelationConfig.table` for
+// relations) names the client delegate; everything else uses the pure
+// camelCase+singularize derivation.
 
-describe('Prisma Model Name Utilities', () => {
-  beforeEach(() => {
-    clearPrismaModelMappings();
+describe('Prisma Delegate Name Resolution', () => {
+  describe('resolvePrismaDelegateName', () => {
+    it('uses an explicit string Model.table as the delegate name (override wins)', async () => {
+      await expect(
+        resolvePrismaDelegateName({ tableName: 'people', table: 'humanBeing' }),
+      ).resolves.toBe('humanBeing');
+    });
+
+    it('ignores a non-string table (e.g. a Drizzle table object) and derives from tableName', async () => {
+      await expect(
+        resolvePrismaDelegateName({ tableName: 'users', table: { columns: {} } }),
+      ).resolves.toBe('user');
+    });
+
+    it('ignores an empty-string table and derives from tableName', async () => {
+      await expect(resolvePrismaDelegateName({ tableName: 'users', table: '' })).resolves.toBe(
+        'user',
+      );
+    });
+
+    it('derives camelCase + singular when no override is set', async () => {
+      await expect(resolvePrismaDelegateName({ tableName: 'user_profiles' })).resolves.toBe(
+        'userProfile',
+      );
+    });
   });
 
-  describe('registerPrismaModelMapping', () => {
-    it('should allow registering custom mappings', () => {
-      // Create a mock Prisma client with a "person" model
-      const mockPrisma = {
-        person: {
-          create: vi.fn(),
-          findMany: vi.fn().mockResolvedValue([]),
-          count: vi.fn().mockResolvedValue(0),
-        },
+  describe('getModelName derivation', () => {
+    it('singularizes regular plurals', async () => {
+      await expect(getModelName('users')).resolves.toBe('user');
+    });
+
+    it('handles irregular plurals via the pluralize library', async () => {
+      await expect(getModelName('people')).resolves.toBe('person');
+      await expect(getModelName('children')).resolves.toBe('child');
+    });
+
+    it('converts snake_case to camelCase', async () => {
+      await expect(getModelName('user_profiles')).resolves.toBe('userProfile');
+    });
+
+    it('converts kebab-case to camelCase', async () => {
+      await expect(getModelName('order-items')).resolves.toBe('orderItem');
+    });
+  });
+
+  describe('Model.table override end-to-end', () => {
+    it('routes the endpoint to the explicitly named delegate', async () => {
+      const findMany = vi.fn().mockResolvedValue([]);
+      const count = vi.fn().mockResolvedValue(0);
+      // The derivation for 'people' is 'person', which does NOT exist on this
+      // client — only the explicit `table: 'humanBeing'` override can succeed.
+      // (`create` is present because the delegate-shape guard requires it.)
+      const mockClient = {
+        humanBeing: { create: vi.fn(), findMany, count },
       };
 
-      // Register mapping from "people" to "person"
-      registerPrismaModelMapping('people', 'person');
-
-      // Define a model using "people" table name
       const peopleModel = defineModel({
         tableName: 'people',
+        table: 'humanBeing',
         schema: z.object({
           id: z.string().uuid(),
           name: z.string(),
         }),
       });
 
-      const peopleMeta = { model: peopleModel };
-
-      // Create an endpoint using the mapping
       class PeopleList extends PrismaListEndpoint {
-        _meta = peopleMeta;
-        prisma = mockPrisma as unknown as Parameters<
-          typeof PrismaListEndpoint.prototype.list
-        >[0] extends { prisma: infer P }
-          ? P
-          : never;
+        _meta = { model: peopleModel };
+        prisma = mockClient as unknown as PrismaClientShape;
         schema = { tags: ['People'], summary: 'List people' };
       }
 
-      // The endpoint should be created without error
-      const endpoint = new PeopleList();
-      expect(endpoint).toBeDefined();
-    });
-
-    it('should be case-insensitive for table names', () => {
-      registerPrismaModelMapping('PEOPLE', 'person');
-      registerPrismaModelMapping('Users', 'user');
-
-      // Both should be stored as lowercase keys
-      const mockPrisma = {
-        person: { create: vi.fn() },
-        user: { create: vi.fn() },
-      };
-
-      // Both uppercase and lowercase should work
-      registerPrismaModelMapping('people', 'person');
-    });
-  });
-
-  describe('registerPrismaModelMappings', () => {
-    it('should allow registering multiple mappings at once', () => {
-      registerPrismaModelMappings({
-        people: 'person',
-        children: 'child',
-        user_addresses: 'userAddress',
+      const app = new Hono();
+      app.get('/people', async (c) => {
+        const endpoint = new PeopleList();
+        endpoint.setContext(c);
+        return endpoint.handle();
       });
 
-      // Mappings should be registered
-      // (We can't directly access the cache, but we can verify via endpoint creation)
-    });
-  });
-
-  describe('clearPrismaModelMappings', () => {
-    it('should clear all custom mappings', () => {
-      registerPrismaModelMapping('people', 'person');
-      clearPrismaModelMappings();
-
-      // After clearing, the default conversion should be used
-      // "people" would no longer map to "person" (would use default pluralization)
-    });
-  });
-
-  describe('Model name conversion edge cases', () => {
-    it('should handle irregular plurals via custom mappings', () => {
-      // These irregular plurals need custom mappings
-      registerPrismaModelMappings({
-        people: 'person',
-        children: 'child',
-        men: 'man',
-        women: 'woman',
-        teeth: 'tooth',
-        feet: 'foot',
-        mice: 'mouse',
-        geese: 'goose',
-      });
-
-      // After registration, these should work correctly
-    });
-
-    it('should handle snake_case table names', () => {
-      // snake_case should be converted to camelCase
-      // e.g., "user_profiles" -> "userProfile"
-      registerPrismaModelMapping('user_profiles', 'userProfile');
-    });
-
-    it('should handle kebab-case table names', () => {
-      // kebab-case should be converted to camelCase
-      // e.g., "user-profiles" -> "userProfile"
-      registerPrismaModelMapping('user-profiles', 'userProfile');
+      const response = await app.request('/people');
+      expect(response.status).toBe(200);
+      expect(findMany).toHaveBeenCalled();
     });
   });
 
   describe('Error messages', () => {
-    it('should provide helpful error when model not found', async () => {
-      const mockPrisma = {
+    it('suggests the Model.table override (not the deleted registry) when a model is missing', async () => {
+      const mockClient = {
         user: { create: vi.fn() },
         post: { create: vi.fn() },
         comment: { create: vi.fn() },
@@ -1428,11 +1406,7 @@ describe('Prisma Model Name Utilities', () => {
 
       class BadEndpoint extends PrismaListEndpoint {
         _meta = badMeta;
-        prisma = mockPrisma as unknown as Parameters<
-          typeof PrismaListEndpoint.prototype.list
-        >[0] extends { prisma: infer P }
-          ? P
-          : never;
+        prisma = mockClient as unknown as PrismaClientShape;
         schema = { tags: ['Bad'], summary: 'Bad endpoint' };
       }
 
@@ -1445,10 +1419,13 @@ describe('Prisma Model Name Utilities', () => {
           await endpoint.list({ filters: [], options: {} });
           return c.json({ success: true });
         } catch (error) {
-          // The error message should include suggestions
+          // The error message should point at the static `table` wiring on the
+          // model meta — the registry it used to suggest no longer exists.
           const message = (error as Error).message;
           expect(message).toContain('not found');
-          expect(message).toContain('registerPrismaModelMapping');
+          expect(message).toContain('defineModel');
+          expect(message).toContain("table: '<prismaDelegateName>'");
+          expect(message).not.toContain('registerPrismaModelMapping');
           return c.json({ error: message }, 500);
         }
       });

--- a/tests/require-approval.test.ts
+++ b/tests/require-approval.test.ts
@@ -16,12 +16,22 @@ import { Hono } from 'hono';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { ApiException, setContextVar } from 'hono-crud';
-import { MemoryApprovalStorage, parseIso8601Duration, requireApproval } from 'hono-crud/auth';
+import {
+  MemoryApprovalStorage,
+  approvalStorageRegistry,
+  parseIso8601Duration,
+  requireApproval,
+} from 'hono-crud/auth';
+import { createStorageMiddleware } from 'hono-crud/storage';
+import type { StorageEnv } from 'hono-crud/storage/types';
 
 describe('requireApproval middleware', () => {
   let storage: MemoryApprovalStorage;
 
   beforeEach(() => {
+    // The approval storage feature is module-global; reset so the lazy
+    // default from one test can't leak into the next.
+    approvalStorageRegistry.reset();
     storage = new MemoryApprovalStorage();
   });
 
@@ -37,7 +47,7 @@ describe('requireApproval middleware', () => {
       '/transfers',
       requireApproval({
         reason: 'Funds transfer',
-        approvalStorage: storage,
+        storage,
         expiresAfter: 'PT1H',
       }),
       async (c) => {
@@ -143,7 +153,7 @@ describe('requireApproval middleware', () => {
       '/transfers',
       requireApproval({
         reason: 'Funds transfer',
-        approvalStorage: storage,
+        storage,
       }),
       (c) => c.json({ ok: true }),
     );
@@ -175,7 +185,7 @@ describe('requireApproval middleware', () => {
       '/transfers',
       requireApproval({
         reason: 'Funds transfer',
-        approvalStorage: storage,
+        storage,
       }),
       (c) => c.json({ ok: true }),
     );
@@ -192,8 +202,51 @@ describe('requireApproval middleware', () => {
   });
 });
 
+describe('requireApproval context-injected storage (createStorageMiddleware)', () => {
+  it('zero-config endpoint resolves the injected approvalStorage end-to-end (submit → approve → resume)', async () => {
+    approvalStorageRegistry.reset();
+    const injected = new MemoryApprovalStorage();
+
+    const app = new Hono<StorageEnv>();
+    app.use('*', createStorageMiddleware({ approvalStorage: injected }));
+    app.post(
+      '/transfers',
+      // No config.storage — the guard must resolve the CONTEXT instance.
+      requireApproval({ reason: 'Injected storage flow' }),
+      async (c) => c.json({ ok: true, body: await c.req.json() }, 200),
+    );
+
+    // Phase 1 — pending action lands in the INJECTED storage.
+    const res1 = await app.request('/transfers', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ amount: 75 }),
+    });
+    expect(res1.status).toBe(202);
+    const { actionId } = (await res1.json()) as { actionId: string };
+    expect(await injected.get(actionId)).not.toBeNull();
+    // The global slot stayed untouched (no hidden default materialized).
+    const { getApprovalStorage } = await import('hono-crud/auth');
+    expect(getApprovalStorage()).toBeNull();
+
+    // Phase 1.5 — approve on the same injected instance (consumer inbox).
+    await injected.approve(actionId, 'reviewer-1');
+
+    // Phase 2 — resume runs the handler with the original input.
+    const res2 = await app.request('/transfers', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ _resume_: actionId }),
+    });
+    expect(res2.status).toBe(200);
+    const json = (await res2.json()) as { ok: boolean; body: Record<string, unknown> };
+    expect(json.body).toEqual({ amount: 75 });
+  });
+});
+
 describe('requireApproval default storage', () => {
-  it('falls back to a process-local in-memory store when approvalStorage is omitted', async () => {
+  it('falls back to a process-local in-memory store when storage is omitted', async () => {
+    approvalStorageRegistry.reset();
     const app = new Hono();
     app.onError((err, c) => {
       if (err instanceof ApiException) return c.json(err.toJSON(), err.status);
@@ -201,7 +254,8 @@ describe('requireApproval default storage', () => {
     });
     app.post(
       '/quick',
-      // No approvalStorage — POC path. Lib uses an internal singleton.
+      // No storage anywhere — POC path. The feature's warned lazy default
+      // materializes via getApprovalStorageRequired().
       requireApproval({ reason: 'POC' }),
       (c) => c.json({ ok: true }),
     );

--- a/tests/storage-unification.test.ts
+++ b/tests/storage-unification.test.ts
@@ -28,6 +28,13 @@ import {
   getAuditStorageRequired,
   setAuditStorage,
 } from 'hono-crud/audit';
+import {
+  MemoryApprovalStorage,
+  approvalStorageRegistry,
+  getApprovalStorage,
+  getApprovalStorageRequired,
+  resolveApprovalStorage,
+} from 'hono-crud/auth';
 import { MemoryAPIKeyStorage } from 'hono-crud/auth/storage/memory';
 import {
   getAPIKeyStorage,
@@ -62,7 +69,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 // The storage features are module-global. Reset every global slot between tests
 // so cross-test leakage can't make a getX()/resolveX() assertion accidentally
 // pass against state set by a previous test. Features WITH a defaultFactory
-// (audit, versioning, cache, eventEmitter) must reset via `registry.reset()` —
+// (audit, versioning, approval, eventEmitter) must reset via `registry.reset()` —
 // it clears the `defaultInitialized` flag so the lazy default re-materializes;
 // a bare `set(null)` would leave the flag set and break the never-null getters.
 function resetGlobalStorage(): void {
@@ -73,6 +80,7 @@ function resetGlobalStorage(): void {
   auditStorageRegistry.reset();
   versioningStorageRegistry.reset();
   cacheStorageRegistry.reset();
+  approvalStorageRegistry.reset();
   eventEmitterRegistry.reset();
 }
 
@@ -146,7 +154,8 @@ describe('§4.1 context-tier now-live (cache / rate-limit / idempotency)', () =>
 //   getX()         → null when unset and no lazyDefaultOnGet
 //   getXRequired() → throws "Storage not configured for '<contextKey>'" when
 //                    unset AND no default; returns the lazy default for
-//                    audit / versioning; never-null at runtime for cache.
+//                    audit / versioning / approval. Cache has no default at
+//                    all anymore (the silent-global-install footgun was removed).
 // ============================================================================
 
 describe('§4.2 two-getter contract per feature', () => {
@@ -205,14 +214,12 @@ describe('§4.2 two-getter contract per feature', () => {
     });
   });
 
-  describe('cache: type-nullable but runtime never-null (lazyDefaultOnGet)', () => {
-    it('getCacheStorage() AND getCacheStorageRequired() both return the default at runtime', () => {
-      const viaGet = getCacheStorage();
-      const viaRequired = getCacheStorageRequired();
-      expect(viaGet).toBeInstanceOf(MemoryCacheStorage);
-      expect(viaRequired).toBeInstanceOf(MemoryCacheStorage);
-      // Same lazily-created instance.
-      expect(viaGet).toBe(viaRequired);
+  describe('cache: honest-null (lazyDefaultOnGet retired — no hidden memory default)', () => {
+    it('getCacheStorage() returns null and getCacheStorageRequired() throws when unset', () => {
+      expect(getCacheStorage()).toBeNull();
+      expect(() => getCacheStorageRequired()).toThrow(
+        `Storage not configured for '${CONTEXT_KEYS.cacheStorage}'`,
+      );
     });
 
     it('getCacheStorage() returns the explicit instance once set', () => {
@@ -220,6 +227,15 @@ describe('§4.2 two-getter contract per feature', () => {
       setCacheStorage(explicit);
       expect(getCacheStorage()).toBe(explicit);
       expect(getCacheStorageRequired()).toBe(explicit);
+    });
+  });
+
+  describe('approval: getX() honest-null, getXRequired() lazy (warned) default', () => {
+    it('getApprovalStorage() is null when unset but getApprovalStorageRequired() materializes a default', () => {
+      expect(getApprovalStorage()).toBeNull();
+      const required = getApprovalStorageRequired();
+      expect(required).toBeInstanceOf(MemoryApprovalStorage);
+      expect(getApprovalStorage()).toBe(required);
     });
   });
 
@@ -233,7 +249,7 @@ describe('§4.2 two-getter contract per feature', () => {
 
 // ============================================================================
 // §4.5 — createCrudMiddleware is deleted; createStorageMiddleware is the single
-// injection factory and the STORAGE_SLOTS lookup map writes EXACTLY the eight
+// injection factory and the STORAGE_SLOTS lookup map writes EXACTLY the nine
 // slots, each readable via getStorage(ctx, key).
 // ============================================================================
 
@@ -249,11 +265,12 @@ describe('§4.5 deleted createCrudMiddleware / unified createStorageMiddleware',
     expect(typeof storageMod.createStorageMiddleware).toBe('function');
   });
 
-  it('createStorageMiddleware injects all eight slots, readable via getStorage()', async () => {
+  it('createStorageMiddleware injects all nine slots, readable via getStorage()', async () => {
     const loggingStorage = new MemoryLoggingStorage();
     const auditStorage = new MemoryAuditLogStorage();
     const versioningStorage = new MemoryVersioningStorage();
     const apiKeyStorage = new MemoryAPIKeyStorage();
+    const approvalStorage = new MemoryApprovalStorage();
     const cacheStorage = new MemoryCacheStorage();
     const rateLimitStorage = new MemoryRateLimitStorage();
     const idempotencyStorage = new MemoryIdempotencyStorage();
@@ -267,6 +284,7 @@ describe('§4.5 deleted createCrudMiddleware / unified createStorageMiddleware',
         auditStorage,
         versioningStorage,
         apiKeyStorage,
+        approvalStorage,
         cacheStorage,
         rateLimitStorage,
         idempotencyStorage,
@@ -275,11 +293,12 @@ describe('§4.5 deleted createCrudMiddleware / unified createStorageMiddleware',
     );
 
     app.get('/test', (ctx) => {
-      // Read each of the eight slots back through the typed accessor.
+      // Read each of the nine slots back through the typed accessor.
       expect(getStorage(ctx, 'loggingStorage')).toBe(loggingStorage);
       expect(getStorage(ctx, 'auditStorage')).toBe(auditStorage);
       expect(getStorage(ctx, 'versioningStorage')).toBe(versioningStorage);
       expect(getStorage(ctx, 'apiKeyStorage')).toBe(apiKeyStorage);
+      expect(getStorage(ctx, 'approvalStorage')).toBe(approvalStorage);
       expect(getStorage(ctx, 'cacheStorage')).toBe(cacheStorage);
       expect(getStorage(ctx, 'rateLimitStorage')).toBe(rateLimitStorage);
       expect(getStorage(ctx, 'idempotencyStorage')).toBe(idempotencyStorage);
@@ -291,7 +310,7 @@ describe('§4.5 deleted createCrudMiddleware / unified createStorageMiddleware',
     expect(res.status).toBe(200);
   });
 
-  it('writes EXACTLY the eight known slots and nothing else', async () => {
+  it('writes EXACTLY the nine known slots and nothing else', async () => {
     const app = new Hono<StorageEnv>();
     app.use(
       '/*',
@@ -309,6 +328,7 @@ describe('§4.5 deleted createCrudMiddleware / unified createStorageMiddleware',
         'auditStorage',
         'versioningStorage',
         'apiKeyStorage',
+        'approvalStorage',
         'cacheStorage',
         'rateLimitStorage',
         'idempotencyStorage',
@@ -320,6 +340,20 @@ describe('§4.5 deleted createCrudMiddleware / unified createStorageMiddleware',
 
     await app.request('/test');
     expect(writtenKeys).toEqual(['cacheStorage']);
+  });
+
+  it('resolveApprovalStorage(ctx) returns the injected instance over a different global', async () => {
+    const contextStorage = new MemoryApprovalStorage();
+
+    const app = new Hono<StorageEnv>();
+    app.use('/*', createStorageMiddleware({ approvalStorage: contextStorage }));
+    app.get('/test', (ctx) => {
+      expect(resolveApprovalStorage(ctx)).toBe(contextStorage);
+      return ctx.text('ok');
+    });
+
+    const res = await app.request('/test');
+    expect(res.status).toBe(200);
   });
 });
 


### PR DESCRIPTION
## Summary

Batch 5 of the 2026-06-12 audit roadmap (B1 #64, B2 #65, B3 #67+#68, B4 #69). Findings 4, 20, 22, 24, 25, 27, 29, 30, 38–40, 49, 51.

- **Redis idempotency backend** — own structural client interface, lock acquisition as one atomic `SET NX PX`. **No KV backend, deliberately**: KV lacks compare-and-swap; documented as a confirmed-intentional asymmetry (README points Workers users at Upstash/Durable Objects). 13 new tests incl. lock contention and TTL expiry.
- **Missing-storage posture unified** — cache/idempotency warn once per isolate instead of silently no-oping (docs claimed a memory default that never existed); `required: true` + no storage → `ConfigurationException`.
- **Idempotency error envelopes → ApiExceptions** — `IdempotencyKeyRequiredException` (400) / `IdempotencyConflictException` (409); they now flow through ErrorMappers/ErrorHooks/responseEnvelope like every sibling middleware. Lock-safety verified: no throw path leaks a held lock (acquire precedes try/finally; PX self-expiry covers unlock failure).
- **Approval storage joins the unified injection system** — quartet + `CONTEXT_KEYS.approvalStorage` + StorageEnv/STORAGE_SLOTS, config field renamed to `storage`, in-handler resolution, exported on `/auth`. (The sweep caught a test silently passing the old field name — now a real assertion.)
- **`ConfigurationException` sweep** per the error-split doctrine (request-time misconfig throws it; setup-time factory validation stays plain `Error`; multi-tenant's deliberate fail-fast excluded).
- **Prisma module-global model-mapping registry deleted** (edge rules ban module-global mutable state; breaking for `registerPrismaModelMapping*` users): delegate names resolve from `Model.table` / `RelationConfig.table` with derivation fallback; `pluralize.ts` shim gone.
- **Docs flip**: every storage feature now leads with `createStorageMiddleware`; cache README's dead import + missing `handle()` override fixed; quartet exports uniform across all 9 storage features.

## Verification

`pnpm -r build` / `-r typecheck` / `typecheck:examples` / lint 0 errors / `test:unit` 1192 / `test:workers` 42 / `example:local` / conformance tsc — green. Postgres leg: conformance + examples, 135 passed / 4 capability skips. Grep gates clean.