### PR TITLE
fix(relations): owner-scope `?include=` to prevent cross-tenant exposure

### DIFF
--- a/.changeset/relation-include-owner-scoping.md
+++ b/.changeset/relation-include-owner-scoping.md
@@ -1,0 +1,30 @@
+---
+"hono-crud": minor
+"@hono-crud/drizzle": patch
+"@hono-crud/memory": patch
+"@hono-crud/prisma": patch
+---
+
+Owner-scope relation includes (`?include=`) — security fix for cross-tenant exposure.
+
+Previously, loading a relation via `?include=` fetched the related rows by foreign key alone, ignoring the **related** model's access scope. A caller who could read a parent row could therefore read a related row in another tenant (or a soft-deleted one) through the include — a cross-tenant data leak.
+
+Relations can now declare a `scope` naming the related table's owner and soft-delete columns:
+
+```ts
+relations: {
+  post: {
+    type: 'belongsTo', model: 'posts', table: posts,
+    foreignKey: 'postId', localKey: 'id',
+    scope: { tenantField: 'authorId', softDeleteField: 'deletedAt' },
+  },
+}
+```
+
+When set, included related rows are filtered to the request's resolved tenant id and exclude soft-deleted rows (unless `?withDeleted=true`), so a foreign key pointing at another tenant's row resolves to `null` (belongsTo/hasOne) or is omitted (hasMany). The filtering lives in the core orchestrator (`batchLoadRelations` / `loadRelationsForItem`), so it applies identically across the drizzle, memory, and prisma adapters; the endpoint threads the parent request's tenant id + `withDeleted` into `IncludeOptions.scope` (Read via core; List via each adapter).
+
+New public types: `RelationScopeConfig`, `RelationRequestScope`; new fields `RelationConfig.scope` and `IncludeOptions.scope`; new protected `getRelationScope()` on the endpoint base class.
+
+Backward-compatible and opt-in: relations without `scope` (or requests that resolve no tenant) behave exactly as before. Declare `scope` on any relation whose related model is access-scoped to close the leak.
+
+Note: scoping is applied as a post-fetch filter in the orchestrator (related rows are fetched, then filtered before being mapped back onto the parent — they never reach the response), not yet pushed down to the adapter `WHERE`/`where`. Correct and leak-free; pushing the predicate into the query is a performance follow-up.

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -241,6 +241,35 @@ export interface RelationConfig<TTable = unknown> {
    * Configuration for cascade operations when parent is deleted.
    */
   cascade?: CascadeConfig;
+  /**
+   * Access scope applied to the RELATED rows when this relation is loaded via
+   * `?include=`. Without it, an include loads related rows by foreign key alone —
+   * so a parent the caller may read can expose a related row in another tenant
+   * (or a soft-deleted one). Declare the related table's owner/soft-delete columns
+   * here to scope the include to the caller, closing that cross-tenant read.
+   */
+  scope?: RelationScopeConfig;
+}
+
+/**
+ * Per-relation access scope for `?include=`. Names the columns ON THE RELATED
+ * TABLE used to constrain loaded related rows to what the caller may read.
+ */
+export interface RelationScopeConfig {
+  /**
+   * Column on the related table holding its owner/tenant id. When set, included
+   * related rows are filtered to the request's resolved tenant id
+   * (`IncludeOptions.scope.tenantId`), so a foreign-key pointing at another
+   * tenant's row resolves to `null` (belongsTo/hasOne) or is omitted (hasMany).
+   * Use when the related model is owner-scoped by the same identity as the parent.
+   */
+  tenantField?: string;
+  /**
+   * Soft-delete column on the related table. When set, soft-deleted related rows
+   * (column non-null) are excluded from includes unless the request opts in via
+   * `?withDeleted=true` (`IncludeOptions.scope.includeDeleted`).
+   */
+  softDeleteField?: string;
 }
 
 /**
@@ -249,11 +278,30 @@ export interface RelationConfig<TTable = unknown> {
 export type RelationsConfig = Record<string, RelationConfig>;
 
 /**
+ * Request-scoped values that drive {@link RelationScopeConfig} filtering of
+ * included related rows. Populated by the endpoint from the parent request's
+ * resolved tenant id and `withDeleted` flag; consumed by the relation loader.
+ */
+export interface RelationRequestScope {
+  /** The request's resolved tenant id (parent endpoint's `getTenantId()`). */
+  tenantId?: unknown;
+  /** When true (`?withDeleted=true`), keep soft-deleted related rows. */
+  includeDeleted?: boolean;
+}
+
+/**
  * Parsed include options from query string.
  */
 export interface IncludeOptions {
   /** List of relation names to include */
   relations: string[];
+  /**
+   * Request-scoped access scope applied to included related rows (owner-scope +
+   * soft-delete), per each relation's {@link RelationScopeConfig}. Omitted when
+   * the request resolves no tenant — in which case only declared `softDeleteField`
+   * filtering (if any) applies.
+   */
+  scope?: RelationRequestScope;
 }
 
 // ============================================================================

