### PR TITLE
refactor!: enablement idiom, vocabulary, and duration-suffix unification

### DIFF
--- a/.changeset/naming-config-shapes.md
+++ b/.changeset/naming-config-shapes.md
@@ -1,0 +1,37 @@
+---
+'hono-crud': patch
+'@hono-crud/cache': patch
+'@hono-crud/rate-limit': patch
+'@hono-crud/idempotency': patch
+'@hono-crud/mcp': patch
+---
+
+Naming & config-shape unification (breaking renames, no aliases).
+
+**Model feature enablement idiom.** `Model.audit` and `Model.versioning` are now `boolean | Config` like their `softDelete`/`multiTenant` siblings; the required `enabled` field is removed from `AuditConfig` and `VersioningConfig`. Write `audit: true` / `versioning: true` (or a config object — presence enables); `getAuditConfig`/`getVersioningConfig` and the `AuditLogger`/`VersionManager`/`createAuditLogger`/`createVersionManager` config params accept the union. `NormalizedAuditConfig`/`NormalizedVersioningConfig` still carry `enabled`. `fieldEncryption` stays presence-enabled (it has required members).
+
+**Path-filter and message vocabulary.** `excludePaths` is the one name for "paths this middleware bypasses": `AuthConfig.skipPaths` → `excludePaths`, `RateLimitConfig.skipPaths` → `excludePaths`, and mcp `AutoOptions.include`/`exclude` → `includePaths`/`excludePaths` (they match `registerCrud` mount paths with the same shared matcher). `AuthConfig.unauthorizedMessage` → `errorMessage`, matching rate-limit and multiTenant.
+
+**Duration unit suffixes (renames only — no field changed its unit).**
+
+| Old | New | Unit |
+| --- | --- | --- |
+| `CacheConfig.ttl` | `ttlSeconds` | seconds |
+| `IdempotencyConfig.ttl` | `ttlSeconds` | seconds |
+| `IdempotencyConfig.lockTimeout` | `lockTimeoutSeconds` | seconds |
+| `JWTConfig.clockTolerance` / `JWTClaimsValidationOptions.clockTolerance` | `clockToleranceSeconds` | seconds |
+| `SubscribeEndpointConfig.heartbeatInterval` | `heartbeatIntervalMs` | ms |
+| `SubscribeEndpointConfig.connectionTimeout` | `connectionTimeoutMs` | ms |
+| `HealthCheck.timeout` | `timeoutMs` | ms |
+| `HealthConfig.defaultTimeout` | `defaultTimeoutMs` | ms |
+| `WebhookEndpoint.timeout` | `timeoutMs` | ms |
+| `MemoryTtlStoreOptions.cleanupInterval` | `cleanupIntervalMs` | ms |
+| `MemoryLoggingStorageOptions.maxAge` / `.cleanupInterval` | `maxAgeMs` / `cleanupIntervalMs` | ms |
+| `MemoryIdempotencyStorageOptions.cleanupInterval` | `cleanupIntervalMs` | ms |
+| `MemoryRateLimitStorageOptions.cleanupInterval` | `cleanupIntervalMs` | ms |
+
+Documented exception: `RateLimitResult.retryAfter` keeps its name (mirrors the HTTP Retry-After header, seconds by RFC).
+
+**Env types.** `TenantEnv` now types its tenant variable optional (`string | undefined` until the middleware runs), matching every other `*Env`. `HonoCrudEnv` now folds in `TenantEnv & ApiVersionEnv`, making its "all core context variables" claim true.
+
+**Rate-limit extractor nullability.** `extractUserId` and `extractAPIKey` return `string | undefined` (was `string | null`); `KeyExtractor` is `(ctx) => string | undefined` — custom extractors returning `null` must return `undefined`. `extractIP` keeps its `'unknown'` fail-closed sentinel: a falsy key would skip rate limiting entirely, and limits must not fail open when no IP is derivable.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Adjudicated differences between sibling packages — never "fix" these for symme
 3. **`MemoryRateLimitStorage` has no `maxEntries` knob** (its memory/cache/idempotency
    siblings are capacity-bounded). Capacity eviction of a live window would silently reset
    its counter, weakening limits exactly under key-flood pressure; memory stays bounded via
-   the `cleanupInterval` sweep of expired windows.
+   the `cleanupIntervalMs` sweep of expired windows.
 
 ## Naming Doctrine
 
@@ -87,6 +87,12 @@ Adjudicated differences between sibling packages — never "fix" these for symme
    genuinely owns multiple routes (health).
 5. `*Config` = top-level setup bag of a middleware/factory; `*Options` = per-operation/per-call
    leaf bag (and storage-adapter constructor bags).
