### PR TITLE
feat(mcp): all CRUD verbs via core's route table; auth/tenant headers forwarded

### DIFF
--- a/.changeset/mcp-depth.md
+++ b/.changeset/mcp-depth.md
@@ -1,0 +1,12 @@
+---
+"@hono-crud/mcp": patch
+---
+
+MCP integration depth batch:
+
+- **Full operation surface**: `OperationName` widens from 5 hand-picked verbs to every `CrudEndpointName` except `import`, and the default exposure is now every operation present in the resource's endpoints map (matching the long-standing doc comment) — `search`, `aggregate`, `export`, `upsert`, `clone`, `bulkPatch`, the batch verbs, and the version sub-resources all become tools automatically. `ResourceOptions.operations` remains the narrowing allow-list. `import` is excluded by design: its schema declares no request body (manual multi-content-type validation), so an auto-generated tool would advertise an input schema lacking the items payload.
+- **Generic dispatch driven by core's `CRUD_ROUTES`**: the hand-written `METHOD`/`REQUEST_BUILDERS` maps are replaced by one dispatcher that takes the HTTP method and URL template from core's canonical route table, substitutes every `:param` segment from the tool input (unlocking `versionRead`'s `/:id/versions/:version`), and splits the remaining input schema-driven — declared query keys to the query string, the rest as the JSON body when the endpoint declares one (covers `bulkPatch`'s query+body mix and `batchDelete`'s DELETE-with-body), everything as query otherwise.
+- **Configurable header forwarding**: new `CrudMcpConfig.forwardHeaders` (case-insensitive allow-list) controls which inbound `/mcp` headers reach the re-dispatched CRUD request. The default — exported as `DEFAULT_FORWARD_HEADERS` — widens from `authorization`/`cookie` to also cover core's own `x-api-key` (API-key auth) and `x-tenant-id` (header multi-tenancy), which previously broke silently through MCP.
+- **Structured output**: where an endpoint's 2xx response is a JSON-object schema (sole content type, JSON-Schema-representable), the tool now advertises a derived MCP `outputSchema` and returns the parsed 2xx response as `structuredContent` alongside the text content.
+- **Annotation/description defaults for every operation**: read-only hints for search/aggregate/export/version reads, explicit `destructiveHint: false` on non-destructive mutations (the MCP spec defaults it to `true`), `destructiveHint: true` for delete/batchDelete, and `idempotentHint: true` where honest (update/upsert/restore).
+- **Docs fix**: README and JSDoc no longer reference the nonexistent `@hono-crud/core/auth` package and `jwtAuth()` helper — the real spelling is `createJWTMiddleware` from `hono-crud/auth`.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -2,7 +2,9 @@
 
 The `@hono-crud/mcp` package turns the CRUD resources you already register into [Model Context Protocol](https://modelcontextprotocol.io) tools, so an AI agent (Claude, Cursor, any MCP client) can call your API.
 
-It introspects each registered resource and exposes its operations — `list`, `read`, `create`, `update`, `delete` — as MCP tools over the HTTP streaming transport. **Tool calls are re-dispatched through the same Hono app**, so they run the exact same pipeline as your REST API: auth, Zod validation, hooks, audit, soft-delete, serialization, and pagination all apply. There is no second code path to keep in sync.
+It introspects each registered resource and exposes every operation present in its endpoints map — all `registerCrud` verbs, from `list`/`read`/`create`/`update`/`delete` through `search`, `aggregate`, `export`, `upsert`, `clone`, `bulkPatch`, the batch operations, and the version sub-resources — as MCP tools over the HTTP streaming transport. **Tool calls are re-dispatched through the same Hono app**, so they run the exact same pipeline as your REST API: auth, Zod validation, hooks, audit, soft-delete, serialization, and pagination all apply. There is no second code path to keep in sync.
+
+The single excluded verb is `import`: its schema intentionally declares no request body (validation is manual, to support JSON, CSV, and multipart payloads), so an auto-generated tool would advertise an input schema lacking the items payload. It is skipped even when present in the endpoints map — register a hand-written tool if you need imports over MCP.
 
 Install: `npm install @hono-crud/mcp @modelcontextprotocol/sdk`.
 
@@ -49,15 +51,33 @@ mcp.resource('/users', userEndpoints);
 app.all('/mcp', mcp.handler());
 ```
 
-This registers five tools — `users_list`, `users_read`, `users_create`, `users_update`, `users_delete` — each with an input schema derived from the endpoint's own Zod schema (path params, query filters, and request body).
+This registers one tool per operation in the endpoints map — here `users_list`, `users_read`, `users_create`, `users_update`, `users_delete` — each with an input schema derived from the endpoint's own Zod schema (path params, query filters, and request body). Registering extended verbs (`search`, `batchCreate`, `versionHistory`, …) yields matching tools the same way.
 
 ---
 
 ## How tool calls run
 
-When a client calls a tool, the package rebuilds the matching HTTP request (method, path, query, body) and **re-dispatches it into your Hono app** via `app.request(...)`. The call flows through the real route — the same middleware, auth, validation, hooks, and serialization your REST clients hit. The tool result is the route's JSON response.
+When a client calls a tool, the package rebuilds the matching HTTP request and **re-dispatches it into your Hono app** via `app.request(...)`. The call flows through the real route — the same middleware, auth, validation, hooks, and serialization your REST clients hit. The tool result is the route's JSON response.
 
-Incoming request headers on the MCP call are forwarded on re-dispatch, so a bearer token (or any header your CRUD pipeline reads) reaches the underlying route. This is what lets a single token gate both `/mcp` and the CRUD routes (see [Authentication](#authentication)).
+The HTTP method and URL template come from core's canonical route table (`CRUD_ROUTES`), so MCP dispatch can never drift from what `registerCrud` mounts. Every `:param` segment of the route template is substituted from the tool input (e.g. `versionRead` fills both `:id` and `:version` in `/:id/versions/:version`); for endpoints that declare a JSON body, the declared query keys go to the query string and the remaining input becomes the body (this covers `bulkPatch`'s query + body mix and `batchDelete`'s DELETE-with-body), while body-less endpoints send every remaining input field as query parameters.
+
+### Header forwarding
+
+An allow-list of inbound `/mcp` headers (matched case-insensitively) is forwarded on re-dispatch, so the call runs as the caller. The default — `authorization`, `cookie`, `x-api-key`, `x-tenant-id` — covers bearer/session auth plus core's own API-key middleware (`createAPIKeyMiddleware`) and header-based multi-tenancy (`multiTenant`). This is what lets a single token gate both `/mcp` and the CRUD routes (see [Authentication](#authentication)). Override the list when your pipeline reads custom headers (a function form for full control may come later):
+
+```typescript
+import { DEFAULT_FORWARD_HEADERS, createCrudMcp } from '@hono-crud/mcp';
+
+createCrudMcp(app, {
+  name: 'my-api',
+  version: '1.0.0',
+  forwardHeaders: [...DEFAULT_FORWARD_HEADERS, 'x-org-id'], // replaces the default list
+});
+```
+
+### Structured output
+
+Where an endpoint's 2xx response is a plain JSON object schema (`application/json` as its sole declared content type, representable in JSON Schema), the tool advertises a matching MCP `outputSchema` and every successful call returns the parsed response as `structuredContent` alongside the pretty-printed text content. Endpoints with a non-JSON response alternative (e.g. `export`'s CSV) skip the output schema rather than declare a contract their non-JSON responses would break.
 
 Errors are returned as MCP tool errors (`isError: true`) with the message text; the failure is also logged through core's logger.
 
@@ -105,15 +125,31 @@ createCrudMcp(app, {
 });
 ```
 
-Default descriptions per operation (a resource-level `description` is prepended when set):
+Default descriptions per operation (a resource-level `description` is prepended when set; _{one}_ is the naively singularized resource label):
 
 | Operation | Default description |
 |---|---|
 | `list` | List _{resource}_ with optional filters, search, sorting and pagination. |
-| `read` | Get a single _{resource}_ by id. |
-| `create` | Create a new _{resource}_. |
-| `update` | Update an existing _{resource}_ by id. |
-| `delete` | Delete a _{resource}_ by id. |
+| `read` | Get a single _{one}_ by id. |
+| `create` | Create a new _{one}_. |
+| `update` | Update an existing _{one}_ by id. |
+| `delete` | Delete a _{one}_ by id. |
+| `restore` | Restore a soft-deleted _{one}_ by id. |
+| `batchCreate` | Create multiple _{resource}_ in one call. |
+| `batchUpdate` | Update multiple _{resource}_ by id in one call. |
+| `batchDelete` | Delete multiple _{resource}_ by id in one call. |
+| `batchRestore` | Restore multiple soft-deleted _{resource}_ by id in one call. |
+| `batchUpsert` | Insert or update multiple _{resource}_ in one call. |
+| `search` | Full-text search _{resource}_ with relevance scoring. |
+| `aggregate` | Compute aggregations (count, sum, avg, min, max, group by) over _{resource}_. |
+| `export` | Export _{resource}_ in bulk. |
+| `upsert` | Insert a new _{one}_ or update the existing one. |
+| `clone` | Duplicate an existing _{one}_ by id. |
+| `bulkPatch` | Apply one partial update to all _{resource}_ matching a filter. |
+| `versionHistory` | List the version history of a _{one}_ by id. |
+| `versionRead` | Get a specific version of a _{one}_. |
+| `versionCompare` | Compare two versions of a _{one}_. |
+| `versionRollback` | Roll a _{one}_ back to a previous version. |
 
 Duplicate tool names across resources throw a `ConfigurationException` at registration — disambiguate with a resource `name`, a custom `naming` strategy, or per-tool `name` overrides.
 
@@ -121,15 +157,14 @@ Duplicate tool names across resources throw a `ConfigurationException` at regist
 
 ## Annotations
 
-MCP tool annotations are advisory hints an LLM client may surface to the user (e.g. confirm before a destructive action). Sensible per-operation defaults are applied and can be overridden per tool:
+MCP tool annotations are advisory hints an LLM client may surface to the user (e.g. confirm before a destructive action). Sensible per-operation defaults are applied and can be overridden per tool. The MCP spec treats an absent `destructiveHint` as `true`, so non-destructive mutations set it to `false` explicitly; `idempotentHint` is set only where repeating the same call converges on the same state:
 
-| Operation | `readOnlyHint` | `destructiveHint` |
-|---|---|---|
-| `list` | `true` | — |
-| `read` | `true` | — |
-| `create` | `false` | `false` |
-| `update` | `false` | `false` |
-| `delete` | `false` | `true` |
+| Operations | `readOnlyHint` | `destructiveHint` | `idempotentHint` |
+|---|---|---|---|
+| `list`, `read`, `search`, `aggregate`, `export`, `versionHistory`, `versionRead`, `versionCompare` | `true` | — | — |
+| `create`, `clone`, `batchCreate`, `batchUpdate`, `batchRestore`, `batchUpsert`, `bulkPatch`, `versionRollback` | `false` | `false` | — |
+| `update`, `upsert`, `restore` | `false` | `false` | `true` |
+| `delete`, `batchDelete` | `false` | `true` | — |
 
 ```typescript
 mcp.resource('/users', userEndpoints, {
@@ -147,7 +182,7 @@ mcp.resource('/users', userEndpoints, {
 mcp.resource('/users', userEndpoints, {
   name: 'people',                            // resource label used in tool names
   description: 'User accounts.',             // prepended to each tool's description
-  operations: ['list', 'read', 'create'],    // allow-list (default: all present)
+  operations: ['list', 'read', 'create'],    // allow-list (default: all present, minus import)
   tools: {
     list: { name: 'find_people', description: 'Search people by name or role.' },
     create: { description: 'Create a person. Admin only.' },
@@ -156,7 +191,7 @@ mcp.resource('/users', userEndpoints, {
 });
 ```
 
-- `operations` is an allow-list applied before per-tool `enabled`.
+- `operations` is a narrowing allow-list applied before per-tool `enabled`; the default exposes every operation present in the endpoints map except `import`.
 - A `tools[op].name` overrides the naming strategy for that tool.
 - A `tools[op].enabled: false` excludes the operation even if it's present in the endpoints map.
 
@@ -267,6 +302,7 @@ mcp-session-id: <id from the initialize response>
 | `instructions` | `string` | — | Free-form guidance surfaced to the LLM. |
 | `naming` | `(ctx) => string` | `` `${resource}_${operation}` `` | Tool-name strategy. |
 | `auth` | `McpAuthOptions` | none (open) | `/mcp` authentication strategy. |
+| `forwardHeaders` | `string[]` | `['authorization', 'cookie', 'x-api-key', 'x-tenant-id']` | Headers forwarded on tool re-dispatch (case-insensitive; replaces the default list). |
 | `auto` | `boolean \| AutoOptions` | `false` | Auto-register every `registerCrud` resource. |
 
 ### `mcp.resource(path, endpoints, options?)` — `ResourceOptions`
@@ -275,7 +311,7 @@ mcp-session-id: <id from the initialize response>
 |---|---|---|---|
 | `name` | `string` | model `tag`/`tableName`, else path segment | Resource label used in tool names. |
 | `description` | `string` | — | Prepended to each generated tool description. |
-| `operations` | `OperationName[]` | all present | Allow-list of operations to expose. |
+| `operations` | `OperationName[]` | all present, minus `import` | Narrowing allow-list of operations to expose. |
 | `tools` | `Partial<Record<OperationName, ToolOptions>>` | `{}` | Per-operation overrides. |
 
 ### `ToolOptions`

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -3,10 +3,16 @@
 Auto-generate [Model Context Protocol](https://modelcontextprotocol.io) (MCP) tools from your
 [hono-crud](https://github.com/kshdotdev/hono-crud) resources.
 
-It introspects the CRUD endpoints you already register and exposes each operation
-(`list`, `read`, `create`, `update`, `delete`) as an MCP tool over HTTP streaming transport. Tool
-calls are **re-dispatched through the same Hono app**, so they run the exact same pipeline as your
-REST API — auth, Zod validation, hooks, audit, soft-delete, serialization and pagination all apply.
+It introspects the CRUD endpoints you already register and exposes every operation present in the
+endpoints map — all `registerCrud` verbs, from `list`/`read`/`create`/`update`/`delete` through
+`search`, `aggregate`, `export`, the batch operations and the version sub-resources — as MCP tools
+over HTTP streaming transport. Tool calls are **re-dispatched through the same Hono app**, so they
+run the exact same pipeline as your REST API — auth, Zod validation, hooks, audit, soft-delete,
+serialization and pagination all apply.
+
+The only excluded verb is `import`: its schema intentionally declares no request body (validation
+is manual, to support JSON, CSV and multipart payloads), so an auto-generated tool would advertise
+an input schema lacking the items payload. Register a hand-written tool if you need imports over MCP.
 
 ## Install
 
@@ -39,8 +45,22 @@ mcp.resource('/users', userEndpoints);
 app.all('/mcp', mcp.handler());
 ```
 
-This generates the tools `users_list`, `users_read`, `users_create`, `users_update`,
-`users_delete`, each with an input schema derived from the endpoint's own Zod schema.
+This generates one tool per operation in the endpoints map (`users_list`, `users_read`,
+`users_create`, `users_update`, `users_delete`, and so on for any extended verbs you register),
+each with an input schema derived from the endpoint's own Zod schema. Where the endpoint's 2xx
+response is a plain JSON object schema, the tool also advertises a matching MCP `outputSchema` and
+returns the parsed response as `structuredContent` alongside the text content.
+
+## Operations and annotations
+
+Every operation ships an MCP annotation profile an LLM client can act on:
+
+| Operations | Annotations |
+|---|---|
+| `list`, `read`, `search`, `aggregate`, `export`, `versionHistory`, `versionRead`, `versionCompare` | `readOnlyHint: true` |
+| `create`, `clone`, `batchCreate`, `batchUpdate`, `batchRestore`, `batchUpsert`, `bulkPatch`, `versionRollback` | `destructiveHint: false` |
+| `update`, `upsert`, `restore` | `destructiveHint: false`, `idempotentHint: true` |
+| `delete`, `batchDelete` | `destructiveHint: true` |
 
 ## Configuration
 
@@ -48,7 +68,7 @@ This generates the tools `users_list`, `users_read`, `users_create`, `users_upda
 mcp.resource('/users', userEndpoints, {
   name: 'people',                              // resource label used in tool names
   description: 'User accounts.',               // base description for the resource's tools
-  operations: ['list', 'read', 'create'],      // allow-list (default: all present)
+  operations: ['list', 'read', 'create'],      // allow-list (default: all present, minus import)
   tools: {
     list: { name: 'find_people', description: 'Search people by name or role.' },
     create: { description: 'Create a person. Admin only.' },
@@ -57,9 +77,28 @@ mcp.resource('/users', userEndpoints, {
 });
 ```
 
-Customize tool naming globally via `createCrudMcp(app, { naming: ({ resource, operation }) => ... })`.
-MCP annotations (`readOnlyHint`, `destructiveHint`, …) default sensibly per operation and can be
-overridden per tool.
+By default every operation present in the endpoints map (except `import`) becomes a tool;
+`operations` narrows that set. Customize tool naming globally via
+`createCrudMcp(app, { naming: ({ resource, operation }) => ... })`. MCP annotations
+(`readOnlyHint`, `destructiveHint`, …) default per the table above and can be overridden per tool.
+
+## Header forwarding
+
+On re-dispatch, an allow-list of inbound `/mcp` headers (matched case-insensitively) is forwarded
+to the CRUD routes so the call runs as the caller. The default —
+`authorization`, `cookie`, `x-api-key`, `x-tenant-id` — covers bearer/session auth plus core's own
+API-key middleware and header-based multi-tenancy. Override it when your pipeline reads custom
+headers (a function form for full control may come later):
+
+```ts
+import { DEFAULT_FORWARD_HEADERS, createCrudMcp } from '@hono-crud/mcp';
+
+createCrudMcp(app, {
+  name: 'my-api',
+  version: '1.0.0',
+  forwardHeaders: [...DEFAULT_FORWARD_HEADERS, 'x-org-id'],
+});
+```
 
 ## Authentication
 
@@ -73,10 +112,12 @@ createCrudMcp(app, {
 });
 ```
 
-**Middleware.** Gate `/mcp` with existing Hono middleware (e.g. `@hono-crud/core/auth`):
+**Middleware.** Gate `/mcp` with existing Hono middleware (e.g. from `hono-crud/auth`):
 
 ```ts
-auth: { strategy: 'middleware', middleware: jwtAuth(...) }
+import { createJWTMiddleware } from 'hono-crud/auth';
+
+auth: { strategy: 'middleware', middleware: createJWTMiddleware({ secret }) }
 ```
 
 **OAuth 2.1 (opt-in).** Bring your own metadata router + bearer middleware (e.g. from

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -7,14 +7,37 @@ export function defaultNaming(ctx: NamingContext): string {
 
 /**
  * Default MCP annotations per operation. `readOnlyHint` and `destructiveHint`
- * let an LLM client warn before a mutating/destructive call.
+ * let an LLM client warn before a mutating/destructive call. `destructiveHint`
+ * defaults to `true` in the MCP spec when absent, so non-destructive mutating
+ * operations set it to `false` explicitly. `idempotentHint` is set only where
+ * honest: repeating the same call with the same arguments converges on the
+ * same state (upsert, update, restore).
  */
 const DEFAULT_ANNOTATIONS: Record<OperationName, ToolAnnotations> = {
+  // Read-only operations
   list: { readOnlyHint: true },
   read: { readOnlyHint: true },
+  search: { readOnlyHint: true },
+  aggregate: { readOnlyHint: true },
+  export: { readOnlyHint: true },
+  versionHistory: { readOnlyHint: true },
+  versionRead: { readOnlyHint: true },
+  versionCompare: { readOnlyHint: true },
+  // Non-destructive mutations
   create: { readOnlyHint: false, destructiveHint: false },
-  update: { readOnlyHint: false, destructiveHint: false },
+  update: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+  upsert: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+  restore: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+  clone: { readOnlyHint: false, destructiveHint: false },
+  batchCreate: { readOnlyHint: false, destructiveHint: false },
+  batchUpdate: { readOnlyHint: false, destructiveHint: false },
+  batchRestore: { readOnlyHint: false, destructiveHint: false },
+  batchUpsert: { readOnlyHint: false, destructiveHint: false },
+  bulkPatch: { readOnlyHint: false, destructiveHint: false },
+  versionRollback: { readOnlyHint: false, destructiveHint: false },
+  // Destructive mutations
   delete: { readOnlyHint: false, destructiveHint: true },
+  batchDelete: { readOnlyHint: false, destructiveHint: true },
 };
 
 export function resolveAnnotations(
@@ -36,6 +59,23 @@ const DESCRIPTIONS: Record<OperationName, (resource: string, one: string) => str
   create: (_resource, one) => `Create a new ${one}.`,
   update: (_resource, one) => `Update an existing ${one} by id.`,
   delete: (_resource, one) => `Delete a ${one} by id.`,
+  restore: (_resource, one) => `Restore a soft-deleted ${one} by id.`,
+  batchCreate: (resource) => `Create multiple ${resource} in one call.`,
+  batchUpdate: (resource) => `Update multiple ${resource} by id in one call.`,
+  batchDelete: (resource) => `Delete multiple ${resource} by id in one call.`,
+  batchRestore: (resource) => `Restore multiple soft-deleted ${resource} by id in one call.`,
+  batchUpsert: (resource) => `Insert or update multiple ${resource} in one call.`,
+  search: (resource) => `Full-text search ${resource} with relevance scoring.`,
+  aggregate: (resource) =>
+    `Compute aggregations (count, sum, avg, min, max, group by) over ${resource}.`,
+  export: (resource) => `Export ${resource} in bulk.`,
+  upsert: (_resource, one) => `Insert a new ${one} or update the existing one.`,
+  clone: (_resource, one) => `Duplicate an existing ${one} by id.`,
+  bulkPatch: (resource) => `Apply one partial update to all ${resource} matching a filter.`,
+  versionHistory: (_resource, one) => `List the version history of a ${one} by id.`,
+  versionRead: (_resource, one) => `Get a specific version of a ${one}.`,
+  versionCompare: (_resource, one) => `Compare two versions of a ${one}.`,
+  versionRollback: (_resource, one) => `Roll a ${one} back to a previous version.`,
 };
 
 export function defaultDescription(

--- a/packages/mcp/src/dispatch.ts
+++ b/packages/mcp/src/dispatch.ts
@@ -1,24 +1,44 @@
 import type { Hono } from 'hono';
+import { CRUD_ROUTES } from 'hono-crud/internal';
 import type { RequestPlan } from './schema';
 import type { OperationName } from './types';
 
-// NOTE: METHOD and REQUEST_BUILDERS below mirror the HTTP method + URL shape that
-// `registerCrud` assigns to each operation (see CRUD_ROUTES in
-// packages/core/src/core/crud-routes.ts — create=POST /, list=GET /,
-// read=GET /:id, update=PATCH /:id, delete=DELETE /:id).
-// CRUD_ROUTES is the source of truth; keep these two in lockstep with it.
-const METHOD: Record<OperationName, 'GET' | 'POST' | 'PATCH' | 'DELETE'> = {
-  list: 'GET',
-  read: 'GET',
-  create: 'POST',
-  update: 'PATCH',
-  delete: 'DELETE',
-};
+type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+interface RouteSpec {
+  method: HttpMethod;
+  /** Sub-path template relative to the resource root, e.g. `/:id/versions/:version`. */
+  subPath: string;
+}
+
+/**
+ * Per-operation HTTP method + sub-path template, derived from core's canonical
+ * `CRUD_ROUTES` table so MCP dispatch can never drift from what `registerCrud`
+ * mounts. `import` is excluded from the MCP surface (see {@link OperationName}).
+ */
+const ROUTES = Object.fromEntries(
+  CRUD_ROUTES.filter(([name]) => name !== 'import').map(([name, method, subPath]) => [
+    name,
+    { method: method.toUpperCase() as HttpMethod, subPath },
+  ]),
+) as Record<OperationName, RouteSpec>;
 
 type Args = Record<string, unknown>;
 
 /** Inbound request headers, as exposed by the MCP SDK's `extra.requestInfo.headers`. */
 export type ForwardHeaders = Record<string, string | string[] | undefined>;
+
+/**
+ * Headers forwarded on re-dispatch when `CrudMcpConfig.forwardHeaders` is
+ * unset: bearer/session auth plus core's own API-key (`createAPIKeyMiddleware`)
+ * and multi-tenant (`multiTenant`) default headers.
+ */
+export const DEFAULT_FORWARD_HEADERS: readonly string[] = [
+  'authorization',
+  'cookie',
+  'x-api-key',
+  'x-tenant-id',
+];
 
 export interface DispatchTarget {
   operation: OperationName;
@@ -55,39 +75,48 @@ function omit(obj: Args, keys: string[]): Args {
   return out;
 }
 
-/** Forward identity-bearing headers so the re-dispatched request runs as the caller. */
-function forwardHeaders(headers: ForwardHeaders | undefined, target: Headers): void {
+/**
+ * Forward allow-listed identity-bearing headers (matched case-insensitively)
+ * so the re-dispatched request runs as the caller.
+ */
+function applyForwardHeaders(
+  headers: ForwardHeaders | undefined,
+  allowed: readonly string[],
+  target: Headers,
+): void {
   if (!headers) return;
-  for (const name of ['authorization', 'cookie']) {
-    const value = headers[name];
+  const allow = new Set(allowed.map((name) => name.toLowerCase()));
+  for (const [name, value] of Object.entries(headers)) {
+    if (!allow.has(name.toLowerCase())) continue;
     if (typeof value === 'string') target.set(name, value);
     else if (Array.isArray(value) && value.length > 0) target.set(name, value.join(', '));
   }
 }
 
-type RequestSpec = { url: string; body?: string };
-
-/** Per-operation request builders: map a tool input + plan to a URL and optional JSON body. */
-const REQUEST_BUILDERS: Record<
-  OperationName,
-  (basePath: string, id: string, args: Args, plan: RequestPlan) => RequestSpec
-> = {
-  list: (basePath, _id, args) => ({ url: basePath + encodeQuery(args) }),
-  read: (basePath, id, args, plan) => ({
-    url: `${basePath}/${id}${encodeQuery(pick(args, plan.queryKeys))}`,
-  }),
-  create: (basePath, _id, args) => ({ url: basePath, body: JSON.stringify(args) }),
-  update: (basePath, id, args, plan) => ({
-    url: `${basePath}/${id}`,
-    body: JSON.stringify(omit(args, plan.paramKeys)),
-  }),
-  delete: (basePath, id) => ({ url: `${basePath}/${id}` }),
-};
+/**
+ * Substitute every `:param` segment of a sub-path template from the tool args
+ * (e.g. `/:id/versions/:version` + `{ id, version }`). Returns the resolved
+ * path and the arg names consumed by the substitution.
+ */
+function buildPath(subPath: string, args: Args): { path: string; consumed: string[] } {
+  const consumed: string[] = [];
+  const path = subPath.replace(/:([^/]+)/g, (_match, name: string) => {
+    consumed.push(name);
+    return encodeURIComponent(String(args[name] ?? ''));
+  });
+  return { path, consumed };
+}
 
 /**
  * Translate a tool call into an internal HTTP request and re-dispatch it through
  * the mounted Hono app, so the full CRUD pipeline (auth, validation, hooks,
  * serialization, pagination) runs exactly as it does for REST.
+ *
+ * The split of the flat tool input is schema-driven: path params are
+ * substituted into the route template; when the endpoint declares a JSON body,
+ * the declared query keys go to the query string and the rest becomes the
+ * body (covers `bulkPatch`'s query+body mix and `batchDelete`'s DELETE-with-body);
+ * body-less endpoints send every remaining arg as query.
  */
 export async function dispatch(
   // biome-ignore lint/suspicious/noExplicitAny: re-dispatch targets any Hono app.
@@ -95,36 +124,61 @@ export async function dispatch(
   target: DispatchTarget,
   args: Args,
   headers?: ForwardHeaders,
+  allowHeaders: readonly string[] = DEFAULT_FORWARD_HEADERS,
 ): Promise<Response> {
   const { operation, basePath, plan } = target;
+  const { method, subPath } = ROUTES[operation];
+
   const requestHeaders = new Headers();
-  forwardHeaders(headers, requestHeaders);
+  applyForwardHeaders(headers, allowHeaders, requestHeaders);
 
-  const idKey = plan.paramKeys[0];
-  const id = idKey ? encodeURIComponent(String(args[idKey])) : '';
+  const { path, consumed } = buildPath(subPath, args);
+  const remaining = omit(args, [...consumed, ...plan.paramKeys]);
 
-  const { url, body } = REQUEST_BUILDERS[operation](basePath, id, args, plan);
+  let body: string | undefined;
+  let query: Args;
+  if (plan.hasBody) {
+    query = pick(remaining, plan.queryKeys);
+    body = JSON.stringify(omit(remaining, plan.queryKeys));
+  } else {
+    query = remaining;
+  }
+
   if (body !== undefined) requestHeaders.set('content-type', 'application/json');
-
-  return app.request(url, { method: METHOD[operation], headers: requestHeaders, body });
+  return app.request(basePath + path + encodeQuery(query), {
+    method,
+    headers: requestHeaders,
+    body,
+  });
 }
 
 export interface ToolCallResult {
   content: { type: 'text'; text: string }[];
+  /** Parsed JSON body of a 2xx response, per the MCP structured-output contract. */
+  structuredContent?: Record<string, unknown>;
   isError: boolean;
 }
 
-/** Format an HTTP Response into an MCP tool result (pretty JSON when possible). */
+/**
+ * Format an HTTP Response into an MCP tool result: pretty JSON when possible,
+ * plus `structuredContent` for 2xx JSON object responses.
+ */
 export async function toToolResult(res: Response): Promise<ToolCallResult> {
   const text = await res.text();
   let formatted = text;
+  let structured: Record<string, unknown> | undefined;
   try {
-    formatted = JSON.stringify(JSON.parse(text), null, 2);
+    const parsed: unknown = JSON.parse(text);
+    formatted = JSON.stringify(parsed, null, 2);
+    if (res.status < 400 && parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      structured = parsed as Record<string, unknown>;
+    }
   } catch {
     // Non-JSON body — return verbatim.
   }
   return {
     content: [{ type: 'text', text: formatted }],
+    ...(structured !== undefined && { structuredContent: structured }),
     isError: res.status >= 400,
   };
 }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,3 +1,4 @@
+export { DEFAULT_FORWARD_HEADERS } from './dispatch';
 export { CrudMcpServer, createCrudMcp } from './server';
 export type {
   AutoOptions,

--- a/packages/mcp/src/schema.ts
+++ b/packages/mcp/src/schema.ts
@@ -1,5 +1,5 @@
 import type { OpenAPIRouteSchema } from 'hono-crud/internal';
-import type { ZodType } from 'zod';
+import { type ZodType, z } from 'zod';
 
 /** A flat MCP input schema: a map of field name to Zod schema. */
 export type RawShape = Record<string, ZodType>;
@@ -26,12 +26,15 @@ function bodySchema(route: OpenAPIRouteSchema): unknown {
 export interface RequestPlan {
   paramKeys: string[];
   queryKeys: string[];
+  /** Whether the endpoint declares an `application/json` request body. */
+  hasBody: boolean;
 }
 
 export function extractRequestPlan(route: OpenAPIRouteSchema): RequestPlan {
   return {
     paramKeys: Object.keys(shapeOf(route.request?.params)),
     queryKeys: Object.keys(shapeOf(route.request?.query)),
+    hasBody: bodySchema(route) !== undefined,
   };
 }
 
@@ -46,4 +49,48 @@ export function buildInputShape(route: OpenAPIRouteSchema): RawShape {
     ...shapeOf(route.request?.query),
     ...shapeOf(bodySchema(route)),
   };
+}
+
+type ResponseContent = { content?: Record<string, { schema?: unknown }> } | undefined;
+
+/**
+ * Whether the MCP SDK can serialize this shape for `tools/list`. The SDK
+ * converts schemas with Zod's `toJSONSchema`, which throws on unrepresentable
+ * types (e.g. `z.date()` in version-history responses) — probe the same
+ * conversion here so such tools simply skip the output schema instead of
+ * breaking the whole listing.
+ */
+function isJsonSchemaRepresentable(shape: RawShape): boolean {
+  try {
+    z.toJSONSchema(z.object(shape));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Derive the MCP `outputSchema` shape from the endpoint's first 2xx response,
+ * where derivable. A tool that declares an output schema MUST return
+ * `structuredContent` on every success (the SDK enforces this), so the shape
+ * is only derived when `application/json` is the response's sole declared
+ * content type — an endpoint with a non-JSON alternative (e.g. export's CSV)
+ * gets no output schema rather than a contract its CSV responses would break.
+ * Shapes the SDK cannot represent in JSON Schema are skipped as well.
+ */
+export function buildOutputShape(route: OpenAPIRouteSchema): RawShape | undefined {
+  const responses = route.responses as Record<string, ResponseContent> | undefined;
+  if (!responses) return undefined;
+  for (const [status, response] of Object.entries(responses)) {
+    const code = Number(status);
+    if (Number.isNaN(code) || code < 200 || code >= 300) continue;
+    const content = response?.content;
+    if (!content) return undefined;
+    const contentTypes = Object.keys(content);
+    if (contentTypes.length !== 1 || contentTypes[0] !== 'application/json') return undefined;
+    const shape = shapeOf(content['application/json']?.schema);
+    if (Object.keys(shape).length === 0) return undefined;
+    return isJsonSchemaRepresentable(shape) ? shape : undefined;
+  }
+  return undefined;
 }

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -3,13 +3,14 @@ import type { Hono } from 'hono';
 import { ConfigurationException, getLogger } from 'hono-crud/internal';
 import { defaultDescription, defaultNaming, resolveAnnotations } from './config';
 import {
+  DEFAULT_FORWARD_HEADERS,
   type DispatchTarget,
   type ForwardHeaders,
   type ToolCallResult,
   dispatch,
   toToolResult,
 } from './dispatch';
-import { buildInputShape, extractRequestPlan } from './schema';
+import { buildInputShape, buildOutputShape, extractRequestPlan } from './schema';
 import {
   type CrudMcpConfig,
   type EndpointInstance,
@@ -32,6 +33,7 @@ type RegisterTool = (
     title?: string;
     description?: string;
     inputSchema?: Record<string, unknown>;
+    outputSchema?: Record<string, unknown>;
     annotations?: ToolAnnotations;
   },
   cb: (args: Record<string, unknown>, extra: ToolExtra) => Promise<ToolCallResult>,
@@ -74,6 +76,7 @@ export function registerResourceTools(
   const normalizedPath = basePath.endsWith('/') ? basePath.slice(0, -1) : basePath;
   const naming = options.naming ?? defaultNaming;
   const requested = resourceOptions.operations ?? OPERATIONS;
+  const forwardHeaders = options.forwardHeaders ?? DEFAULT_FORWARD_HEADERS;
   const register = server.registerTool.bind(server) as unknown as RegisterTool;
   const registered: string[] = [];
 
@@ -107,16 +110,18 @@ export function registerResourceTools(
       plan: extractRequestPlan(route),
     };
 
+    const outputSchema = buildOutputShape(route);
     register(
       toolName,
       {
         description,
         inputSchema: buildInputShape(route),
+        ...(outputSchema !== undefined && { outputSchema }),
         annotations: resolveAnnotations(operation, toolOptions.annotations),
       },
       async (args, extra) => {
         try {
-          const res = await dispatch(app, target, args ?? {}, headersFrom(extra));
+          const res = await dispatch(app, target, args ?? {}, headersFrom(extra), forwardHeaders);
           return await toToolResult(res);
         } catch (err) {
           getLogger().error('@hono-crud/mcp tool dispatch failed', {

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -1,24 +1,33 @@
 import type { Context, Hono, MiddlewareHandler } from 'hono';
-import type {
-  CrudEndpointName,
-  CrudEndpoints,
-  MetaInput,
-  OpenAPIRoute,
-  OpenAPIRouteSchema,
-  PathPattern,
+import {
+  CRUD_ROUTES,
+  type CrudEndpointName,
+  type CrudEndpoints,
+  type MetaInput,
+  type OpenAPIRoute,
+  type OpenAPIRouteSchema,
+  type PathPattern,
 } from 'hono-crud/internal';
 
 /**
- * The five standard CRUD operations exposed as MCP tools. Pinned to core's
- * `CrudEndpointName` via `Extract` so a rename in core surfaces as a compile
- * error here rather than silent drift.
+ * Every CRUD operation exposable as an MCP tool — all `registerCrud` slots
+ * except `import`. Derived from core's `CrudEndpointName` via `Exclude` so a
+ * change in core surfaces as a compile error here rather than silent drift.
+ *
+ * `import` is excluded by design: its schema intentionally declares no request
+ * body (validation is manual, to support JSON, CSV and multipart payloads), so
+ * an auto-generated tool would advertise an input schema lacking the items
+ * payload. Register a hand-written tool if you need imports over MCP.
  */
-export type OperationName = Extract<
-  CrudEndpointName,
-  'list' | 'read' | 'create' | 'update' | 'delete'
->;
+export type OperationName = Exclude<CrudEndpointName, 'import'>;
 
-export const OPERATIONS: readonly OperationName[] = ['list', 'read', 'create', 'update', 'delete'];
+/**
+ * All exposable operations, in core's canonical route-table order
+ * (`CRUD_ROUTES`), minus the excluded `import` slot.
+ */
+export const OPERATIONS: readonly OperationName[] = CRUD_ROUTES.map(([name]) => name).filter(
+  (name): name is OperationName => name !== 'import',
+);
 
 export type Awaitable<T> = T | Promise<T>;
 
@@ -53,7 +62,10 @@ export interface ResourceOptions {
   name?: string;
   /** Base description applied to every tool generated for this resource. */
   description?: string;
-  /** Allow-list of operations to expose. Defaults to every operation present in the endpoints map. */
+  /**
+   * Allow-list of operations to expose. Defaults to every operation present in
+   * the endpoints map except `import` (see {@link OperationName}).
+   */
   operations?: OperationName[];
   /** Per-operation overrides. */
   tools?: Partial<Record<OperationName, ToolOptions>>;
@@ -94,7 +106,10 @@ export interface VerifierAuthOptions {
   verifyToken: (token: string, c: Context) => Awaitable<Identity | null>;
 }
 
-/** Gate `/mcp` with existing Hono middleware (e.g. `@hono-crud/core/auth`). */
+/**
+ * Gate `/mcp` with existing Hono middleware (e.g. `createJWTMiddleware({ secret })`
+ * from `hono-crud/auth`).
+ */
 export interface MiddlewareAuthOptions {
   strategy: 'middleware';
   middleware: MiddlewareHandler | MiddlewareHandler[];
@@ -130,6 +145,16 @@ export interface CrudMcpConfig {
   naming?: (ctx: NamingContext) => string;
   /** Authentication for the `/mcp` endpoint. Defaults to none (open). */
   auth?: McpAuthOptions;
+  /**
+   * Allow-list of inbound `/mcp` request headers forwarded on tool re-dispatch,
+   * matched case-insensitively. Replaces the default list
+   * (`DEFAULT_FORWARD_HEADERS`: `authorization`, `cookie`, `x-api-key`,
+   * `x-tenant-id`) — spread the defaults in when extending. Configure this when
+   * your CRUD pipeline reads identity/tenant data from custom headers (e.g. a
+   * renamed `APIKeyConfig.headerName`). A function form (full control over the
+   * synthesized headers) may be added later.
+   */
+  forwardHeaders?: string[];
   /**
    * Auto-register every resource registered via `registerCrud(...)`. `true` uses
    * defaults; pass {@link AutoOptions} to scope/override. Manual `mcp.resource()`

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -2,6 +2,7 @@ import { createCrudMcp } from '@hono-crud/mcp';
 import { dispatch } from '@hono-crud/mcp/dispatch';
 import { registerResourceTools } from '@hono-crud/mcp/tools';
 import {
+  MemoryAdapters,
   MemoryCreateEndpoint,
   MemoryDeleteEndpoint,
   MemoryListEndpoint,
@@ -13,7 +14,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { Hono } from 'hono';
-import { type MetaInput, type Model, fromHono, registerCrud } from 'hono-crud';
+import { type MetaInput, type Model, defineEndpoints, fromHono, registerCrud } from 'hono-crud';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
@@ -153,6 +154,38 @@ async function toolNamesOverHttp(app: { request: (...args: any[]) => Promise<Res
   return (tools as Array<{ name: string }>).map((t) => t.name).sort();
 }
 
+// Initialize an MCP session over /mcp and call one tool, returning the JSON-RPC result.
+async function callToolOverHttp(
+  // biome-ignore lint/suspicious/noExplicitAny: app of any Env/Schema is fine to request.
+  app: { request: (...args: any[]) => Promise<Response> },
+  name: string,
+  args: Record<string, unknown>,
+  extraHeaders: Record<string, string> = {},
+) {
+  const headers = (sid?: string): Record<string, string> => ({
+    'content-type': 'application/json',
+    accept: 'application/json, text/event-stream',
+    ...(sid ? { 'mcp-session-id': sid } : {}),
+    ...extraHeaders,
+  });
+  const post = (body: unknown, sid?: string) =>
+    app.request('/mcp', { method: 'POST', headers: headers(sid), body: JSON.stringify(body) });
+
+  const initRes = await post({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'c', version: '1' } },
+  });
+  const sid = initRes.headers.get('mcp-session-id') ?? undefined;
+  await post({ jsonrpc: '2.0', method: 'notifications/initialized' }, sid);
+  const callRes = await post(
+    { jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name, arguments: args } },
+    sid,
+  );
+  return messages(await callRes.text()).find((m) => m.id === 3)?.result;
+}
+
 // Drive a freshly-built McpServer via an in-memory client.
 async function connectClient(server: McpServer): Promise<Client> {
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
@@ -285,7 +318,11 @@ describe('authentication', () => {
 
     const res = await dispatch(
       app,
-      { operation: 'list', basePath: '/users', plan: { paramKeys: [], queryKeys: [] } },
+      {
+        operation: 'list',
+        basePath: '/users',
+        plan: { paramKeys: [], queryKeys: [], hasBody: false },
+      },
       {},
       { authorization: 'Bearer secret-token' },
     );
@@ -444,5 +481,320 @@ describe('auto-discovery', () => {
     expect(names).toContain('people_list'); // manual override wins for /users
     expect(names.some((n) => n.startsWith('users_'))).toBe(false);
     expect(names.filter((n) => n.startsWith('posts_'))).toHaveLength(5); // posts still auto
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Widened operation surface (all CRUD verbs driven by CRUD_ROUTES)
+// ---------------------------------------------------------------------------
+
+// Every registerCrud slot, built through the config API (import included on
+// purpose: MCP must skip it even when the endpoints map registers it).
+const fullEndpoints = defineEndpoints(
+  {
+    meta: userMeta,
+    create: {},
+    list: {},
+    read: {},
+    update: {},
+    delete: {},
+    restore: {},
+    batchCreate: {},
+    batchUpdate: {},
+    batchDelete: {},
+    batchRestore: {},
+    batchUpsert: {},
+    search: {},
+    aggregate: {},
+    export: {},
+    import: {},
+    upsert: {},
+    clone: {},
+    bulkPatch: {},
+    versionHistory: {},
+    versionRead: {},
+    versionCompare: {},
+    versionRollback: {},
+  },
+  MemoryAdapters,
+);
+
+describe('widened operation surface', () => {
+  it('generates a tool for every registered verb except import', async () => {
+    const app = buildApp();
+    const server = new McpServer(serverInfo);
+    registerResourceTools(server, app, '/users', fullEndpoints, serverInfo);
+    const client = await connectClient(server);
+
+    const { tools } = await client.listTools();
+    const names = tools.map((t) => t.name).sort();
+    expect(names).toEqual([
+      'users_aggregate',
+      'users_batchCreate',
+      'users_batchDelete',
+      'users_batchRestore',
+      'users_batchUpdate',
+      'users_batchUpsert',
+      'users_bulkPatch',
+      'users_clone',
+      'users_create',
+      'users_delete',
+      'users_export',
+      'users_list',
+      'users_read',
+      'users_restore',
+      'users_search',
+      'users_update',
+      'users_upsert',
+      'users_versionCompare',
+      'users_versionHistory',
+      'users_versionRead',
+      'users_versionRollback',
+    ]);
+    expect(names).not.toContain('users_import');
+  });
+
+  it('applies default annotations to extended verbs (destructive batchDelete, read-only search)', async () => {
+    const app = buildApp();
+    const server = new McpServer(serverInfo);
+    registerResourceTools(server, app, '/users', fullEndpoints, serverInfo);
+    const client = await connectClient(server);
+
+    const { tools } = await client.listTools();
+    const batchDelete = tools.find((t) => t.name === 'users_batchDelete');
+    expect(batchDelete?.annotations?.destructiveHint).toBe(true);
+    expect(batchDelete?.annotations?.readOnlyHint).toBe(false);
+
+    const search = tools.find((t) => t.name === 'users_search');
+    expect(search?.annotations?.readOnlyHint).toBe(true);
+    expect(search?.annotations?.destructiveHint).toBeUndefined();
+  });
+
+  it('narrows extended verbs via the operations allow-list', async () => {
+    const app = buildApp();
+    const server = new McpServer(serverInfo);
+    registerResourceTools(server, app, '/users', fullEndpoints, serverInfo, {
+      operations: ['search', 'versionHistory'],
+    });
+    const client = await connectClient(server);
+
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name).sort()).toEqual(['users_search', 'users_versionHistory']);
+  });
+
+  it('substitutes every path param of the route template (versionRead: :id and :version)', async () => {
+    const app = new Hono();
+    let params: Record<string, string> = {};
+    app.get('/docs/:id/versions/:version', (c) => {
+      params = c.req.param();
+      return c.json({ ok: true });
+    });
+
+    const res = await dispatch(
+      app,
+      {
+        operation: 'versionRead',
+        basePath: '/docs',
+        plan: { paramKeys: ['id', 'version'], queryKeys: [], hasBody: false },
+      },
+      { id: 'doc-1', version: 3 },
+    );
+
+    expect(res.status).toBe(200);
+    expect(params).toEqual({ id: 'doc-1', version: '3' });
+  });
+
+  it('sends body args as JSON for batchDelete (DELETE with a body)', async () => {
+    const app = new Hono();
+    let received: unknown;
+    app.delete('/users/batch', async (c) => {
+      received = await c.req.json();
+      return c.json({ ok: true });
+    });
+
+    const res = await dispatch(
+      app,
+      {
+        operation: 'batchDelete',
+        basePath: '/users',
+        plan: { paramKeys: [], queryKeys: [], hasBody: true },
+      },
+      { ids: ['a', 'b'] },
+    );
+
+    expect(res.status).toBe(200);
+    expect(received).toEqual({ ids: ['a', 'b'] });
+  });
+
+  it('splits declared query keys from the body for mixed endpoints (bulkPatch dryRun)', async () => {
+    const app = new Hono();
+    let received: unknown;
+    let dryRun: string | undefined;
+    app.patch('/users/bulk', async (c) => {
+      dryRun = c.req.query('dryRun');
+      received = await c.req.json();
+      return c.json({ ok: true });
+    });
+
+    const res = await dispatch(
+      app,
+      {
+        operation: 'bulkPatch',
+        basePath: '/users',
+        plan: { paramKeys: [], queryKeys: ['dryRun'], hasBody: true },
+      },
+      { dryRun: 'true', role: 'user' },
+    );
+
+    expect(res.status).toBe(200);
+    expect(dryRun).toBe('true');
+    expect(received).toEqual({ role: 'user' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Header forwarding
+// ---------------------------------------------------------------------------
+
+describe('header forwarding', () => {
+  function captureApp() {
+    const app = new Hono();
+    let seen: Record<string, string | undefined> = {};
+    app.get('/users', (c) => {
+      seen = {
+        apiKey: c.req.header('x-api-key'),
+        tenant: c.req.header('x-tenant-id'),
+        auth: c.req.header('authorization'),
+        custom: c.req.header('x-custom'),
+      };
+      return c.json({ ok: true });
+    });
+    return { app, seen: () => seen };
+  }
+
+  const listTarget = {
+    operation: 'list',
+    basePath: '/users',
+    plan: { paramKeys: [], queryKeys: [], hasBody: false },
+  } as const;
+
+  it('forwards X-API-Key and X-Tenant-ID by default and strips other headers', async () => {
+    const { app, seen } = captureApp();
+
+    await dispatch(app, listTarget, {}, {
+      'X-API-Key': 'key-1', // matched case-insensitively
+      'x-tenant-id': 'tenant-1',
+      authorization: 'Bearer tok',
+      'x-custom': 'nope',
+    });
+
+    expect(seen()).toEqual({
+      apiKey: 'key-1',
+      tenant: 'tenant-1',
+      auth: 'Bearer tok',
+      custom: undefined,
+    });
+  });
+
+  it('narrows forwarding to an explicit allow-list', async () => {
+    const { app, seen } = captureApp();
+
+    await dispatch(
+      app,
+      listTarget,
+      {},
+      { 'x-api-key': 'key-1', authorization: 'Bearer tok' },
+      ['x-api-key'],
+    );
+
+    expect(seen()).toEqual({
+      apiKey: 'key-1',
+      tenant: undefined,
+      auth: undefined,
+      custom: undefined,
+    });
+  });
+
+  it('threads CrudMcpConfig.forwardHeaders to tool dispatch over HTTP (case-insensitive)', async () => {
+    const app = fromHono(new Hono());
+    let seen: Record<string, string | undefined> = {};
+    app.use('/users', async (c, next) => {
+      seen = { apiKey: c.req.header('x-api-key'), auth: c.req.header('authorization') };
+      await next();
+    });
+    registerCrud(app, '/users', endpoints);
+
+    const mcp = createCrudMcp(app, { ...serverInfo, forwardHeaders: ['X-API-Key'] });
+    mcp.resource('/users', endpoints);
+    app.all('/mcp', mcp.handler());
+
+    const result = await callToolOverHttp(app, 'users_list', {}, {
+      'x-api-key': 'key-1',
+      authorization: 'Bearer tok',
+    });
+
+    expect(result?.isError).toBeFalsy();
+    expect(seen.apiKey).toBe('key-1');
+    expect(seen.auth).toBeUndefined(); // not in the configured allow-list
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Structured output
+// ---------------------------------------------------------------------------
+
+describe('structured output', () => {
+  it('advertises outputSchema derived from the 2xx response and returns structuredContent', async () => {
+    const app = buildApp();
+    const server = new McpServer(serverInfo);
+    registerResourceTools(server, app, '/users', endpoints, serverInfo);
+    const client = await connectClient(server);
+
+    const { tools } = await client.listTools();
+    const read = tools.find((t) => t.name === 'users_read');
+    const readOutput = Object.keys(
+      (read?.outputSchema as { properties?: Record<string, unknown> })?.properties ?? {},
+    );
+    expect(readOutput).toEqual(expect.arrayContaining(['success', 'result']));
+
+    const created = await client.callTool({
+      name: 'users_create',
+      arguments: { email: 'sc@example.com', name: 'Structured', role: 'user' },
+    });
+    const structured = created.structuredContent as {
+      success: boolean;
+      result: { id: string; email: string };
+    };
+    expect(structured.success).toBe(true);
+    expect(structured.result.email).toBe('sc@example.com');
+    // Text content still mirrors the same payload.
+    expect(JSON.parse(textOf(created as { content: Array<{ type: string; text?: string }> }))).toEqual(structured);
+  });
+
+  it('does not advertise an outputSchema when a 2xx declares a non-JSON alternative (export CSV)', async () => {
+    const app = buildApp();
+    const server = new McpServer(serverInfo);
+    registerResourceTools(server, app, '/users', fullEndpoints, serverInfo);
+    const client = await connectClient(server);
+
+    const { tools } = await client.listTools();
+    const exportTool = tools.find((t) => t.name === 'users_export');
+    expect(exportTool).toBeDefined();
+    expect(exportTool?.outputSchema).toBeUndefined();
+  });
+
+  it('omits structuredContent on error results', async () => {
+    const app = buildApp();
+    const server = new McpServer(serverInfo);
+    registerResourceTools(server, app, '/users', endpoints, serverInfo);
+    const client = await connectClient(server);
+    await client.listTools();
+
+    const missing = await client.callTool({
+      name: 'users_read',
+      arguments: { id: '00000000-0000-4000-8000-000000000000' },
+    });
+    expect(missing.isError).toBe(true);
+    expect(missing.structuredContent).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Batch 7 of the 2026-06-12 audit roadmap. Findings 57, 69–72. `@hono-crud/mcp` only — core untouched (B3's `CRUD_ROUTES` extraction was built for exactly this).

- **All verbs**: `OperationName = Exclude<CrudEndpointName, 'import'>`; dispatch derives from `CRUD_ROUTES`; multi-param `:id`/`:version` substitution unlocks the version verbs; hand-written `METHOD`/`REQUEST_BUILDERS` deleted.
- **Schema-driven query/body split** (`RequestPlan.hasBody` from `getSchema()`): correctly handles `batchDelete` (DELETE + JSON `{ids}` body) and `bulkPatch` (PATCH + `dryRun` query + body) that a method-based rule would break — both pinned by tests.
- **`import` excluded at the type level** — its schema declares no JSON body, so an auto-tool would advertise a payload-less input schema.
- **Default = every registered operation** (the doc comment finally matches the code); `operations` narrows. 21 operations annotated (read-only/destructive/idempotent hints) and described.
- **Header forwarding** defaults to `authorization, cookie, x-api-key, x-tenant-id` — previously MCP silently broke core's own API-key auth and multi-tenancy; `forwardHeaders` config overrides (case-insensitive).
- **Structured output**: `structuredContent` + `outputSchema` mined from the 200 schema, with a representability probe (z.date() schemas would have broken the entire `tools/list` with MCP -32603 — discovered by test, skipped gracefully).
- README/docs rewritten for the widened surface; phantom `@hono-crud/core/auth` / `jwtAuth()` references fixed.

## Verification

Build/typecheck/examples/lint(0 errors) green; `test:unit` 1214 (12 new MCP tests, 23 total) / workers 42 / example:local green; conformance tsc pass; grep gates clean.