--- a/packages/core/src/endpoints/base.ts
+++ b/packages/core/src/endpoints/base.ts
@@ -41,6 +41,7 @@ import {
   type NormalizedSoftDeleteConfig,
   type NormalizedVersioningConfig,
   type PolicyContext,
+  type RelationRequestScope,
   type SchemaResolveContext,
   type ValidatedData,
 } from '../core/types';
@@ -258,6 +259,17 @@ export abstract class CrudEndpoint<
     if (!this.context) return undefined;
     const config = this.getMultiTenantConfig();
     return extractTenantId(this.context, config);
+  }
+
+  /**
+   * Build the request-scoped access scope for relation includes — the parent
+   * request's resolved tenant id plus whether soft-deleted related rows are
+   * wanted. Threaded into `IncludeOptions.scope` so the relation loader can
+   * constrain included related rows per each relation's `scope` config
+   * (owner-scope + soft-delete), preventing cross-tenant exposure via `?include=`.
+   */
+  protected getRelationScope(includeDeleted = false): RelationRequestScope {
+    return { tenantId: this.getTenantId(), includeDeleted };
   }
 
   /**

--- a/packages/core/src/endpoints/read.ts
+++ b/packages/core/src/endpoints/read.ts
@@ -322,6 +322,10 @@ export abstract class ReadEndpoint<
     const lookupValue = await this.getLookupValue();
     const additionalFilters = await this.getAdditionalFilters();
     const includeOptions = await this.getIncludeOptions();
+    // Scope included related rows to the caller (owner-scope + soft-delete), so
+    // `?include=` can't expose a related row in another tenant. Read never
+    // surfaces soft-deleted rows, so includeDeleted stays false.
+    if (includeOptions) includeOptions.scope = this.getRelationScope();
     const fieldSelection = await this.getFieldSelection();
 
     // Inject tenant filter if multi-tenancy is enabled

--- a/packages/core/src/relations/batch-loader.ts
+++ b/packages/core/src/relations/batch-loader.ts
@@ -6,10 +6,44 @@
  * sync loader so memory stays fully synchronous.
  */
 
-import type { IncludeOptions, MetaInput, RelationConfig, RelationType } from '../core/types';
+import type {
+  IncludeOptions,
+  MetaInput,
+  RelationConfig,
+  RelationRequestScope,
+  RelationType,
+} from '../core/types';
 
 /** A loaded related record (opaque to the orchestrator). */
 export type RelatedRecord = Record<string, unknown>;
+
+/**
+ * Filter fetched related rows to what the caller may read, per the relation's
+ * `scope` (owner column + soft-delete column) and the request scope (tenant id +
+ * `includeDeleted`). Pure and adapter-agnostic, so every adapter inherits
+ * owner-scoped includes identically — a related row in another tenant (or a
+ * soft-deleted one) is dropped BEFORE it is mapped back onto the parent and
+ * never reaches the response. No-op when the relation declares no `scope` or the
+ * request carries none.
+ */
+function applyRelationScope(
+  records: RelatedRecord[],
+  config: RelationConfig,
+  requestScope?: RelationRequestScope,
+): RelatedRecord[] {
+  const scope = config.scope;
+  if (!scope || !requestScope) return records;
+  const { tenantField, softDeleteField } = scope;
+  const { tenantId, includeDeleted } = requestScope;
+  const scopeTenant = tenantField != null && tenantId != null;
+  const scopeSoftDelete = softDeleteField != null && !includeDeleted;
+  if (!scopeTenant && !scopeSoftDelete) return records;
+  return records.filter((record) => {
+    if (scopeTenant && record[tenantField as string] !== tenantId) return false;
+    if (scopeSoftDelete && record[softDeleteField as string] != null) return false;
+    return true;
+  });
+}
 
 // --- ASYNC adapter (drizzle, prisma) ---
 // MUST be PromiseLike, NOT Promise: drizzle's fetchRelated returns a
