### PR TITLE
fix(changeset): release hono-crud as patch, not minor (avoid 1.0.0 sub-package cascade)

### DIFF
--- a/.changeset/relation-include-owner-scoping.md
+++ b/.changeset/relation-include-owner-scoping.md
@@ -1,5 +1,5 @@
 ---
-"hono-crud": minor
+"hono-crud": patch
 "@hono-crud/drizzle": patch
 "@hono-crud/memory": patch
 "@hono-crud/prisma": patch


### PR DESCRIPTION
The Version Packages PR (#76) bumps **every** sub-package — `@hono-crud/{cache,drizzle,idempotency,mcp,memory,prisma,rate-limit}` — to **1.0.0**, which we don't want.

**Cause:** my owner-scoped-includes changeset marked `hono-crud` as `minor` (0.13 → 0.14). For a 0.x package that's a breaking range change, and every sub-package peer-depends on `hono-crud` via `workspace:^`. With `onlyUpdatePeerDependentsWhenOutOfRange: true`, core leaving the sub-packages' peer range major-bumps them all → 1.0.0.

**Fix:** mark `hono-crud` as `patch`. The change is backward-compatible (opt-in `RelationConfig.scope`), and consumers already pin `^0.13.14` / `^0.1.12` — the intended release is a patch. Patch keeps core in the peer range, so no cascade.

**Verified** via a throwaway `changeset version`:
- `hono-crud` → **0.13.15**
- `@hono-crud/drizzle` → 0.1.13, `@hono-crud/memory` → 0.1.12, `@hono-crud/prisma` → 0.1.13 (the adapters touched by the fix; patch)
- `@hono-crud/{cache,idempotency,mcp,rate-limit}` → **unchanged** (no 1.0.0)

Merging this regenerates #76 with these versions.