### PR TITLE
feat(openapi): document `?include=` relations in List/Read responses

### DIFF
--- a/.changeset/include-response-schema.md
+++ b/.changeset/include-response-schema.md
@@ -1,0 +1,15 @@
+---
+"hono-crud": patch
+---
+
+OpenAPI: document `?include=` relations in List/Read responses.
+
+When a List/Read endpoint has `allowedIncludes` and an included relation declares
+a `schema` (the related model's shape), that relation is now added to the response
+**item** schema as an OPTIONAL field — `hasMany` → array, `belongsTo`/`hasOne` →
+nullable object. Previously a relation's `schema` was used only for internal
+response typing and never reached the generated OpenAPI document, so consumers of
+generated typed clients had to hand-type the embedded relation.
+
+Backward-compatible and opt-in: relations without a `schema` (or endpoints without
+`allowedIncludes`) are unchanged. Adds the internal helper `withIncludableRelations`.

--- a/packages/core/src/endpoints/list.ts
+++ b/packages/core/src/endpoints/list.ts
@@ -9,6 +9,7 @@ import type {
   SortSpec,
 } from '../core/types';
 import { SORT_DIRECTIONS } from '../core/types';
+import { withIncludableRelations } from '../relations/response-schema';
 import { CrudEndpoint } from './base';
 import { errorResponseSchema, mergeRouteSchema } from './responses';
 import {
@@ -283,7 +284,13 @@ export abstract class ListEndpoint<
               'application/json': {
                 schema: z.object({
                   success: z.literal(true),
-                  result: z.array(this.getModelSchema()),
+                  result: z.array(
+                    withIncludableRelations(
+                      this.getModelSchema(),
+                      this._meta,
+                      this.allowedIncludes,
+                    ),
+                  ),
                   result_info: z.object(resultInfoShape),
                 }),
               },

--- a/packages/core/src/endpoints/read.ts
+++ b/packages/core/src/endpoints/read.ts
@@ -2,6 +2,7 @@ import type { Env } from 'hono';
 import { type ZodObject, type ZodRawShape, z } from 'zod';
 import { NotFoundException } from '../core/exceptions';
 import type { IncludeOptions, MetaInput, OpenAPIRouteSchema } from '../core/types';
+import { withIncludableRelations } from '../relations/response-schema';
 import { generateETag, matchesIfNoneMatch } from '../utils/etag';
 import { CrudEndpoint } from './base';
 import { errorResponseSchema, mergeRouteSchema } from './responses';
@@ -168,7 +169,11 @@ export abstract class ReadEndpoint<
               'application/json': {
                 schema: z.object({
                   success: z.literal(true),
-                  result: this.getModelSchema(),
+                  result: withIncludableRelations(
+                    this.getModelSchema(),
+                    this._meta,
+                    this.allowedIncludes,
+                  ),
                 }),
               },
             },

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -137,6 +137,8 @@ export type {
   SyncFetchRelated,
   SyncRelationLoaderAdapter,
 } from './relations/batch-loader';
+// Adds includable relations to a List/Read response item schema (OpenAPI).
+export { withIncludableRelations } from './relations/response-schema';
 
 // The contract adapter bundles implement, plus the generated-endpoints map.
 export type { AdapterBundle, GeneratedEndpoints } from './config/index';

--- a/packages/core/src/relations/response-schema.ts
+++ b/packages/core/src/relations/response-schema.ts
@@ -25,7 +25,8 @@ export function withIncludableRelations(
   const relations = meta.model.relations;
   if (!relations || allowedIncludes.length === 0) return itemSchema;
 
-  const extension: ZodRawShape = {};
+  // Use Record for mutable shape building (ZodRawShape is readonly in Zod v4).
+  const extension: Record<string, z.ZodTypeAny> = {};
   for (const name of allowedIncludes) {
     const relation = relations[name] as RelationConfig | undefined;
     const relationSchema = relation?.schema;

--- a/packages/core/src/relations/response-schema.ts
+++ b/packages/core/src/relations/response-schema.ts
@@ -1,0 +1,40 @@
+import { type ZodObject, type ZodRawShape, z } from 'zod';
+
+import type { MetaInput, RelationConfig } from '../core/types';
+
+/**
+ * Extend a List/Read response **item** schema with the model's includable
+ * relations, so the OpenAPI response documents what `?include=<relation>`
+ * returns — and generated typed clients auto-type the embedded related data
+ * instead of consumers having to hand-type it.
+ *
+ * A relation is added only when it is listed in `allowedIncludes` AND declares a
+ * `schema` (the related model's shape). The field is always OPTIONAL, since the
+ * relation is present only when explicitly requested via `?include=`:
+ *   - `hasMany`            → `z.array(relationSchema).optional()`
+ *   - `belongsTo` / `hasOne` → `relationSchema.nullable().optional()`
+ *
+ * No-op (returns `itemSchema` unchanged) when there are no allowed includes or no
+ * included relation declares a `schema`.
+ */
+export function withIncludableRelations(
+  itemSchema: ZodObject<ZodRawShape>,
+  meta: MetaInput,
+  allowedIncludes: readonly string[],
+): ZodObject<ZodRawShape> {
+  const relations = meta.model.relations;
+  if (!relations || allowedIncludes.length === 0) return itemSchema;
+
+  const extension: ZodRawShape = {};
+  for (const name of allowedIncludes) {
+    const relation = relations[name] as RelationConfig | undefined;
+    const relationSchema = relation?.schema;
+    if (!relationSchema) continue;
+    extension[name] =
+      relation.type === 'hasMany'
+        ? z.array(relationSchema).optional()
+        : relationSchema.nullable().optional();
+  }
+
+  return Object.keys(extension).length > 0 ? itemSchema.extend(extension) : itemSchema;
+}

--- a/tests/relation-response-schema.test.ts
+++ b/tests/relation-response-schema.test.ts
@@ -1,0 +1,66 @@
+// Unit tests for `withIncludableRelations` (packages/core/src/relations/
+// response-schema.ts) — the helper that adds includable relations to a List/Read
+// OpenAPI response item schema so `?include=` shapes are documented + typed.
+import type { MetaInput, RelationsConfig } from 'hono-crud';
+import { withIncludableRelations } from 'hono-crud/internal';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+const itemSchema = z.object({ id: z.string(), postId: z.string().nullable() });
+const postSchema = z.object({ id: z.string(), title: z.string() });
+
+function metaWith(relations: RelationsConfig | undefined): MetaInput {
+  return { model: { tableName: 'comment', schema: itemSchema, primaryKeys: ['id'], relations } };
+}
+
+describe('withIncludableRelations', () => {
+  it('adds a belongsTo relation as an optional, nullable object', () => {
+    const meta = metaWith({
+      post: { type: 'belongsTo', model: 'post', foreignKey: 'postId', schema: postSchema },
+    });
+    const extended = withIncludableRelations(itemSchema, meta, ['post']);
+
+    expect('post' in extended.shape).toBe(true);
+    // Optional — parses fine when the relation is absent (not requested).
+    expect(extended.parse({ id: 'c1', postId: null })).toEqual({ id: 'c1', postId: null });
+    // Nullable — a missing FK / cross-tenant row resolves to null.
+    expect(extended.parse({ id: 'c1', postId: null, post: null }).post).toBeNull();
+    // Embedded object is kept (not stripped).
+    expect(extended.parse({ id: 'c1', postId: 'p1', post: { id: 'p1', title: 'X' } }).post).toEqual(
+      { id: 'p1', title: 'X' },
+    );
+  });
+
+  it('adds a hasMany relation as an optional array', () => {
+    const meta = metaWith({
+      comments: { type: 'hasMany', model: 'comment', foreignKey: 'postId', schema: postSchema },
+    });
+    const extended = withIncludableRelations(itemSchema, meta, ['comments']);
+
+    expect(extended.parse({ id: 'c1', postId: null }).comments).toBeUndefined();
+    expect(
+      extended.parse({ id: 'c1', postId: null, comments: [{ id: 'p1', title: 'X' }] }).comments,
+    ).toHaveLength(1);
+  });
+
+  it('skips a relation that is not in allowedIncludes', () => {
+    const meta = metaWith({
+      post: { type: 'belongsTo', model: 'post', foreignKey: 'postId', schema: postSchema },
+    });
+    const extended = withIncludableRelations(itemSchema, meta, []);
+    expect('post' in extended.shape).toBe(false);
+    expect(extended).toBe(itemSchema); // no-op → same reference
+  });
+
+  it('skips a relation that declares no schema', () => {
+    const meta = metaWith({ post: { type: 'belongsTo', model: 'post', foreignKey: 'postId' } });
+    const extended = withIncludableRelations(itemSchema, meta, ['post']);
+    expect('post' in extended.shape).toBe(false);
+    expect(extended).toBe(itemSchema);
+  });
+
+  it('returns the item schema unchanged when the model has no relations', () => {
+    const extended = withIncludableRelations(itemSchema, metaWith(undefined), ['post']);
+    expect(extended).toBe(itemSchema);
+  });
+});


### PR DESCRIPTION
## Problem

A relation's `schema` (the related model's shape) was used only for **internal** response typing — it never reached the generated OpenAPI document. So `GET /comments?include=post` returned an embedded `post` at runtime, but the OpenAPI response item had only the scalar columns. Consumers of generated typed clients (`@hey-api/openapi-ts`, etc.) had to hand-type the embedded relation.

## Fix

When a List/Read endpoint has `allowedIncludes` and an included relation declares a `schema`, the relation is now added to the response **item** schema as an OPTIONAL field:

- `hasMany` → `z.array(relationSchema).optional()`
- `belongsTo` / `hasOne` → `relationSchema.nullable().optional()`

It's optional because the relation is only present when explicitly requested via `?include=`. The new `withIncludableRelations` helper (`packages/core/src/relations/response-schema.ts`) is wired into `ListEndpoint.getSchema()` and `ReadEndpoint.getSchema()`.

```ts
// before:  result: z.array(this.getModelSchema())
// after:   result: z.array(withIncludableRelations(this.getModelSchema(), this._meta, this.allowedIncludes))
```

So a generated client's row type now gains, e.g., `post?: Post | null` automatically.

## Compatibility

Backward-compatible and opt-in: a relation without a `schema`, or an endpoint without `allowedIncludes`, is unchanged (the helper returns the item schema by reference).

## Tests / checks

- 5 new unit tests (`tests/relation-response-schema.test.ts`): belongsTo → optional nullable object, hasMany → optional array, not-in-`allowedIncludes` skipped, no-`schema` skipped, no-relations no-op.
- `pnpm test:unit` → **1228 passed**; `pnpm -r build` + `pnpm -r typecheck` clean; biome-clean.
- Changeset: `hono-crud` **patch** (core-only; no adapter changes → no `workspace:^` peer cascade).

## Follow-up

Pairs with the owner-scoped includes from #75 — together, `?include=` is now both **secure** (owner-scoped) and **fully typed** end-to-end. Downstream (saas-template) can drop its hand-written `CommentWithPost` once this publishes.