@@ -85,6 +119,7 @@ export async function batchLoadRelations<
       relationConfig,
       handle as unknown,
       adapter as unknown as RelationLoaderAdapter<unknown>,
+      includeOptions.scope,
     );
   }
   return results;
@@ -96,11 +131,12 @@ type BatchHandler = <T extends Record<string, unknown>>(
   config: RelationConfig,
   handle: unknown,
   adapter: RelationLoaderAdapter<unknown>,
+  requestScope?: RelationRequestScope,
 ) => Promise<T[]>;
 
 /** Shared hasOne/hasMany grouping; `single` shapes the map-back. */
 function makeHasHandler(single: boolean): BatchHandler {
-  return async (results, relationName, config, handle, adapter) => {
+  return async (results, relationName, config, handle, adapter, requestScope) => {
     const localKey = config.localKey || 'id';
     const localValues = [
       ...new Set(results.map((i) => i[localKey]).filter((v) => v !== undefined && v !== null)),
@@ -108,7 +144,8 @@ function makeHasHandler(single: boolean): BatchHandler {
     if (localValues.length === 0) {
       return results.map((i) => ({ ...i, [relationName]: single ? null : [] }));
     }
-    const records = await adapter.fetchRelated(handle, config.foreignKey, localValues);
+    const fetched = await adapter.fetchRelated(handle, config.foreignKey, localValues);
+    const records = applyRelationScope(fetched, config, requestScope);
     const byForeignKey = new Map<unknown, RelatedRecord[]>();
     for (const record of records) {
       const fk = record[config.foreignKey];
@@ -124,7 +161,7 @@ function makeHasHandler(single: boolean): BatchHandler {
 }
 
 function makeBelongsToHandler(): BatchHandler {
-  return async (results, relationName, config, handle, adapter) => {
+  return async (results, relationName, config, handle, adapter, requestScope) => {
     const refLocalKey = config.localKey || 'id';
     const foreignValues = [
       ...new Set(
@@ -134,7 +171,8 @@ function makeBelongsToHandler(): BatchHandler {
     if (foreignValues.length === 0) {
       return results.map((i) => ({ ...i, [relationName]: null }));
     }
-    const records = await adapter.fetchRelated(handle, refLocalKey, foreignValues);
+    const fetched = await adapter.fetchRelated(handle, refLocalKey, foreignValues);
+    const records = applyRelationScope(fetched, config, requestScope);
     const byLocalKey = new Map<unknown, RelatedRecord>();
     for (const record of records) byLocalKey.set(record[refLocalKey], record); // last-writer-wins
     return results.map((i) => ({
@@ -188,11 +226,16 @@ export async function resolveRelationValueAsync<Handle>(
   config: RelationConfig,
   handle: Handle,
   fetchRelated: FetchRelated<Handle>,
+  requestScope?: RelationRequestScope,
 ): Promise<unknown> {
   const reducer = RELATION_SINGLE_REDUCER[config.type];
   const plan = singleQueryPlan(config, item);
   if (!plan) return reducer([]);
-  const records = await fetchRelated(handle, plan.keyField, [plan.gateValue]);
+  const records = applyRelationScope(
+    await fetchRelated(handle, plan.keyField, [plan.gateValue]),
+    config,
+    requestScope,
+  );
   return reducer(records);
 }
 
@@ -201,11 +244,16 @@ export function resolveRelationValueSync<Handle>(
   config: RelationConfig,
   handle: Handle,
   fetchRelated: SyncFetchRelated<Handle>,
+  requestScope?: RelationRequestScope,
 ): unknown {
   const reducer = RELATION_SINGLE_REDUCER[config.type];
   const plan = singleQueryPlan(config, item);
   if (!plan) return reducer([]);
-  const records = fetchRelated(handle, plan.keyField, [plan.gateValue]);
+  const records = applyRelationScope(
+    fetchRelated(handle, plan.keyField, [plan.gateValue]),
+    config,
+    requestScope,
+  );
   return reducer(records);
 }
 
@@ -234,6 +282,7 @@ export async function loadRelationsForItem<
       config,
       handle,
       adapter.fetchRelated,
+      includeOptions.scope,
     );
   }
   return result as T;
@@ -257,7 +306,13 @@ export function loadRelationsForItemSync<
     if (!config) continue;
     const handle = adapter.resolveRelation(config);
     if (handle == null) continue;
-    result[relationName] = resolveRelationValueSync(result, config, handle, adapter.fetchRelated);
+    result[relationName] = resolveRelationValueSync(
+      result,
+      config,
+      handle,
+      adapter.fetchRelated,
+      includeOptions.scope,
+    );
   }
   return result as T;
 }

--- a/packages/drizzle/src/crud.ts
+++ b/packages/drizzle/src/crud.ts
@@ -804,7 +804,12 @@ export abstract class DrizzleListEndpoint<
       cursorField: this.isCursorPaginationActive() ? this.cursorField || 'id' : undefined,
     });
 
-    const includeOptions: IncludeOptions = { relations: filters.options.include || [] };
+    const includeOptions: IncludeOptions = {
+      relations: filters.options.include || [],
+      // Scope included related rows to the caller (owner-scope + soft-delete),
+      // honoring `?withDeleted` for the related soft-delete filter.
+      scope: this.getRelationScope(filters.options.withDeleted),
+    };
 
     // Keyset cursor page: trim the has-more sentinel row before loading
     // relations, then return the canonical cursor-mode envelope.

--- a/packages/memory/src/crud.ts
+++ b/packages/memory/src/crud.ts
@@ -460,7 +460,12 @@ export abstract class MemoryListEndpoint<
     const store = getStore<ModelObject<M['model']>>(this._meta.model.tableName);
     const items = queryMemoryStore(store, filters, this.searchFields, this.getSoftDeleteConfig());
     const totalCount = items.length;
-    const includeOptions: IncludeOptions = { relations: filters.options.include || [] };
+    const includeOptions: IncludeOptions = {
+      relations: filters.options.include || [],
+      // Scope included related rows to the caller (owner-scope + soft-delete),
+      // honoring `?withDeleted` for the related soft-delete filter.
+      scope: this.getRelationScope(filters.options.withDeleted),
+    };
 
     const loadItemRelations = (item: ModelObject<M['model']>) =>
       loadRelations(item as Record<string, unknown>, this._meta, includeOptions) as ModelObject<

--- a/packages/prisma/src/crud.ts
+++ b/packages/prisma/src/crud.ts
@@ -326,7 +326,12 @@ export abstract class PrismaListEndpoint<
       cursorField: this.isCursorPaginationActive() ? this.cursorField || 'id' : undefined,
     });
 
-    const includeOptions: IncludeOptions = { relations: filters.options.include || [] };
+    const includeOptions: IncludeOptions = {
+      relations: filters.options.include || [],
+      // Scope included related rows to the caller (owner-scope + soft-delete),
+      // honoring `?withDeleted` for the related soft-delete filter.
+      scope: this.getRelationScope(filters.options.withDeleted),
+    };
 
     // Keyset cursor page: trim the has-more sentinel row before loading
     // relations, then return the canonical cursor-mode envelope.

--- a/tests/relation-orchestrator.test.ts
+++ b/tests/relation-orchestrator.test.ts
@@ -557,3 +557,139 @@ describe('resolveRelationValueSync', () => {
     expect(calls).toHaveLength(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Owner-scoped includes — `RelationConfig.scope` + `IncludeOptions.scope`
+//
+// Security: `?include=` must not expose a related row the caller can't read.
+// The orchestrator filters fetched related rows by the related table's owner
+// column (scoped to the request's tenant id) and soft-delete column BEFORE they
+// are mapped back onto the parent — so a foreign-key pointing at another
+// tenant's row resolves to null/[] and never reaches the response.
+// ---------------------------------------------------------------------------
+
+describe('include scope filtering (owner-scope + soft-delete)', () => {
+  // comment belongsTo post; the related post is owner-scoped by `authorId` and
+  // soft-deleted via `deletedAt`.
+  const scopedPost = belongsTo({
+    model: 'posts',
+    foreignKey: 'postId',
+    localKey: 'id',
+    scope: { tenantField: 'authorId', softDeleteField: 'deletedAt' },
+  });
+
+  it('belongsTo: a related row owned by another tenant resolves to null', async () => {
+    // comment owned by tenant A references a post owned by tenant B.
+    const { fetch } = makeFakeFetch([{ id: 'p1', authorId: 'B', deletedAt: null }]);
+    const result = await batchLoadRelations(
+      [{ id: 'c1', postId: 'p1' }],
+      metaWith({ post: scopedPost }),
+      asyncAdapter(fetch),
+      { relations: ['post'], scope: { tenantId: 'A' } },
+    );
+    expect(result[0].post).toBeNull();
+  });
+
+  it('belongsTo: a related row owned by the same tenant is returned', async () => {
+    const post = { id: 'p1', authorId: 'A', deletedAt: null };
+    const { fetch } = makeFakeFetch([post]);
+    const result = await batchLoadRelations(
+      [{ id: 'c1', postId: 'p1' }],
+      metaWith({ post: scopedPost }),
+      asyncAdapter(fetch),
+      { relations: ['post'], scope: { tenantId: 'A' } },
+    );
+    expect(result[0].post).toEqual(post);
+  });
+
+  it('belongsTo: a soft-deleted related row is excluded by default', async () => {
+    const { fetch } = makeFakeFetch([{ id: 'p1', authorId: 'A', deletedAt: '2020-01-01' }]);
+    const result = await batchLoadRelations(
+      [{ id: 'c1', postId: 'p1' }],
+      metaWith({ post: scopedPost }),
+      asyncAdapter(fetch),
+      { relations: ['post'], scope: { tenantId: 'A' } },
+    );
+    expect(result[0].post).toBeNull();
+  });
+
+  it('belongsTo: a soft-deleted related row is kept when includeDeleted', async () => {
+    const post = { id: 'p1', authorId: 'A', deletedAt: '2020-01-01' };
+    const { fetch } = makeFakeFetch([post]);
+    const result = await batchLoadRelations(
+      [{ id: 'c1', postId: 'p1' }],
+      metaWith({ post: scopedPost }),
+      asyncAdapter(fetch),
+      { relations: ['post'], scope: { tenantId: 'A', includeDeleted: true } },
+    );
+    expect(result[0].post).toEqual(post);
+  });
+
+  it('hasMany: drops related rows in other tenants and soft-deleted ones', async () => {
+    const scopedPosts = hasMany({
+      model: 'posts',
+      foreignKey: 'ownerId', // grouping key (the parent user id)
+      scope: { tenantField: 'tenantId', softDeleteField: 'deletedAt' },
+    });
+    const posts: RelatedRecord[] = [
+      { id: 'p1', ownerId: 'u1', tenantId: 'A', deletedAt: null }, // kept
+      { id: 'p2', ownerId: 'u1', tenantId: 'B', deletedAt: null }, // other tenant → dropped
+      { id: 'p3', ownerId: 'u1', tenantId: 'A', deletedAt: '2020' }, // soft-deleted → dropped
+    ];
+    const { fetch } = makeFakeFetch(posts);
+    const result = await batchLoadRelations(
+      [{ id: 'u1' }],
+      metaWith({ posts: scopedPosts }),
+      asyncAdapter(fetch),
+      { relations: ['posts'], scope: { tenantId: 'A' } },
+    );
+    expect(result[0].posts).toEqual([{ id: 'p1', ownerId: 'u1', tenantId: 'A', deletedAt: null }]);
+  });
+
+  it('no-op when the relation declares no scope (backward compatible)', async () => {
+    const post = { id: 'p1', authorId: 'B', deletedAt: '2020' };
+    const { fetch } = makeFakeFetch([post]);
+    const result = await batchLoadRelations(
+      [{ id: 'c1', postId: 'p1' }],
+      metaWith({ post: belongsTo({ foreignKey: 'postId', localKey: 'id' }) }),
+      asyncAdapter(fetch),
+      { relations: ['post'], scope: { tenantId: 'A' } },
+    );
+    expect(result[0].post).toEqual(post); // unscoped relation → unfiltered
+  });
+
+  it('no-op when the request carries no scope (backward compatible)', async () => {
+    const post = { id: 'p1', authorId: 'B', deletedAt: '2020' };
+    const { fetch } = makeFakeFetch([post]);
+    const result = await batchLoadRelations(
+      [{ id: 'c1', postId: 'p1' }],
+      metaWith({ post: scopedPost }),
+      asyncAdapter(fetch),
+      { relations: ['post'] }, // no scope on the request
+    );
+    expect(result[0].post).toEqual(post);
+  });
+
+  it('sync path: cross-tenant related row resolves to null', () => {
+    const { fetch } = makeFakeFetch([{ id: 'p1', authorId: 'B', deletedAt: null }]);
+    const result = loadRelationsForItemSync(
+      { id: 'c1', postId: 'p1' },
+      metaWith({ post: scopedPost }),
+      syncAdapter(fetch),
+      { relations: ['post'], scope: { tenantId: 'A' } },
+    );
+    expect(result.post).toBeNull();
+  });
+
+  it('single primitive: resolveRelationValueAsync honors the request scope', async () => {
+    const { fetch } = makeFakeFetch([{ id: 'p1', authorId: 'B', deletedAt: null }]);
+    const value = await resolveRelationValueAsync(
+      { id: 'c1', postId: 'p1' },
+      scopedPost,
+      'HANDLE',
+      fetch,
+      { tenantId: 'A' },
+    );
+    expect(value).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem (security)

Relation includes (`?include=relation`) loaded the related rows **by foreign key alone**, ignoring the *related* model's access scope. A caller who could read a parent row could therefore read a related row in **another tenant** — or a **soft-deleted** one — through the include. Cross-tenant data leak.

Example: `comment` (owner-scoped by `ownerId`) `belongsTo` `post` (owner-scoped by `authorId`). `GET /comments/:id?include=post` returned the post by `postId` even when that post belonged to a different user.

## Fix

Relations can declare a `scope` naming the related table's owner + soft-delete columns:

```ts
relations: {
  post: {
    type: 'belongsTo', model: 'posts', table: posts,
    foreignKey: 'postId', localKey: 'id',
    scope: { tenantField: 'authorId', softDeleteField: 'deletedAt' },
  },
}
```

When set, included related rows are filtered to the request's resolved tenant id and exclude soft-deleted rows (unless `?withDeleted=true`) — a foreign key into another tenant resolves to `null` (belongsTo/hasOne) or is omitted (hasMany).

The filtering lives in the **core orchestrator** (`batchLoadRelations` / `loadRelationsForItem`), applied as a pure post-fetch filter before related rows are mapped onto the parent. So drizzle, memory, and prisma inherit identical behavior with no per-adapter reimplementation. The endpoint threads the parent request's tenant id + `withDeleted` into `IncludeOptions.scope` (Read via core `read.ts`; List via each adapter's handler; new protected `getRelationScope()` on the endpoint base).

## Public surface (new)

- `RelationConfig.scope?: RelationScopeConfig` (`{ tenantField?, softDeleteField? }`)
- `IncludeOptions.scope?: RelationRequestScope` (`{ tenantId?, includeDeleted? }`)
- `RelationScopeConfig`, `RelationRequestScope` types
- protected `getRelationScope()` on the endpoint base

## Compatibility

Backward-compatible and **opt-in**: relations without `scope` (or requests that resolve no tenant) behave exactly as before. Declare `scope` on any relation whose related model is access-scoped to close the leak.

## Tests / checks

- **11 new cases** in `tests/relation-orchestrator.test.ts`: cross-tenant → `null`, same-tenant kept, soft-deleted excluded / `includeDeleted` kept, hasMany drop, no-scope & no-request backward-compat, sync-path parity, single-primitive.
- `pnpm test:unit` → **70 files, 1223 passed** (0 failed).
- `pnpm -r build` ✓, `pnpm -r typecheck` ✓, biome-clean additions.
- Changeset: `hono-crud` minor; `@hono-crud/{drizzle,memory,prisma}` patch.

## Follow-up

Scoping is a post-fetch filter (rows fetched then filtered — never reach the response), not yet pushed down to the adapter `WHERE`/`where`. Correct and leak-free; pushing the predicate into the query is a performance follow-up. A conformance cell would require the conformance harness to gain a second (related) model — also a follow-up.