+6. **Model feature toggles:** `boolean | Config` when every option is defaultable (softDelete,
+   multiTenant, audit, versioning); presence-enables when the config has required members
+   (fieldEncryption, relations, computedFields, policies); never a required `enabled` field.
+7. **Duration fields:** every public duration field carries a unit suffix naming its existing
+   unit (`*Seconds` or `*Ms`); renames only, never unit conversions. Exception: `retryAfter`
+   (mirrors HTTP Retry-After header semantics, seconds by RFC).
 
 ### Config vs Options naming
 - `*Config` — the top-level bag a middleware factory, route/router factory, or feature factory

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ app.use('*', createStorageMiddleware({ cacheStorage: new MemoryCacheStorage() })
 
 class UserRead extends withCache(MemoryReadEndpoint) {
   _meta = userMeta;
-  cacheConfig = { ttl: 300, perUser: false };
+  cacheConfig = { ttlSeconds: 300, perUser: false };
 
   async handle(ctx) {
     this.setContext(ctx);

--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -269,7 +269,7 @@ const UserModel = defineModel({
   schema: UserSchema,
   primaryKeys: ['id'],
   versioning: true,
-  // Or: versioning: { maxVersions: 50, includeMetadata: true }
+  // Or: versioning: { maxVersions: 50, trackChangedBy: true }
 });
 ```
 
@@ -322,7 +322,7 @@ const UserModel = defineModel({
   schema: UserSchema,
   primaryKeys: ['id'],
   audit: true,
-  // Or: audit: { includeChanges: true, includePrevious: true }
+  // Or: audit: { trackChanges: true, excludeFields: ['password'] }
 });
 ```
 
@@ -594,7 +594,7 @@ app.use('*', createStorageMiddleware({
 // Apply to mutation endpoints
 app.use('/api/*', createIdempotencyMiddleware({
   headerName: 'Idempotency-Key',  // default
-  ttl: 86400,                      // 24 hours (default)
+  ttlSeconds: 86400,               // 24 hours (default)
 }));
 ```
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -18,7 +18,7 @@ app.use('/api/*', createJWTMiddleware({
   algorithm: 'HS256',     // default
   issuer: 'my-app',       // optional: validate iss claim
   audience: 'my-api',     // optional: validate aud claim
-  clockTolerance: 30,     // optional: seconds of clock skew tolerance
+  clockToleranceSeconds: 30, // optional: seconds of clock skew tolerance
 }));
 
 // After middleware runs, context variables are available:

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -65,7 +65,7 @@ class UserRead extends withCache(MemoryReadEndpoint) {
   schema = { tags: ['Users'], summary: 'Get user' };
 
   cacheConfig = {
-    ttl: 300,           // 5 minutes
+    ttlSeconds: 300,    // 5 minutes
     perUser: false,     // Shared cache (true = per-user cache keys)
     tags: ['users'],    // Cache tags for targeted invalidation
   };
@@ -98,21 +98,21 @@ class UserRead extends withCache(MemoryReadEndpoint) {
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `enabled` | `boolean` | `true` | Enable/disable caching |
-| `ttl` | `number` | `300` | Time to live in seconds |
+| `ttlSeconds` | `number` | `300` | Time to live in seconds |
 | `perUser` | `boolean` | `false` | Include userId in cache key |
 | `tags` | `string[]` | `[]` | Cache tags for targeted invalidation |
 | `keyFields` | `string[]` | - | Additional fields in cache key |
 | `prefix` | `string` | - | Custom key prefix |
 
-> **TTL units.** `cacheConfig.ttl` is **seconds** — the ergonomic, user-facing
+> **TTL units.** `cacheConfig.ttlSeconds` is **seconds** — the ergonomic, user-facing
 > unit. The underlying storage contract works in **milliseconds**: the mixin
-> converts once (`ttl * 1000`) before calling `CacheStorage.set(key, data, { ttlMs })`.
+> converts once (`ttlSeconds * 1000`) before calling `CacheStorage.set(key, data, { ttlMs })`.
 > If you implement a custom `CacheStorage`, its `set` receives `ttlMs`
 > (milliseconds), not seconds.
 >
 > **Cloudflare KV floor.** KV's `expirationTtl` has a 60-second minimum, so
 > `KVCacheStorage` silently floors short TTLs:
-> `expirationTtl = Math.max(60, Math.ceil(ttlMs / 1000))`. A sub-minute `ttl`
+> `expirationTtl = Math.max(60, Math.ceil(ttlMs / 1000))`. A sub-minute `ttlSeconds`
 > therefore behaves as 60s on KV. This is a documented KV-platform constraint.
 
 ### Cache Methods

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -99,8 +99,8 @@ createCrudMcp(app, {
   name: 'my-api',
   version: '1.0.0',
   auto: {
-    include: ['/users', '/posts/*'],          // globs/RegExp; default: all
-    exclude: ['/internal/*'],                  // excludes always win
+    includePaths: ['/users', '/posts/*'],     // globs/RegExp; default: all
+    excludePaths: ['/internal/*'],             // excludes always win
     operations: ['list', 'read'],              // default allow-list for every resource
     resources: {
       '/users': { operations: ['list', 'read', 'create'] }, // per-path override

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -58,7 +58,7 @@ app.use('/api/*', createRateLimitMiddleware({
   limit: 100,
   windowSeconds: 60,
   keyStrategy: 'ip',
-  skipPaths: ['/health', '/docs/*'],
+  excludePaths: ['/health', '/docs/*'],
 }));
 
 // Stricter limit for expensive operations
@@ -92,7 +92,7 @@ When rate limit is exceeded, the response is `429 Too Many Requests` with a `Ret
 | `algorithm` | `'fixed-window' \| 'sliding-window'` | `'sliding-window'` | Rate limit algorithm |
 | `keyStrategy` | `KeyStrategy \| function` | `'ip'` | How to identify clients |
 | `keyPrefix` | `string` | `'rl'` | Storage key prefix |
-| `skipPaths` | `string[]` | `[]` | Paths to skip (glob patterns) |
+| `excludePaths` | `string[]` | `[]` | Paths excluded from rate limiting (glob patterns) |
 | `includeHeaders` | `boolean` | `true` | Include rate limit headers |
 | `errorMessage` | `string` | `'Too many requests'` | Error message on 429 |
 | `storage` | `RateLimitStorage` | - | Per-middleware storage override |

--- a/examples/local-consumer/src/app.ts
+++ b/examples/local-consumer/src/app.ts
@@ -148,7 +148,6 @@ const UserModel = defineModel({
     },
   },
   audit: {
-    enabled: true,
     actions: [
       'create',
       'update',
@@ -174,11 +173,8 @@ const DocumentModel = defineModel({
   tableName: 'documents',
   schema: DocumentSchema,
   primaryKeys: ['id'],
-  versioning: {
-    enabled: true,
-    field: 'version',
-    historyTable: 'documents_history',
-  },
+  // Boolean shorthand: defaults are field 'version' + historyTable '{tableName}_history'.
+  versioning: true,
 });
 
 const userMeta = defineMeta({ model: UserModel });

--- a/examples/memory/audit-logging.ts
+++ b/examples/memory/audit-logging.ts
@@ -49,10 +49,8 @@ const UserModel = defineModel({
   tableName: 'users',
   schema: UserSchema,
   primaryKeys: ['id'],
+  // Presence enables audit logging (`audit: true` uses all defaults)
   audit: {
-    // Enable audit logging
-    enabled: true,
-
     // Actions to audit (default: all)
     actions: ['create', 'update', 'delete', 'restore'],
 

--- a/examples/memory/rate-limiting.ts
+++ b/examples/memory/rate-limiting.ts
@@ -139,14 +139,14 @@ app.onError((err, c) => {
 // ============================================================================
 
 // Global rate limit: 100 requests per minute per IP
-// Skip health check and docs paths
+// Exclude health check and docs paths
 app.use(
   '*',
   createRateLimitMiddleware<AppEnv>({
     limit: 100,
     windowSeconds: 60,
     keyStrategy: 'ip',
-    skipPaths: ['/health', '/docs', '/docs/*', '/openapi.json'],
+    excludePaths: ['/health', '/docs', '/docs/*', '/openapi.json'],
     includeHeaders: true,
     onRateLimitExceeded: async (ctx, result, key) => {
       console.log(`Rate limit exceeded for key: ${key}`);

--- a/examples/memory/versioning.ts
+++ b/examples/memory/versioning.ts
@@ -52,10 +52,8 @@ const DocumentModel = defineModel({
   tableName: 'documents',
   schema: DocumentSchema,
   primaryKeys: ['id'],
+  // Presence enables versioning (`versioning: true` uses all defaults)
   versioning: {
-    // Enable versioning
-    enabled: true,
-
     // Field that stores the version number (default: 'version')
     field: 'version',
 

--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -22,4 +22,4 @@ app.use('*', createStorageMiddleware({
 
 Exports cache storage backends (e.g. `MemoryCacheStorage`) and the caching mixins used by hono-crud endpoints.
 
-`cacheConfig.ttl` is in **seconds**; the `CacheStorage.set` boundary works in **milliseconds** (`ttlMs`). On Cloudflare KV, `expirationTtl` is floored to 60s.
+`cacheConfig.ttlSeconds` is in **seconds**; the `CacheStorage.set` boundary works in **milliseconds** (`ttlMs`). On Cloudflare KV, `expirationTtl` is floored to 60s.

--- a/packages/cache/src/mixin.ts
+++ b/packages/cache/src/mixin.ts
@@ -169,7 +169,7 @@ export interface CacheInvalidationMethods {
  *   _meta = { model: UserModel };
  *
  *   cacheConfig = {
- *     ttl: 300,           // 5 minutes
+ *     ttlSeconds: 300,    // 5 minutes
  *     perUser: false,     // Shared cache
  *   };
  *
@@ -212,7 +212,7 @@ export function withCache<TBase extends Constructor<OpenAPIRoute>>(
     getCacheConfig(): CacheConfig {
       return {
         enabled: true,
-        ttl: 300,
+        ttlSeconds: 300,
         perUser: false,
         ...this.cacheConfig,
       };
@@ -352,7 +352,7 @@ export function withCache<TBase extends Constructor<OpenAPIRoute>>(
       }
 
       await storage.set(key, data, {
-        ttlMs: config.ttl != null ? config.ttl * 1000 : undefined,
+        ttlMs: config.ttlSeconds != null ? config.ttlSeconds * 1000 : undefined,
         tags: tags.length > 0 ? tags : undefined,
       });
     }

--- a/packages/cache/src/types.ts
+++ b/packages/cache/src/types.ts
@@ -1,8 +1,8 @@
 /**
  * Cache storage contracts are owned by core (`storage/contracts.ts`) and
  * re-exported here so consumers can keep importing them from the cache plugin.
- * `CacheSetOptions.ttl` is now `ttlMs` (milliseconds) at the storage boundary;
- * the user-facing `CacheConfig.ttl` below stays in seconds for ergonomics.
+ * `CacheSetOptions.ttlMs` is milliseconds at the storage boundary; the
+ * user-facing `CacheConfig.ttlSeconds` below stays in seconds for ergonomics.
  */
 export type { CacheEntry, CacheSetOptions, CacheStats, CacheStorage } from 'hono-crud/internal';
 
@@ -13,7 +13,7 @@ export interface CacheConfig {
   /** Whether caching is enabled. @default true */
   enabled?: boolean;
   /** Time-to-live in seconds. @default 300 (5 min) */
-  ttl?: number;
+  ttlSeconds?: number;
   /** Key prefix for cache entries. */
   prefix?: string;
   /** Query parameters to include in the cache key. */

--- a/packages/core/src/audit/config.ts
+++ b/packages/core/src/audit/config.ts
@@ -6,9 +6,11 @@ import type { AuditConfig, AuditFieldChange, NormalizedAuditConfig } from '../co
 
 /**
  * Get normalized audit configuration with defaults.
+ * Accepts the model-side union: `true` enables with defaults, a config
+ * object enables with overrides, `false`/`undefined` disables.
  */
-export function getAuditConfig(config?: AuditConfig): NormalizedAuditConfig {
-  if (!config || !config.enabled) {
+export function getAuditConfig(config?: boolean | AuditConfig): NormalizedAuditConfig {
+  if (!config) {
     return {
       enabled: false,
       tableName: 'audit_logs',
@@ -20,15 +22,17 @@ export function getAuditConfig(config?: AuditConfig): NormalizedAuditConfig {
     };
   }
 
+  const overrides: AuditConfig = config === true ? {} : config;
+
   return {
     enabled: true,
-    tableName: config.tableName || 'audit_logs',
-    actions: config.actions || ['create', 'update', 'delete'],
-    excludeFields: config.excludeFields || [],
-    storeRecord: config.storeRecord ?? true,
-    storePreviousRecord: config.storePreviousRecord ?? true,
-    trackChanges: config.trackChanges ?? true,
-    getUserId: config.getUserId,
+    tableName: overrides.tableName || 'audit_logs',
+    actions: overrides.actions || ['create', 'update', 'delete'],
+    excludeFields: overrides.excludeFields || [],
+    storeRecord: overrides.storeRecord ?? true,
+    storePreviousRecord: overrides.storePreviousRecord ?? true,
+    trackChanges: overrides.trackChanges ?? true,
+    getUserId: overrides.getUserId,
   };
 }
 

--- a/packages/core/src/audit/index.ts
+++ b/packages/core/src/audit/index.ts
@@ -168,7 +168,7 @@ export class AuditLogger {
   private config: NormalizedAuditConfig;
   private storage: AuditLogStorage | null;
 
-  constructor(config: AuditConfig | undefined, storage?: AuditLogStorage, ctx?: Context) {
+  constructor(config: boolean | AuditConfig | undefined, storage?: AuditLogStorage, ctx?: Context) {
     this.config = getAuditConfig(config);
     this.storage = auditStorageFeature.resolve(ctx, storage);
   }
@@ -414,7 +414,7 @@ export class AuditLogger {
  * ```
  */
 export function createAuditLogger(
-  config: AuditConfig | undefined,
+  config: boolean | AuditConfig | undefined,
   storage?: AuditLogStorage,
   ctx?: Context,
 ): AuditLogger {

--- a/packages/core/src/auth/middleware/combined.ts
+++ b/packages/core/src/auth/middleware/combined.ts
@@ -22,7 +22,7 @@ import { createJWTMiddleware } from './jwt';
  *   apiKey: {
  *     lookupKey: async (hash) => await db.apiKeys.findByHash(hash),
  *   },
- *   skipPaths: ['/health', '/docs/*'],
+ *   excludePaths: ['/health', '/docs/*'],
  * }));
  *
  * app.get('/me', (c) => {
@@ -37,8 +37,8 @@ export function createAuthMiddleware<E extends AuthEnv = AuthEnv>(
   config: AuthConfig,
 ): MiddlewareHandler<E> {
   const requireAuth = config.requireAuth ?? true;
-  const skipPaths = config.skipPaths || [];
-  const unauthorizedMessage = config.unauthorizedMessage || 'Unauthorized';
+  const excludePaths = config.excludePaths || [];
+  const errorMessage = config.errorMessage || 'Unauthorized';
   const authOrder = config.authOrder || ['jwt', 'api-key'];
 
   // Create individual middleware instances
@@ -46,9 +46,9 @@ export function createAuthMiddleware<E extends AuthEnv = AuthEnv>(
   const apiKeyMiddleware = config.apiKey ? createAPIKeyMiddleware<E>(config.apiKey) : null;
 
   return async (ctx, next) => {
-    // Check if path should skip auth
+    // Check if path is excluded from auth
     const path = ctx.req.path;
-    if (matchAny(path, skipPaths)) {
+    if (matchAny(path, excludePaths)) {
       ctx.set(CONTEXT_KEYS.authType, 'none');
       return next();
     }
@@ -93,7 +93,7 @@ export function createAuthMiddleware<E extends AuthEnv = AuthEnv>(
         if (lastError instanceof UnauthorizedException) {
           throw lastError;
         }
-        throw new UnauthorizedException(unauthorizedMessage);
+        throw new UnauthorizedException(errorMessage);
       }
       // Auth not required, set auth type to none
       ctx.set(CONTEXT_KEYS.authType, 'none');

--- a/packages/core/src/auth/middleware/jwt.ts
+++ b/packages/core/src/auth/middleware/jwt.ts
@@ -97,7 +97,7 @@ export function createJWTMiddleware<E extends AuthEnv = AuthEnv>(
   config: JWTConfig,
 ): MiddlewareHandler<E> {
   const algorithm = validateAlgorithm(config.algorithm || 'HS256');
-  const clockTolerance = config.clockTolerance || 0;
+  const clockToleranceSeconds = config.clockToleranceSeconds || 0;
   const extractToken = config.extractToken || defaultExtractToken;
   const extractUser = config.extractUser || defaultExtractUser;
 
@@ -152,7 +152,7 @@ export function createJWTMiddleware<E extends AuthEnv = AuthEnv>(
     // Validate additional claims (issuer, audience) using shared validator
     // Note: Hono's verify already validates exp, nbf, iat
     validateJWTClaims(claims, {
-      clockTolerance,
+      clockToleranceSeconds,
       issuer: config.issuer,
       audience: config.audience,
     });
@@ -182,7 +182,7 @@ export function createJWTMiddleware<E extends AuthEnv = AuthEnv>(
  */
 export async function verifyJWT(token: string, config: JWTConfig): Promise<JWTClaims> {
   const algorithm = validateAlgorithm(config.algorithm || 'HS256');
-  const clockTolerance = config.clockTolerance || 0;
+  const clockToleranceSeconds = config.clockToleranceSeconds || 0;
 
   // Decode header to verify algorithm
   const decoded = decode(token);
@@ -219,7 +219,7 @@ export async function verifyJWT(token: string, config: JWTConfig): Promise<JWTCl
 
   // Validate additional claims using shared validator
   validateJWTClaims(claims, {
-    clockTolerance,
+    clockToleranceSeconds,
     issuer: config.issuer,
     audience: config.audience,
   });

--- a/packages/core/src/auth/types.ts
+++ b/packages/core/src/auth/types.ts
@@ -221,7 +221,7 @@ export interface JWTConfig {
    * Clock tolerance in seconds for exp/nbf validation.
    * @default 0
    */
-  clockTolerance?: number;
+  clockToleranceSeconds?: number;
 
   /**
    * Custom function to extract user info from JWT claims.
@@ -389,17 +389,17 @@ export interface AuthConfig {
   requireAuth?: boolean;
 
   /**
-   * Paths that skip authentication entirely.
+   * Paths excluded from authentication entirely.
    * These paths won't have any auth processing.
    * @default []
    */
-  skipPaths?: PathPattern[];
+  excludePaths?: PathPattern[];
 
   /**
    * Custom error message for unauthorized requests.
    * @default 'Unauthorized'
    */
-  unauthorizedMessage?: string;
+  errorMessage?: string;
 
   /**
    * Try authentication methods in order.

--- a/packages/core/src/auth/validators/jwt-claims.ts
+++ b/packages/core/src/auth/validators/jwt-claims.ts
@@ -11,7 +11,7 @@ export interface JWTClaimsValidationOptions {
    * This option is kept for backwards compatibility and manual validation.
    * @default 0
    */
-  clockTolerance?: number;
+  clockToleranceSeconds?: number;
 
   /**
    * Expected issuer claim (iss).
@@ -57,7 +57,7 @@ export function validateJWTClaims(
   claims: JWTClaims,
   options: JWTClaimsValidationOptions = {},
 ): void {
-  const { clockTolerance = 0, issuer, audience, skipTimeValidation = false } = options;
+  const { clockToleranceSeconds = 0, issuer, audience, skipTimeValidation = false } = options;
 
   // Only check time-based claims if not skipped (for backwards compatibility)
   if (!skipTimeValidation) {
@@ -65,14 +65,14 @@ export function validateJWTClaims(
 
     // Check expiration
     if (claims.exp !== undefined) {
-      if (now > claims.exp + clockTolerance) {
+      if (now > claims.exp + clockToleranceSeconds) {
         throw new UnauthorizedException('Token has expired');
       }
     }
 
     // Check not before
     if (claims.nbf !== undefined) {
-      if (now < claims.nbf - clockTolerance) {
+      if (now < claims.nbf - clockToleranceSeconds) {
         throw new UnauthorizedException('Token not yet valid');
       }
     }

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -430,12 +430,6 @@ export interface AuditLogEntry<T = Record<string, unknown>> {
  */
 export interface AuditConfig {
   /**
-   * Whether audit logging is enabled.
-   * @default false
-   */
-  enabled: boolean;
-
-  /**
    * Name of the audit log table/store.
    * @default 'audit_logs'
    */
@@ -527,8 +521,6 @@ export interface VersionHistoryEntry<T = Record<string, unknown>> {
  * (api-version).
  */
 export interface VersioningConfig {
-  /** Enable versioning for this model */
-  enabled: boolean;
   /** Field name for the version counter on the main table (default: 'version') */
   field?: string;
   /** Table name for storing version history (default: '{tableName}_history') */
@@ -969,35 +961,43 @@ export interface Model<
   /**
    * Configure audit logging for this model.
    * When enabled, all changes are automatically logged.
+   * `true` enables with defaults; pass a config object to customize.
    *
    * @example
    * ```ts
+   * // Simple: enable with defaults
+   * audit: true
+   *
+   * // Customized
    * const UserModel = defineModel({
    *   tableName: 'users',
    *   schema: UserSchema,
    *   primaryKeys: ['id'],
    *   audit: {
-   *     enabled: true,
    *     actions: ['create', 'update', 'delete'],
    *     excludeFields: ['password', 'refreshToken'],
    *   },
    * });
    * ```
    */
-  audit?: AuditConfig;
+  audit?: boolean | AuditConfig;
 
   /**
    * Configure versioning for this model.
    * When enabled, every update creates a history record.
+   * `true` enables with defaults; pass a config object to customize.
    *
    * @example
    * ```ts
+   * // Simple: enable with defaults
+   * versioning: true
+   *
+   * // Customized
    * const DocumentModel = defineModel({
    *   tableName: 'documents',
    *   schema: DocumentSchema,
    *   primaryKeys: ['id'],
    *   versioning: {
-   *     enabled: true,
    *     field: 'version',           // Version counter field
    *     historyTable: 'documents_history',
    *     maxVersions: 50,            // Keep last 50 versions
@@ -1006,7 +1006,7 @@ export interface Model<
    * });
    * ```
    */
-  versioning?: VersioningConfig;
+  versioning?: boolean | VersioningConfig;
 
   /**
    * Configure multi-tenancy for this model.

--- a/packages/core/src/endpoints/subscribe.ts
+++ b/packages/core/src/endpoints/subscribe.ts
@@ -26,11 +26,11 @@ export interface SubscribeEndpointConfig {
   /** Filter function to control which events are sent to a specific client */
   filter?: (event: CrudEventPayload, ctx: Context) => boolean;
   /** Heartbeat interval in milliseconds. @default 30000 */
-  heartbeatInterval?: number;
+  heartbeatIntervalMs?: number;
   /** Maximum concurrent SSE connections per table. @default 1000 */
   maxConnections?: number;
   /** Connection timeout in milliseconds. @default 300000 (5 min) */
-  connectionTimeout?: number;
+  connectionTimeoutMs?: number;
   /** Fields to strip from event payloads before streaming. @default ['password', 'token', 'secret', 'apiKey', 'creditCard', 'ssn'] */
   excludeFields?: string[];
 }
@@ -94,9 +94,9 @@ export function createSubscribeHandler(config: SubscribeEndpointConfig) {
     events: eventFilter,
     emitter: customEmitter,
     filter,
-    heartbeatInterval = 30000,
+    heartbeatIntervalMs = 30000,
     maxConnections = 1000,
-    connectionTimeout = 300_000,
+    connectionTimeoutMs = 300_000,
     excludeFields = DEFAULT_EXCLUDE_FIELDS,
   } = config;
 
@@ -185,13 +185,13 @@ export function createSubscribeHandler(config: SubscribeEndpointConfig) {
         const now = Date.now();
 
         // Connection timeout
-        if (now - startTime >= connectionTimeout) {
+        if (now - startTime >= connectionTimeoutMs) {
           stream.abort();
           break;
         }
 
         // Heartbeat
-        if (now - lastHeartbeat >= heartbeatInterval) {
+        if (now - lastHeartbeat >= heartbeatIntervalMs) {
           lastHeartbeat = now;
           try {
             await stream.writeSSE({

--- a/packages/core/src/events/webhook.ts
+++ b/packages/core/src/events/webhook.ts
@@ -15,7 +15,7 @@ export interface WebhookEndpoint {
   /** Custom headers to include with each request */
   headers?: Record<string, string>;
   /** Timeout in milliseconds. @default 10000 */
-  timeout?: number;
+  timeoutMs?: number;
   /** Number of retry attempts on failure. @default 2 */
   retries?: number;
 }
@@ -91,7 +91,7 @@ async function deliverToEndpoint(
   endpoint: WebhookEndpoint,
   event: CrudEventPayload,
 ): Promise<WebhookDeliveryResult> {
-  const timeout = endpoint.timeout ?? 10000;
+  const timeoutMs = endpoint.timeoutMs ?? 10000;
   const maxRetries = endpoint.retries ?? 2;
   const body = JSON.stringify(event);
 
@@ -112,7 +112,7 @@ async function deliverToEndpoint(
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
       const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), timeout);
+      const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
       const response = await fetch(endpoint.url, {
         method: 'POST',

--- a/packages/core/src/health/endpoint.ts
+++ b/packages/core/src/health/endpoint.ts
@@ -5,8 +5,8 @@ import type { HealthCheck, HealthCheckResult, HealthConfig, HealthResponse } fro
 /**
  * Run a single health check with timeout.
  */
-async function runCheck(check: HealthCheck, defaultTimeout: number): Promise<HealthCheckResult> {
-  const timeout = check.timeout ?? defaultTimeout;
+async function runCheck(check: HealthCheck, defaultTimeoutMs: number): Promise<HealthCheckResult> {
+  const timeoutMs = check.timeoutMs ?? defaultTimeoutMs;
   const start = Date.now();
 
   // Use a shared timer that we can clear once the check resolves, otherwise
@@ -14,7 +14,7 @@ async function runCheck(check: HealthCheck, defaultTimeout: number): Promise<Hea
   // Cloudflare Workers where every pending timer holds a tick).
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => reject(new Error('Health check timed out')), timeout);
+    timer = setTimeout(() => reject(new Error('Health check timed out')), timeoutMs);
   });
 
   try {
@@ -42,9 +42,9 @@ async function runCheck(check: HealthCheck, defaultTimeout: number): Promise<Hea
  */
 async function runAllChecks(
   checks: HealthCheck[],
-  defaultTimeout: number,
+  defaultTimeoutMs: number,
 ): Promise<{ results: HealthCheckResult[]; status: HealthResponse['status'] }> {
-  const results = await Promise.all(checks.map((c) => runCheck(c, defaultTimeout)));
+  const results = await Promise.all(checks.map((c) => runCheck(c, defaultTimeoutMs)));
 
   const criticalFailed = results.some((r, i) => !r.healthy && (checks[i].critical ?? true));
   const anyFailed = results.some((r) => !r.healthy);
@@ -94,7 +94,7 @@ export function createHealthRoutes<E extends Env = Env>(config: HealthConfig = {
     version,
     path = '/health',
     readyPath = '/ready',
-    defaultTimeout = 5000,
+    defaultTimeoutMs = 5000,
     verbose = true,
   } = config;
 
@@ -115,7 +115,7 @@ export function createHealthRoutes<E extends Env = Env>(config: HealthConfig = {
   // Readiness — runs all checks
   app.get(readyPath, async (c) => {
     const start = Date.now();
-    const { results, status } = await runAllChecks(checks, defaultTimeout);
+    const { results, status } = await runAllChecks(checks, defaultTimeoutMs);
     const totalLatency = Date.now() - start;
 
     const response: HealthResponse = {

--- a/packages/core/src/health/types.ts
+++ b/packages/core/src/health/types.ts
@@ -32,7 +32,7 @@ export interface HealthCheck {
   /** Whether this check is critical (affects overall status). @default true */
   critical?: boolean;
   /** Timeout in milliseconds for this check. @default 5000 */
-  timeout?: number;
+  timeoutMs?: number;
 }
 
 /**
@@ -64,7 +64,7 @@ export interface HealthConfig {
   /** Path for the readiness endpoint. @default '/ready' */
   readyPath?: string;
   /** Default timeout per check in milliseconds. @default 5000 */
-  defaultTimeout?: number;
+  defaultTimeoutMs?: number;
   /** Whether to include detailed check info in response. @default true */
   verbose?: boolean;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,12 +8,18 @@
  */
 
 // Combined environment type
+import type { ApiVersionEnv } from './api-version/types';
 import type { AuthEnv } from './auth/types';
 import type { LoggingEnv } from './logging/types';
+import type { TenantEnv } from './multi-tenant/index';
 import type { StorageEnv } from './storage/types';
 
-/** Combined environment type with all hono-crud context variables */
-export type HonoCrudEnv = AuthEnv & LoggingEnv & StorageEnv;
+/**
+ * Combined environment type with all core hono-crud context variables
+ * (auth, logging, storage, multi-tenant, api-version). All variables are
+ * optional — each is only set after its middleware has run.
+ */
+export type HonoCrudEnv = AuthEnv & LoggingEnv & StorageEnv & TenantEnv & ApiVersionEnv;
 
 // Core exports
 export { OpenAPIRoute, isRouteClass } from './core/route';

--- a/packages/core/src/logging/storage/memory.ts
+++ b/packages/core/src/logging/storage/memory.ts
@@ -18,7 +18,7 @@ export interface MemoryLoggingStorageOptions {
    * Set to 0 to disable age-based cleanup.
    * @default 86400000 (24 hours)
    */
-  maxAge?: number;
+  maxAgeMs?: number;
 
   /**
    * Minimum interval between automatic cleanup runs (ms).
@@ -27,7 +27,7 @@ export interface MemoryLoggingStorageOptions {
    * Set to 0 to disable automatic cleanup.
    * @default 300000 (5 minutes)
    */
-  cleanupInterval?: number;
+  cleanupIntervalMs?: number;
 }
 
 /**
@@ -51,7 +51,7 @@ export interface MemoryLoggingStorageOptions {
  *
  * const storage = new MemoryLoggingStorage({
  *   maxEntries: 5000,
- *   maxAge: 3600000, // 1 hour
+ *   maxAgeMs: 3600000, // 1 hour
  * });
  * setLoggingStorage(storage);
  * ```
@@ -67,18 +67,18 @@ export class MemoryLoggingStorage implements LoggingStorage {
   private maxEntries: number;
 
   /** Maximum age in milliseconds */
-  private maxAge: number;
+  private maxAgeMs: number;
 
   /** Minimum interval between cleanup runs (ms) */
-  private cleanupInterval: number;
+  private cleanupIntervalMs: number;
 
   /** Timestamp of last cleanup run */
   private lastCleanup = 0;
 
   constructor(options?: MemoryLoggingStorageOptions) {
     this.maxEntries = options?.maxEntries ?? 10000;
-    this.maxAge = options?.maxAge ?? 86400000; // 24 hours
-    this.cleanupInterval = options?.cleanupInterval ?? 300000; // 5 minutes
+    this.maxAgeMs = options?.maxAgeMs ?? 86400000; // 24 hours
+    this.cleanupIntervalMs = options?.cleanupIntervalMs ?? 300000; // 5 minutes
   }
 
   /**
@@ -86,11 +86,11 @@ export class MemoryLoggingStorage implements LoggingStorage {
    * Called lazily on access to avoid background timers.
    */
   private maybeCleanup(): void {
-    if (this.cleanupInterval <= 0 || this.maxAge <= 0) return;
+    if (this.cleanupIntervalMs <= 0 || this.maxAgeMs <= 0) return;
     const now = Date.now();
-    if (now - this.lastCleanup >= this.cleanupInterval) {
+    if (now - this.lastCleanup >= this.cleanupIntervalMs) {
       this.lastCleanup = now;
-      this.deleteOlderThanSync(this.maxAge);
+      this.deleteOlderThanSync(this.maxAgeMs);
     }
   }
 

--- a/packages/core/src/multi-tenant/index.ts
+++ b/packages/core/src/multi-tenant/index.ts
@@ -204,6 +204,10 @@ export function multiTenant<E extends Env = Env>(
 /**
  * Type helper for defining tenant-aware Hono app types.
  *
+ * The variable is typed optional because it is only set after the multiTenant
+ * middleware has run (and `required: false` lets requests through without a
+ * tenant) — the same convention every other `*Env` type follows.
+ *
  * @example
  * ```ts
  * import { Hono } from 'hono';
@@ -213,14 +217,14 @@ export function multiTenant<E extends Env = Env>(
  * app.use('/*', multiTenant());
  *
  * app.get('/data', (c) => {
- *   const tenantId = c.get('tenantId'); // TypeScript knows this is string
+ *   const tenantId = c.get('tenantId'); // string | undefined
  *   return c.json({ tenantId });
  * });
  * ```
  */
 export type TenantEnv<TenantKey extends string = 'tenantId'> = {
   Variables: {
-    [K in TenantKey]: string;
+    [K in TenantKey]?: string;
   };
 };
 

--- a/packages/core/src/storage/memory-ttl-store.ts
+++ b/packages/core/src/storage/memory-ttl-store.ts
@@ -15,7 +15,7 @@ export interface MemoryTtlStoreOptions<V> {
 
   /** Minimum interval between lazy cleanup-on-access sweeps (ms). `<= 0`
    *  disables lazy sweeping (explicit `cleanup()` still works). @default 0 */
-  cleanupInterval?: number;
+  cleanupIntervalMs?: number;
 
   /** Maximum entries before evicting the oldest (insertion order). `<= 0`
    *  disables capacity eviction. @default 0 (unlimited) */
@@ -31,22 +31,22 @@ export interface MemoryTtlStoreOptions<V> {
 export class MemoryTtlStore<V> {
   private readonly map = new Map<string, V>();
   private readonly isExpired: (value: V, now: number) => boolean;
-  private readonly cleanupInterval: number;
+  private readonly cleanupIntervalMs: number;
   private readonly maxEntries: number;
   private readonly onEvict?: (key: string, value: V) => void;
   private lastCleanup = 0;
 
   constructor(options: MemoryTtlStoreOptions<V>) {
     this.isExpired = options.isExpired;
-    this.cleanupInterval = options.cleanupInterval ?? 0;
+    this.cleanupIntervalMs = options.cleanupIntervalMs ?? 0;
     this.maxEntries = options.maxEntries ?? 0;
     this.onEvict = options.onEvict;
   }
 
-  /** Lazy cleanup-on-access. No-op when `cleanupInterval <= 0`. */
+  /** Lazy cleanup-on-access. No-op when `cleanupIntervalMs <= 0`. */
   maybeCleanup(now: number = Date.now()): void {
-    if (this.cleanupInterval <= 0) return;
-    if (now - this.lastCleanup >= this.cleanupInterval) {
+    if (this.cleanupIntervalMs <= 0) return;
+    if (now - this.lastCleanup >= this.cleanupIntervalMs) {
       this.lastCleanup = now;
       this.cleanup(now);
     }

--- a/packages/core/src/versioning/config.ts
+++ b/packages/core/src/versioning/config.ts
@@ -6,12 +6,14 @@ import type { NormalizedVersioningConfig, VersioningConfig } from '../core/types
 
 /**
  * Get normalized versioning configuration with defaults.
+ * Accepts the model-side union: `true` enables with defaults, a config
+ * object enables with overrides, `false`/`undefined` disables.
  */
 export function getVersioningConfig(
-  config: VersioningConfig | undefined,
+  config: boolean | VersioningConfig | undefined,
   tableName: string,
 ): NormalizedVersioningConfig {
-  if (!config || !config.enabled) {
+  if (!config) {
     return {
       enabled: false,
       field: 'version',
@@ -22,13 +24,15 @@ export function getVersioningConfig(
     };
   }
 
+  const overrides: VersioningConfig = config === true ? {} : config;
+
   return {
     enabled: true,
-    field: config.field || 'version',
-    historyTable: config.historyTable || `${tableName}_history`,
-    maxVersions: config.maxVersions ?? null,
-    trackChangedBy: config.trackChangedBy ?? false,
-    excludeFields: config.excludeFields || [],
-    getUserId: config.getUserId,
+    field: overrides.field || 'version',
+    historyTable: overrides.historyTable || `${tableName}_history`,
+    maxVersions: overrides.maxVersions ?? null,
+    trackChangedBy: overrides.trackChangedBy ?? false,
+    excludeFields: overrides.excludeFields || [],
+    getUserId: overrides.getUserId,
   };
 }

--- a/packages/core/src/versioning/index.ts
+++ b/packages/core/src/versioning/index.ts
@@ -224,7 +224,7 @@ export class VersionManager {
   private tableName: string;
 
   constructor(
-    config: VersioningConfig | undefined,
+    config: boolean | VersioningConfig | undefined,
     tableName: string,
     storage?: VersioningStorage,
     ctx?: Context,
@@ -433,7 +433,7 @@ export class VersionManager {
  * ```
  */
 export function createVersionManager(
-  config: VersioningConfig | undefined,
+  config: boolean | VersioningConfig | undefined,
   tableName: string,
   storage?: VersioningStorage,
   ctx?: Context,

--- a/packages/idempotency/src/middleware.ts
+++ b/packages/idempotency/src/middleware.ts
@@ -91,7 +91,7 @@ let warnedMissingIdempotencyStorage = false;
  *
  * // Or with configuration:
  * app.use('/api/*', createIdempotencyMiddleware({
- *   ttl: 3600,              // 1 hour
+ *   ttlSeconds: 3600,       // 1 hour
  *   enforcedMethods: ['POST', 'PUT'],
  *   required: true,         // Require the header
  * }));
@@ -101,11 +101,11 @@ export function createIdempotencyMiddleware<E extends Env = Env>(
   config: IdempotencyConfig = {},
 ): MiddlewareHandler<E> {
   const headerName = config.headerName ?? 'Idempotency-Key';
-  const ttlSeconds = config.ttl ?? 86400;
+  const ttlSeconds = config.ttlSeconds ?? 86400;
   const ttlMs = ttlSeconds * 1000;
   const enforcedMethods = (config.enforcedMethods ?? ['POST']).map((m) => m.toUpperCase());
   const required = config.required ?? false;
-  const lockTimeoutMs = (config.lockTimeout ?? 60) * 1000;
+  const lockTimeoutMs = (config.lockTimeoutSeconds ?? 60) * 1000;
 
   return async (ctx, next) => {
     const method = ctx.req.method.toUpperCase();

--- a/packages/idempotency/src/storage/memory.ts
+++ b/packages/idempotency/src/storage/memory.ts
@@ -10,7 +10,7 @@ export interface MemoryIdempotencyStorageOptions {
    * access, not via background timers (edge-safe). Set 0 to disable.
    * @default 60_000 (1 minute)
    */
-  cleanupInterval?: number;
+  cleanupIntervalMs?: number;
   /** Maximum response entries before oldest-first eviction (0 = unlimited). @default 10_000 */
   maxEntries?: number;
 }
@@ -47,32 +47,32 @@ export class MemoryIdempotencyStorage implements IdempotencyStorage {
   private lockStore: MemoryTtlStore<number>;
 
   /** Minimum interval between cleanup runs (ms) */
-  private cleanupInterval: number;
+  private cleanupIntervalMs: number;
   /** Timestamp of last cleanup run */
   private lastCleanup = 0;
 
   constructor(options?: MemoryIdempotencyStorageOptions) {
-    this.cleanupInterval = options?.cleanupInterval ?? 60000;
+    this.cleanupIntervalMs = options?.cleanupIntervalMs ?? 60000;
     const maxEntries = options?.maxEntries ?? 10_000;
-    // Both inner stores keep `cleanupInterval: 0` so their built-in
+    // Both inner stores keep `cleanupIntervalMs: 0` so their built-in
     // `maybeCleanup` is a no-op; the domain class owns the single guarded
     // lazy sweep over BOTH maps (see `maybeCleanup` below).
     this.entryStore = new MemoryTtlStore({
       isExpired: (wrapper, now) => now > wrapper.expiresAt,
-      cleanupInterval: 0,
+      cleanupIntervalMs: 0,
       maxEntries,
     });
     this.lockStore = new MemoryTtlStore<number>({
       isExpired: (expiresAt, now) => now > expiresAt,
-      cleanupInterval: 0,
+      cleanupIntervalMs: 0,
       maxEntries: 0,
     });
   }
 
   private maybeCleanup(): void {
-    if (this.cleanupInterval <= 0) return;
+    if (this.cleanupIntervalMs <= 0) return;
     const now = Date.now();
-    if (now - this.lastCleanup >= this.cleanupInterval) {
+    if (now - this.lastCleanup >= this.cleanupIntervalMs) {
       this.lastCleanup = now;
       this.entryStore.cleanup(now);
       this.lockStore.cleanup(now);

--- a/packages/idempotency/src/types.ts
+++ b/packages/idempotency/src/types.ts
@@ -22,7 +22,7 @@ export interface IdempotencyConfig {
    * TTL for stored responses in seconds.
    * @default 86400 (24 hours)
    */
-  ttl?: number;
+  ttlSeconds?: number;
 
   /**
    * HTTP methods that require idempotency keys.
@@ -51,7 +51,7 @@ export interface IdempotencyConfig {
    * Lock timeout in seconds for in-flight requests.
    * @default 60
    */
-  lockTimeout?: number;
+  lockTimeoutSeconds?: number;
 
   /**
    * Custom storage instance.

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -75,13 +75,13 @@ export class CrudMcpServer {
     if (!this.options.auto) return;
 
     const config: AutoOptions = this.options.auto === true ? {} : this.options.auto;
-    const include = config.include ?? [];
-    const exclude = config.exclude ?? [];
+    const includePaths = config.includePaths ?? [];
+    const excludePaths = config.excludePaths ?? [];
 
     for (const { path, endpoints } of getRegisteredCrudResources(this.app)) {
       const normalized = normalizePath(path);
       if (this.resourcePaths.has(normalized)) continue; // manual registration wins
-      if (!isPathIncluded(normalized, include, exclude)) continue;
+      if (!isPathIncluded(normalized, includePaths, excludePaths)) continue;
 
       const override = config.resources?.[path] ?? config.resources?.[normalized] ?? {};
       this.resource(normalized, endpoints, { operations: config.operations, ...override });

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -83,10 +83,10 @@ export interface NamingContext {
  * for defaults, or pass this object to scope and override.
  */
 export interface AutoOptions {
-  /** Only auto-register resources whose path matches one of these (glob or RegExp). Default: all. */
-  include?: PathPattern[];
-  /** Skip resources whose path matches one of these. Excludes always win. */
-  exclude?: PathPattern[];
+  /** Only auto-register resources whose mount path matches one of these (glob or RegExp). Default: all. */
+  includePaths?: PathPattern[];
+  /** Skip resources whose mount path matches one of these. Excludes always win. */
+  excludePaths?: PathPattern[];
   /** Default operation allow-list applied to every auto-registered resource. */
   operations?: OperationName[];
   /** Per-path overrides, keyed by the `registerCrud` path (e.g. `'/users'`). */

--- a/packages/rate-limit/src/middleware.ts
+++ b/packages/rate-limit/src/middleware.ts
@@ -257,7 +257,7 @@ let warnedMissingRateLimitStorage = false;
  *   limit: 100,
  *   windowSeconds: 60,
  *   keyStrategy: 'ip',
- *   skipPaths: ['/health', '/docs/*'],
+ *   excludePaths: ['/health', '/docs/*'],
  * }));
  *
  * // Stricter limit for expensive endpoint
@@ -292,7 +292,7 @@ export function createRateLimitMiddleware<E extends Env = Env>(
   const algorithm = config.algorithm ?? 'sliding-window';
   const keyStrategy = config.keyStrategy ?? 'ip';
   const keyPrefix = config.keyPrefix ?? DEFAULT_RATE_LIMIT_KEY_PREFIX;
-  const skipPaths = config.skipPaths ?? [];
+  const excludePaths = config.excludePaths ?? [];
   const includeHeaders = config.includeHeaders ?? true;
   const errorMessage = config.errorMessage ?? 'Too many requests';
 
@@ -300,9 +300,9 @@ export function createRateLimitMiddleware<E extends Env = Env>(
   const extractKey = getKeyExtractor(keyStrategy, config);
 
   return async (ctx, next) => {
-    // Check if path should skip rate limiting
+    // Check if path is excluded from rate limiting
     const path = ctx.req.path;
-    if (skipPaths.length > 0 && shouldSkipPath(path, skipPaths)) {
+    if (excludePaths.length > 0 && shouldSkipPath(path, excludePaths)) {
       return next();
     }
 

--- a/packages/rate-limit/src/storage/memory.ts
+++ b/packages/rate-limit/src/storage/memory.ts
@@ -17,7 +17,7 @@ export interface MemoryRateLimitStorageOptions {
    * Set to 0 to disable automatic cleanup.
    * @default 60000 (1 minute)
    */
-  cleanupInterval?: number;
+  cleanupIntervalMs?: number;
 }
 
 /**
@@ -60,11 +60,11 @@ export class MemoryRateLimitStorage implements RateLimitStorage {
   constructor(options?: MemoryRateLimitStorageOptions) {
     this.store = new MemoryTtlStore<RateLimitWrapper>({
       isExpired: (wrapper, now) => now > wrapper.expiresAt,
-      cleanupInterval: options?.cleanupInterval ?? 60000,
+      cleanupIntervalMs: options?.cleanupIntervalMs ?? 60000,
       // maxEntries: 0 (unbounded) is required for correctness, not an
       // oversight: capacity eviction of a live window would silently reset
       // its counter, weakening limits under key-flood pressure. Memory stays
-      // bounded via the cleanupInterval sweep of expired windows.
+      // bounded via the cleanupIntervalMs sweep of expired windows.
       maxEntries: 0,
     });
   }

--- a/packages/rate-limit/src/types.ts
+++ b/packages/rate-limit/src/types.ts
@@ -52,8 +52,10 @@ export type KeyStrategy = 'ip' | 'user' | 'api-key' | 'combined';
 
 /**
  * Custom key extraction function.
+ * Return `undefined` when no key can be derived — the middleware then skips
+ * rate limiting for that request.
  */
-export type KeyExtractor<E extends Env = Env> = (ctx: Context<E>) => string | null;
+export type KeyExtractor<E extends Env = Env> = (ctx: Context<E>) => string | undefined;
 
 // ============================================================================
 // Rate Limit Algorithm
@@ -99,7 +101,7 @@ export type OnRateLimitExceeded<E extends Env = Env> = (
 ) => void | Promise<void>;
 
 /**
- * Path pattern for skip configuration.
+ * Path pattern for exclude configuration.
  * Supports exact paths, wildcards, and regex.
  *
  * Canonical definition is core's `utils/path-match.ts` (via
@@ -154,11 +156,11 @@ export interface RateLimitConfig<E extends Env = Env> {
   keyPrefix?: string;
 
   /**
-   * Paths to skip rate limiting.
+   * Paths excluded from rate limiting.
    * Supports exact paths ('/health'), wildcards ('/public/*'), and regex.
    * @default []
    */
-  skipPaths?: PathPattern[];
+  excludePaths?: PathPattern[];
 
   /**
    * Whether to include rate limit headers in responses.

--- a/packages/rate-limit/src/utils.ts
+++ b/packages/rate-limit/src/utils.ts
@@ -12,8 +12,11 @@ import type { PathPattern } from './types';
 
 /**
  * Extract client IP address from request.
- * Returns `'unknown'` if no IP can be determined (rate-limit module historically
- * uses a sentinel string for the bucket key; the shared helper returns undefined).
+ * Returns `'unknown'` if no IP can be determined (the shared helper returns
+ * undefined). This sentinel is intentional fail-closed behavior, NOT a
+ * convention violation: a falsy key makes the middleware skip rate limiting
+ * entirely, so an underivable IP must still produce a usable bucket key —
+ * rate limiting must not fail open exactly when the client is unidentifiable.
  *
  * `trustProxy` defaults to `true` (library-wide default — on edge runtimes
  * the client IP only exists in proxy headers); pass `false` to suppress
@@ -31,8 +34,8 @@ export function extractIP<E extends Env>(
 // User ID Extraction
 // ============================================================================
 
-export function extractUserId<E extends Env>(ctx: Context<E>): string | null {
-  return getUserIdShared(ctx) ?? null;
+export function extractUserId<E extends Env>(ctx: Context<E>): string | undefined {
+  return getUserIdShared(ctx);
 }
 
 // ============================================================================
@@ -42,8 +45,8 @@ export function extractUserId<E extends Env>(ctx: Context<E>): string | null {
 export function extractAPIKey<E extends Env>(
   ctx: Context<E>,
   headerName = 'X-API-Key',
-): string | null {
-  return ctx.req.header(headerName) || null;
+): string | undefined {
+  return ctx.req.header(headerName) || undefined;
 }
 
 // ============================================================================

--- a/tests/audit.test.ts
+++ b/tests/audit.test.ts
@@ -37,7 +37,6 @@ const UserModel = defineModel({
   schema: UserSchema,
   primaryKeys: ['id'],
   audit: {
-    enabled: true,
     actions: ['create', 'update', 'delete'],
     trackChanges: true,
     storeRecord: true,

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -456,13 +456,13 @@ describe('Combined Auth Middleware', () => {
     expect(data.authType).toBe('api-key');
   });
 
-  it('should skip configured paths', async () => {
+  it('should skip excluded paths', async () => {
     const app = createTestApp<AuthEnv>();
     app.use(
       '*',
       createAuthMiddleware({
         jwt: { secret },
-        skipPaths: ['/health', '/docs/*'],
+        excludePaths: ['/health', '/docs/*'],
       }),
     );
     app.get('/health', (c) => c.json({ ok: true }));

--- a/tests/cache-ttl-ms.test.ts
+++ b/tests/cache-ttl-ms.test.ts
@@ -11,7 +11,7 @@ import { z } from 'zod';
 
 // §4.4 — TTL milliseconds conversion across every cache layer.
 //
-//   * mixin:   CacheConfig.ttl (seconds) → CacheStorage.set({ ttlMs })  (×1000)
+//   * mixin:   CacheConfig.ttlSeconds (seconds) → CacheStorage.set({ ttlMs })  (×1000)
 //   * storage: MemoryCacheStorage.set({ ttlMs: 5000 }) → expiresAt = now + 5000
 //   * KV:      set({ ttlMs }) → expirationTtl = max(60, ceil(ttlMs/1000))
 //   * openapi: wrapCacheStorageForOpenApi.set(k, v, ttlMs) → { ttlMs } passthrough
@@ -32,13 +32,13 @@ type UserMeta = MetaInput<typeof UserSchema>;
 const userMeta: UserMeta = { model: UserModel };
 
 // ============================================================================
-// Mixin: CacheConfig.ttl (seconds) → storage ttlMs (×1000)
+// Mixin: CacheConfig.ttlSeconds (seconds) → storage ttlMs (×1000)
 // ============================================================================
 
-describe('§4.4 mixin: CacheConfig.ttl seconds → storage ttlMs', () => {
+describe('§4.4 mixin: CacheConfig.ttlSeconds (seconds) → storage ttlMs', () => {
   class CachedUserRead extends withCache(MemoryReadEndpoint) {
     _meta = userMeta;
-    cacheConfig = { ttl: 300 }; // 300 seconds
+    cacheConfig = { ttlSeconds: 300 }; // 300 seconds
 
     async handle(): Promise<Response> {
       const cached = await this.getCachedResponse<UserItem>();

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -560,7 +560,7 @@ describe('withCache Mixin', () => {
   // Create cached endpoint classes
   class CachedUserRead extends withCache(MemoryReadEndpoint) {
     _meta = userMeta;
-    cacheConfig = { ttl: 300 };
+    cacheConfig = { ttlSeconds: 300 };
 
     async handle(): Promise<Response> {
       // Try cache first
@@ -588,7 +588,7 @@ describe('withCache Mixin', () => {
   class CachedUserList extends withCache(MemoryListEndpoint) {
     _meta = userMeta;
     cacheConfig = {
-      ttl: 60,
+      ttlSeconds: 60,
       keyFields: ['page', 'per_page', 'status'],
     };
 
@@ -757,7 +757,7 @@ describe('withCacheInvalidation Mixin', () => {
   // Cached read endpoint
   class CachedUserRead extends withCache(MemoryReadEndpoint) {
     _meta = userMeta;
-    cacheConfig = { ttl: 300 };
+    cacheConfig = { ttlSeconds: 300 };
 
     async handle(): Promise<Response> {
       const cached = await this.getCachedResponse<UserItem>();
@@ -781,7 +781,7 @@ describe('withCacheInvalidation Mixin', () => {
   // Cached list endpoint
   class CachedUserList extends withCache(MemoryListEndpoint) {
     _meta = userMeta;
-    cacheConfig = { ttl: 300 };
+    cacheConfig = { ttlSeconds: 300 };
 
     async handle(): Promise<Response> {
       const cached = await this.getCachedResponse<UserItem[]>();
@@ -1040,7 +1040,7 @@ describe('withCache + responseEnvelope', () => {
   // one shape. `setCachedResponse` stores the raw row, not a serialised body.
   class CachedUserRead extends withCache(MemoryReadEndpoint) {
     _meta = userMeta;
-    cacheConfig = { ttl: 300 };
+    cacheConfig = { ttlSeconds: 300 };
 
     async handle(): Promise<Response> {
       const cached = await this.getCachedResponse<UserItem>();
@@ -1064,7 +1064,7 @@ describe('withCache + responseEnvelope', () => {
   // so the configured envelope (with pagination `info`) is applied uniformly.
   class CachedUserList extends withCache(MemoryListEndpoint) {
     _meta = userMeta;
-    cacheConfig = { ttl: 300, keyFields: ['page', 'per_page'] };
+    cacheConfig = { ttlSeconds: 300, keyFields: ['page', 'per_page'] };
 
     async handle(): Promise<Response> {
       const cached = await this.getCachedResponse<UserItem[]>();

--- a/tests/error-handler.test.ts
+++ b/tests/error-handler.test.ts
@@ -393,7 +393,7 @@ describe('createErrorHandler', () => {
     let storage: MemoryLoggingStorage;
 
     beforeEach(() => {
-      storage = new MemoryLoggingStorage({ maxEntries: 100, cleanupInterval: 0 });
+      storage = new MemoryLoggingStorage({ maxEntries: 100, cleanupIntervalMs: 0 });
       setLoggingStorage(storage);
     });
 

--- a/tests/health.test.ts
+++ b/tests/health.test.ts
@@ -97,7 +97,7 @@ describe('Health Endpoints', () => {
 
     it('should timeout slow checks', async () => {
       const app = createHealthRoutes({
-        defaultTimeout: 50,
+        defaultTimeoutMs: 50,
         checks: [
           {
             name: 'slow',
@@ -128,14 +128,14 @@ describe('Health Endpoints', () => {
 
     it('should respect per-check timeout', async () => {
       const app = createHealthRoutes({
-        defaultTimeout: 5000,
+        defaultTimeoutMs: 5000,
         checks: [
           {
             name: 'slow',
             check: async () => {
               await new Promise((r) => setTimeout(r, 200));
             },
-            timeout: 50,
+            timeoutMs: 50,
           },
         ],
       });

--- a/tests/idempotency-exceptions.test.ts
+++ b/tests/idempotency-exceptions.test.ts
@@ -44,7 +44,7 @@ describe('idempotency exceptions flow through createErrorHandler', () => {
       createIdempotencyMiddleware({
         storage: new MemoryIdempotencyStorage(),
         required,
-        lockTimeout: 60,
+        lockTimeoutSeconds: 60,
       }),
     );
     app.post('/op', (c) => c.json({ ok: true }));

--- a/tests/idempotency-lifecycle.test.ts
+++ b/tests/idempotency-lifecycle.test.ts
@@ -54,7 +54,7 @@ describe('§4.7 idempotency storage lifecycle', () => {
     vi.useFakeTimers();
     try {
       // Disable the lazy maybeCleanup-on-access so cleanup() is the only sweep.
-      const storage = new MemoryIdempotencyStorage({ cleanupInterval: 0 });
+      const storage = new MemoryIdempotencyStorage({ cleanupIntervalMs: 0 });
 
       const entry = (key: string): IdempotencyEntry => ({
         key,
@@ -84,7 +84,7 @@ describe('§4.7 idempotency storage lifecycle', () => {
   it('cleanup() returns 0 when nothing is expired', async () => {
     vi.useFakeTimers();
     try {
-      const storage = new MemoryIdempotencyStorage({ cleanupInterval: 0 });
+      const storage = new MemoryIdempotencyStorage({ cleanupIntervalMs: 0 });
       await storage.set(
         'a',
         { key: 'a', statusCode: 200, body: '{}', headers: {}, createdAt: Date.now() },

--- a/tests/logging.test.ts
+++ b/tests/logging.test.ts
@@ -287,7 +287,7 @@ describe('MemoryLoggingStorage', () => {
   });
 
   beforeEach(() => {
-    storage = new MemoryLoggingStorage({ maxEntries: 100, cleanupInterval: 0 });
+    storage = new MemoryLoggingStorage({ maxEntries: 100, cleanupIntervalMs: 0 });
   });
 
   afterEach(() => {
@@ -330,7 +330,7 @@ describe('MemoryLoggingStorage', () => {
 
   describe('max entries limit', () => {
     it('should enforce max entries limit', async () => {
-      const smallStorage = new MemoryLoggingStorage({ maxEntries: 5, cleanupInterval: 0 });
+      const smallStorage = new MemoryLoggingStorage({ maxEntries: 5, cleanupIntervalMs: 0 });
 
       for (let i = 0; i < 10; i++) {
         await smallStorage.store(createTestEntry());
@@ -341,7 +341,7 @@ describe('MemoryLoggingStorage', () => {
     });
 
     it('should remove oldest entries when limit exceeded', async () => {
-      const smallStorage = new MemoryLoggingStorage({ maxEntries: 3, cleanupInterval: 0 });
+      const smallStorage = new MemoryLoggingStorage({ maxEntries: 3, cleanupIntervalMs: 0 });
 
       const entry1 = createTestEntry({ id: 'entry-1' });
       const entry2 = createTestEntry({ id: 'entry-2' });
@@ -560,7 +560,7 @@ describe('MemoryLoggingStorage', () => {
       expect(recentLogs).toHaveLength(2);
     });
 
-    it('should delete entries older than maxAge', async () => {
+    it('should delete entries older than maxAgeMs', async () => {
       const now = Date.now();
 
       await storage.store(
@@ -618,7 +618,7 @@ describe('Logging Middleware', () => {
   let storage: MemoryLoggingStorage;
 
   beforeEach(() => {
-    storage = new MemoryLoggingStorage({ maxEntries: 100, cleanupInterval: 0 });
+    storage = new MemoryLoggingStorage({ maxEntries: 100, cleanupIntervalMs: 0 });
     setLoggingStorage(storage);
   });
 

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -448,9 +448,9 @@ describe('auto-discovery', () => {
     expect(names).toContain('posts_create');
   });
 
-  it('respects include/exclude path patterns', async () => {
+  it('respects includePaths/excludePaths patterns', async () => {
     const app = buildAppUsersPosts();
-    const mcp = createCrudMcp(app, { ...serverInfo, auto: { exclude: ['/posts'] } });
+    const mcp = createCrudMcp(app, { ...serverInfo, auto: { excludePaths: ['/posts'] } });
     app.all('/mcp', mcp.handler());
 
     const names = await toolNamesOverHttp(app);

--- a/tests/memory-ttl-store.test.ts
+++ b/tests/memory-ttl-store.test.ts
@@ -222,9 +222,9 @@ describe('MemoryTtlStore', () => {
   });
 
   describe('maybeCleanup (lazy cleanup-on-access guard)', () => {
-    it('never sweeps when cleanupInterval <= 0', () => {
+    it('never sweeps when cleanupIntervalMs <= 0', () => {
       const onEvict = vi.fn();
-      const store = makeStore({ cleanupInterval: 0, onEvict });
+      const store = makeStore({ cleanupIntervalMs: 0, onEvict });
 
       store.set('a', wrap('a', 1000));
       // Even far past expiry, the lazy guard is disabled.
@@ -235,7 +235,7 @@ describe('MemoryTtlStore', () => {
     });
 
     it('sweeps at most once per interval window', () => {
-      const store = makeStore({ cleanupInterval: 1000 });
+      const store = makeStore({ cleanupIntervalMs: 1000 });
 
       store.set('a', wrap('a', 500));
       store.set('b', wrap('b', 5000));

--- a/tests/prisma.test.ts
+++ b/tests/prisma.test.ts
@@ -25,7 +25,6 @@ import { type AggregateOptions, defineModel, fromHono, registerCrud } from 'hono
 import {
   MemoryVersioningStorage,
   createVersionManager,
-  getVersioningConfig,
   setVersioningStorage,
 } from 'hono-crud/versioning';
 /**
@@ -356,7 +355,7 @@ const VersionedUserModel = defineModel({
   tableName: 'users',
   schema: UserSchema.extend({ version: z.number().default(1) }),
   primaryKeys: ['id'],
-  versioning: { enabled: true, field: 'version' },
+  versioning: { field: 'version' },
 });
 
 // ============================================================================
@@ -1271,7 +1270,7 @@ describe('Prisma Adapter', () => {
       // Seed a version so the base handler passes its version-existence check,
       // but leave the table empty so the adapter's rollback finds no record.
       const manager = createVersionManager(
-        getVersioningConfig(VersionedUserModel.versioning, VersionedUserModel.tableName),
+        VersionedUserModel.versioning,
         VersionedUserModel.tableName,
       );
       await manager.saveVersion(userId, {

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -378,7 +378,7 @@ describe('MemoryRateLimitStorage fixed window', () => {
     // Direct guard for the §B.10 MUST-FIX: within-window increments mutate the
     // live entry's count in place and must NOT re-set expiry. The entry must
     // expire at `windowStart + windowMs`, never at `lastIncrement + windowMs`.
-    const storage = new MemoryRateLimitStorage({ cleanupInterval: 0 });
+    const storage = new MemoryRateLimitStorage({ cleanupIntervalMs: 0 });
     const windowMs = 60_000;
 
     // Open the window at t=0 (windowStart=0, expiresAt=60_000).
@@ -402,7 +402,7 @@ describe('MemoryRateLimitStorage fixed window', () => {
   it('expires the fixed window via cleanup() at windowStart + windowMs', async () => {
     // Companion guard using cleanup() rather than get(): the swept count proves
     // the within-window increments did not extend the expiry past 60_000.
-    const storage = new MemoryRateLimitStorage({ cleanupInterval: 0 });
+    const storage = new MemoryRateLimitStorage({ cleanupIntervalMs: 0 });
     const windowMs = 60_000;
 
     await storage.increment('user:fixed', windowMs); // windowStart=0

--- a/tests/versioning.test.ts
+++ b/tests/versioning.test.ts
@@ -40,7 +40,6 @@ const DocumentModel = defineModel({
   schema: DocumentSchema,
   primaryKeys: ['id'],
   versioning: {
-    enabled: true,
     field: 'version',
     maxVersions: 10,
     trackChangedBy: true,
@@ -98,7 +97,7 @@ describe('Record Versioning', () => {
     });
 
     it('should normalize config with defaults', () => {
-      const config = getVersioningConfig({ enabled: true }, 'documents');
+      const config = getVersioningConfig(true, 'documents');
       expect(config.enabled).toBe(true);
       expect(config.field).toBe('version');
       expect(config.historyTable).toBe('documents_history');
@@ -110,7 +109,6 @@ describe('Record Versioning', () => {
     it('should use provided values', () => {
       const config = getVersioningConfig(
         {
-          enabled: true,
           field: 'rev',
           historyTable: 'doc_versions',
           maxVersions: 50,


### PR DESCRIPTION
## Summary

Batch 8 of the 2026-06-12 audit roadmap. Findings 21, 23, 28, 31, 33. Breaking renames, sanctioned pre-1.0.

- **Enablement idiom**: `audit?: boolean | AuditConfig`, `versioning?: boolean | VersioningConfig` — the required `enabled` field is gone (it carried zero information: `{enabled: false, ...}` was treated exactly like `undefined`). Two teachable idioms remain: `boolean | Config` when fully defaultable; presence-enables when the config has required members. `versioning: true` compiles and runs in the local-consumer example.
- **One vocabulary per concept**: `skipPaths` → `excludePaths` (auth, rate-limit; mcp's `include`/`exclude` → `includePaths`/`excludePaths` — verified they match mount paths via the shared helper); `unauthorizedMessage` → `errorMessage`.
- **Duration suffixes** (rename-only; every unit verified against consuming code before renaming): `ttlSeconds`, `lockTimeoutSeconds`, `clockToleranceSeconds`, `heartbeatIntervalMs`, `connectionTimeoutMs`, health `timeoutMs`/`defaultTimeoutMs`, webhook `timeoutMs`, 4× `cleanupIntervalMs`, `maxAgeMs`. Documented exception: `retryAfter` (HTTP Retry-After).
- **`TenantEnv`** Variables now optional like every other `*Env`; **`HonoCrudEnv`** folds in tenant + api-version so its "all context variables" claim is true.
- **Rate-limit extractors** → `string | undefined` (cross-package convention); `extractIP` keeps the fail-closed `'unknown'` sentinel with its rationale documented.
- CLAUDE.md gains doctrine rules 6 (toggle idioms) + 7 (duration suffixes).

## Verification

Build/typecheck/examples/lint(0 errors) green; `test:unit` 1214 / workers 42 / example:local green; conformance Postgres leg 141 passed / 4 skips; per-field grep gates clean (each renamed field individually).