### PR TITLE
feat(relations): push owner-scoped `?include=` down to the adapter query

### DIFF
--- a/.changeset/relation-include-scope-pushdown.md
+++ b/.changeset/relation-include-scope-pushdown.md
@@ -1,0 +1,23 @@
+---
+"hono-crud": patch
+"@hono-crud/drizzle": patch
+"@hono-crud/memory": patch
+"@hono-crud/prisma": patch
+---
+
+Push owner-scoped relation includes (`?include=`) down to the adapter query.
+
+The owner-scope filter on relation includes ran as a **post-fetch** filter in the
+core orchestrator: related rows were fetched by foreign key, then cross-tenant /
+soft-deleted ones were dropped before the response. Now the resolved scope (tenant
+column + value, soft-delete column) is threaded into each adapter's `fetchRelated`,
+so the filter is pushed into the **WHERE clause** (drizzle / prisma) or the store
+scan (memory) — the disallowed rows are never fetched. The core orchestrator keeps
+its post-fetch `applyRelationScope` as a defense-in-depth net for adapters that
+ignore the scope argument.
+
+Adds the internal `RelationFetchScope` type + `resolveFetchScope`; the
+`FetchRelated` / `SyncFetchRelated` types gain an optional 4th `scope` argument
+(backward-compatible — a 3-arg adapter `fetchRelated` stays assignable). Also adds
+a cross-adapter relation-scoping conformance cell (runs on memory + drizzle; a
+named skip on the prisma leg, whose fixed examples schema has no self-relation).

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -130,6 +130,7 @@ export {
 } from './relations/batch-loader';
 export type {
   RelatedRecord,
+  RelationFetchScope,
   ResolveRelation,
   FetchRelated,
   RelationLoaderAdapter,

--- a/packages/core/src/relations/batch-loader.ts
+++ b/packages/core/src/relations/batch-loader.ts
@@ -45,6 +45,44 @@ function applyRelationScope(
   });
 }
 
+/**
+ * The push-down form of {@link RelationConfig.scope} for a single request: the
+ * concrete column + value an adapter can add to its related-row query (WHERE) so
+ * the owner-scope is enforced in SQL instead of by post-fetch filtering. Computed
+ * by {@link resolveFetchScope} from the relation `scope` + the request scope.
+ */
+export interface RelationFetchScope {
+  /** Owner/tenant column on the related table to constrain by equality. */
+  tenantField?: string;
+  /** The request's tenant id (the equality value for `tenantField`). */
+  tenantValue?: unknown;
+  /** Soft-delete column on the related table to require `IS NULL`. */
+  excludeDeletedField?: string;
+}
+
+/**
+ * Resolve the per-relation, per-request fetch scope an adapter can push into its
+ * query. Returns `undefined` when there is nothing to constrain (no relation
+ * `scope`, no request scope, or every applicable field opted out). Adapters that
+ * honor it filter in SQL; the orchestrator still applies {@link applyRelationScope}
+ * afterward as a defense-in-depth net for adapters that ignore the scope arg.
+ */
+export function resolveFetchScope(
+  config: RelationConfig,
+  requestScope?: RelationRequestScope,
+): RelationFetchScope | undefined {
+  const scope = config.scope;
+  if (!scope || !requestScope) return undefined;
+  const tenantField =
+    scope.tenantField != null && requestScope.tenantId != null ? scope.tenantField : undefined;
+  const excludeDeletedField =
+    scope.softDeleteField != null && !requestScope.includeDeleted
+      ? scope.softDeleteField
+      : undefined;
+  if (tenantField == null && excludeDeletedField == null) return undefined;
+  return { tenantField, tenantValue: requestScope.tenantId, excludeDeletedField };
+}
+
 // --- ASYNC adapter (drizzle, prisma) ---
 // MUST be PromiseLike, NOT Promise: drizzle's fetchRelated returns a
 // QueryBuilder<Row> which `extends PromiseLike<Row[]>` (drizzle helpers.ts:77),
@@ -60,6 +98,7 @@ export type FetchRelated<Handle> = (
   handle: Handle,
   keyField: string,
   values: unknown[],
+  scope?: RelationFetchScope,
 ) => RelatedRecord[] | PromiseLike<RelatedRecord[]>;
 
 export interface RelationLoaderAdapter<Handle> {
@@ -76,6 +115,7 @@ export type SyncFetchRelated<Handle> = (
   handle: Handle,
   keyField: string,
   values: unknown[],
+  scope?: RelationFetchScope,
 ) => RelatedRecord[];
 
 export interface SyncRelationLoaderAdapter<Handle> {
@@ -144,7 +184,8 @@ function makeHasHandler(single: boolean): BatchHandler {
     if (localValues.length === 0) {
       return results.map((i) => ({ ...i, [relationName]: single ? null : [] }));
     }
-    const fetched = await adapter.fetchRelated(handle, config.foreignKey, localValues);
+    const fetchScope = resolveFetchScope(config, requestScope);
+    const fetched = await adapter.fetchRelated(handle, config.foreignKey, localValues, fetchScope);
     const records = applyRelationScope(fetched, config, requestScope);
     const byForeignKey = new Map<unknown, RelatedRecord[]>();
     for (const record of records) {
@@ -171,7 +212,8 @@ function makeBelongsToHandler(): BatchHandler {
     if (foreignValues.length === 0) {
       return results.map((i) => ({ ...i, [relationName]: null }));
     }
-    const fetched = await adapter.fetchRelated(handle, refLocalKey, foreignValues);
+    const fetchScope = resolveFetchScope(config, requestScope);
+    const fetched = await adapter.fetchRelated(handle, refLocalKey, foreignValues, fetchScope);
     const records = applyRelationScope(fetched, config, requestScope);
     const byLocalKey = new Map<unknown, RelatedRecord>();
     for (const record of records) byLocalKey.set(record[refLocalKey], record); // last-writer-wins
@@ -232,7 +274,12 @@ export async function resolveRelationValueAsync<Handle>(
   const plan = singleQueryPlan(config, item);
   if (!plan) return reducer([]);
   const records = applyRelationScope(
-    await fetchRelated(handle, plan.keyField, [plan.gateValue]),
+    await fetchRelated(
+      handle,
+      plan.keyField,
+      [plan.gateValue],
+      resolveFetchScope(config, requestScope),
+    ),
     config,
     requestScope,
   );
@@ -250,7 +297,7 @@ export function resolveRelationValueSync<Handle>(
   const plan = singleQueryPlan(config, item);
   if (!plan) return reducer([]);
   const records = applyRelationScope(
-    fetchRelated(handle, plan.keyField, [plan.gateValue]),
+    fetchRelated(handle, plan.keyField, [plan.gateValue], resolveFetchScope(config, requestScope)),
     config,
     requestScope,
   );

--- a/packages/drizzle/src/helpers.ts
+++ b/packages/drizzle/src/helpers.ts
@@ -255,11 +255,25 @@ function drizzleRelationAdapter(
 ): RelationLoaderAdapter<DrizzleTable> {
   return {
     resolveRelation: (config) => (config as RelationConfig<DrizzleTable>).table ?? null,
-    fetchRelated: (table, keyField, values) =>
-      cast<RelatedRecord>(db)
+    // Push the owner-scope into the WHERE clause (instead of post-fetch filtering):
+    // the related rows are constrained to the caller's tenant + non-soft-deleted in
+    // SQL, so cross-tenant rows are never fetched. The core orchestrator still
+    // re-filters as a defense-in-depth net.
+    fetchRelated: (table, keyField, values, scope) => {
+      // Inferred as drizzle's real `SQL[]` (operators return SQLWrapper) so `_and`
+      // accepts it — not the local `DrizzleSql` stand-in.
+      const conditions = [inArray(getColumn(table, keyField), values)];
+      if (scope?.tenantField != null && scope.tenantValue != null) {
+        conditions.push(eq(getColumn(table, scope.tenantField), scope.tenantValue));
+      }
+      if (scope?.excludeDeletedField != null) {
+        conditions.push(isNull(getColumn(table, scope.excludeDeletedField)));
+      }
+      return cast<RelatedRecord>(db)
         .select()
         .from(table)
-        .where(inArray(getColumn(table, keyField), values)),
+        .where(conditions.length === 1 ? conditions[0] : _and(...conditions));
+    },
   };
 }
 

--- a/packages/memory/src/helpers.ts
+++ b/packages/memory/src/helpers.ts
@@ -41,8 +41,23 @@ export function getStore<T>(tableName: string): Map<string, T> {
 function memoryRelationAdapter(): SyncRelationLoaderAdapter<Map<string, RelatedRecord>> {
   return {
     resolveRelation: (config) => getStore<RelatedRecord>(config.model),
-    fetchRelated: (store, keyField, values) =>
-      Array.from(store.values()).filter((r) => values.includes(r[keyField])),
+    // Apply the owner-scope while scanning the store (parity with the SQL adapters'
+    // WHERE push-down): a related row in another tenant or a soft-deleted one is
+    // skipped here, not just by the orchestrator's defense-in-depth re-filter.
+    fetchRelated: (store, keyField, values, scope) =>
+      Array.from(store.values()).filter((r) => {
+        if (!values.includes(r[keyField])) return false;
+        if (
+          scope?.tenantField != null &&
+          scope.tenantValue != null &&
+          r[scope.tenantField] !== scope.tenantValue
+        ) {
+          return false;
+        }
+        if (scope?.excludeDeletedField != null && r[scope.excludeDeletedField] != null)
+          return false;
+        return true;
+      }),
   };
 }
 

--- a/packages/prisma/src/helpers.ts
+++ b/packages/prisma/src/helpers.ts
@@ -383,8 +383,19 @@ function prismaRelationAdapter(prisma: PrismaClient): RelationLoaderAdapter<Pris
         prisma,
         await resolvePrismaDelegateName({ tableName: config.model, table: config.table }),
       ) ?? null,
-    fetchRelated: (model, keyField, values) =>
-      model.findMany({ where: { [keyField]: { in: values } } }),
+    // Push the owner-scope into the `where` (instead of post-fetch filtering): the
+    // related rows are constrained to the caller's tenant + non-soft-deleted in the
+    // query. The core orchestrator still re-filters as a defense-in-depth net.
+    fetchRelated: (model, keyField, values, scope) => {
+      const where: Record<string, unknown> = { [keyField]: { in: values } };
+      if (scope?.tenantField != null && scope.tenantValue != null) {
+        where[scope.tenantField] = scope.tenantValue;
+      }
+      if (scope?.excludeDeletedField != null) {
+        where[scope.excludeDeletedField] = null;
+      }
+      return model.findMany({ where });
+    },
   };
 }
 

--- a/tests/conformance/adapters/drizzle.ts
+++ b/tests/conformance/adapters/drizzle.ts
@@ -62,6 +62,7 @@ const itemsTable = sqliteTable('conformance_items', {
   role: text('role').notNull().default('user'),
   age: integer('age'),
   tenantId: text('tenantId'),
+  parentId: text('parentId'),
   deletedAt: text('deletedAt'),
   createdAt: integer('createdAt'),
   updatedAt: integer('updatedAt'),
@@ -73,6 +74,7 @@ const itemsTable = sqliteTable('conformance_items', {
 
 const schema = buildConformanceSchema('epoch-ms').extend({
   tenantId: z.string().nullable().optional(),
+  parentId: z.string().nullable().optional(),
 });
 type Item = z.infer<typeof schema>;
 
@@ -96,6 +98,20 @@ const tenantModel = defineModel({
   softDelete: { field: 'deletedAt' },
   timestamps: true,
   multiTenant: { field: 'tenantId', source: 'context', contextKey: 'tenantId' },
+  // Owner-scoped self-relation: a row's `parent` is filtered to the caller's
+  // tenant + excludes soft-deleted parents — the include scope pushes these into
+  // the SQL WHERE (see drizzle helpers `fetchRelated`).
+  relations: {
+    parent: {
+      type: 'belongsTo',
+      model: TABLE,
+      table: itemsTable,
+      foreignKey: 'parentId',
+      localKey: 'id',
+      schema,
+      scope: { tenantField: 'tenantId', softDeleteField: 'deletedAt' },
+    },
+  },
 });
 const tenantMeta = defineMeta({ model: tenantModel });
 
@@ -182,6 +198,7 @@ class TenantCreate extends DrizzleCreateEndpoint {
 class TenantRead extends DrizzleReadEndpoint {
   _meta = tenantMeta;
   db = DB;
+  protected override allowedIncludes = ['parent'];
 }
 class TenantUpdate extends DrizzleUpdateEndpoint {
   _meta = tenantMeta;
@@ -194,6 +211,7 @@ class TenantDelete extends DrizzleDeleteEndpoint {
 class TenantList extends DrizzleListEndpoint {
   _meta = tenantMeta;
   db = DB;
+  protected override allowedIncludes = ['parent'];
 }
 
 class FinalizeCreate extends DrizzleCreateEndpoint {
@@ -266,6 +284,7 @@ async function setup(): Promise<AdapterContext> {
       role TEXT NOT NULL DEFAULT 'user',
       age INTEGER,
       tenantId TEXT,
+      parentId TEXT,
       deletedAt TEXT,
       createdAt INTEGER,
       updatedAt INTEGER
@@ -331,6 +350,7 @@ export const drizzleConformance: AdapterDescriptor = {
     uniqueConstraints: true,
     timestampKind: 'epoch-ms',
     transactionalHooks: 'rollback',
+    relationScoping: true,
   },
   tenant: {
     field: 'tenantId',

--- a/tests/conformance/adapters/memory.ts
+++ b/tests/conformance/adapters/memory.ts
@@ -37,6 +37,7 @@ import { CONFORMANCE_FILTER_CONFIG, buildConformanceSchema } from '../model';
 
 const schema = buildConformanceSchema('epoch-ms').extend({
   tenantId: z.string().nullable().optional(),
+  parentId: z.string().nullable().optional(),
 });
 type Item = z.infer<typeof schema>;
 
@@ -58,6 +59,18 @@ const tenantModel = defineModel({
   softDelete: { field: 'deletedAt' },
   timestamps: true,
   multiTenant: { field: 'tenantId', source: 'context', contextKey: 'tenantId' },
+  // Owner-scoped self-relation: a row's `parent` is filtered to the caller's
+  // tenant + excludes soft-deleted parents (exercises the relation-include scope).
+  relations: {
+    parent: {
+      type: 'belongsTo',
+      model: TABLE,
+      foreignKey: 'parentId',
+      localKey: 'id',
+      schema,
+      scope: { tenantField: 'tenantId', softDeleteField: 'deletedAt' },
+    },
+  },
 });
 const tenantMeta = defineMeta({ model: tenantModel });
 
@@ -130,6 +143,7 @@ class TenantCreate extends MemoryCreateEndpoint {
 }
 class TenantRead extends MemoryReadEndpoint {
   _meta = tenantMeta;
+  protected override allowedIncludes = ['parent'];
 }
 class TenantUpdate extends MemoryUpdateEndpoint {
   _meta = tenantMeta;
@@ -139,6 +153,7 @@ class TenantDelete extends MemoryDeleteEndpoint {
 }
 class TenantList extends MemoryListEndpoint {
   _meta = tenantMeta;
+  protected override allowedIncludes = ['parent'];
 }
 
 class FinalizeCreate extends MemoryCreateEndpoint {
@@ -252,6 +267,7 @@ export const memoryConformance: AdapterDescriptor = {
     uniqueConstraints: false,
     timestampKind: 'epoch-ms',
     transactionalHooks: 'noop-sentinel',
+    relationScoping: true,
   },
   tenant: {
     field: 'tenantId',

--- a/tests/conformance/adapters/prisma.ts
+++ b/tests/conformance/adapters/prisma.ts
@@ -326,6 +326,9 @@ export const prismaConformance: AdapterDescriptor = {
     uniqueConstraints: true,
     timestampKind: 'iso-datetime',
     transactionalHooks: 'rollback',
+    // The prisma leg reuses the fixed examples `users` schema, which has no
+    // self-relation column — the relation-scoping cell is a named skip here.
+    relationScoping: false,
   },
   tenant: {
     field: 'status',

--- a/tests/conformance/cells/index.ts
+++ b/tests/conformance/cells/index.ts
@@ -14,6 +14,7 @@ import { registerFilterOperatorCells } from './filter-operators';
 import { registerFinalizePipelineCells } from './finalize-pipeline';
 import { registerManagedFieldCells } from './managed-fields';
 import { registerPaginationCells } from './pagination';
+import { registerRelationScopingCells } from './relation-scoping';
 import { registerSoftDeleteLifecycleCells } from './soft-delete-lifecycle';
 import { registerTenantScopingCells } from './tenant-scoping';
 import { registerTransactionalHookCells } from './transactional-hooks';
@@ -49,6 +50,7 @@ export function registerConformanceCells(descriptor: AdapterDescriptor): void {
   registerManagedFieldCells(descriptor, ctx);
   registerUniqueConflictCells(descriptor, ctx);
   registerTenantScopingCells(descriptor, ctx);
+  registerRelationScopingCells(descriptor, ctx);
   registerFinalizePipelineCells(descriptor, ctx);
   registerUpsertRestoreCells(descriptor, ctx);
   registerTransactionalHookCells(descriptor, ctx);

--- a/tests/conformance/cells/relation-scoping.ts
+++ b/tests/conformance/cells/relation-scoping.ts
@@ -1,0 +1,103 @@
+/**
+ * Cell — owner-scoped relation includes (`?include=parent`).
+ *
+ * The conformance model carries a self-relation (`parent` belongsTo via
+ * `parentId`) whose `scope` ties it to the tenant + soft-delete columns. A parent
+ * the caller may not read — another tenant's row, or a soft-deleted one — must be
+ * omitted from the include (resolved to `null`), never leaked through a child the
+ * caller CAN read. The filter is pushed into the adapter query (`fetchRelated`),
+ * so this exercises each adapter's WHERE translation, not just the core net.
+ *
+ * Skipped (named) on the prisma leg: it reuses the fixed examples `users` schema,
+ * which has no self-relation column.
+ */
+import { expect, test } from 'vitest';
+import {
+  type AdapterDescriptor,
+  type ConformanceRecord,
+  type CtxGetter,
+  createRecord,
+  expectSuccess,
+} from '../contract';
+
+export function registerRelationScopingCells(descriptor: AdapterDescriptor, ctx: CtxGetter): void {
+  const { headerName, tenantA, tenantB } = descriptor.tenant;
+  const asTenant = (tenant: string): Record<string, string> => ({ [headerName]: tenant });
+
+  const title =
+    'relation include scoping (?include=parent): cross-tenant + soft-deleted parents resolve to null';
+
+  if (!descriptor.capabilities.relationScoping) {
+    test.skip(`${title} [skipped: ${descriptor.name} model has no self-relation]`, () => {});
+    return;
+  }
+
+  const readParent = async (childId: string, tenant: string): Promise<unknown> => {
+    const result = await expectSuccess<ConformanceRecord>(
+      await ctx().app.request(`/tenant-items/${childId}?include=parent`, {
+        headers: asTenant(tenant),
+      }),
+      200,
+    );
+    return result.parent;
+  };
+
+  test(title, async () => {
+    const { app } = ctx();
+
+    // A parent owned by tenant B.
+    const parentB = await createRecord(
+      app,
+      '/tenant-items',
+      { name: 'Parent B', email: 'rel-parent-b@conformance.test', role: 'user', age: 40 },
+      asTenant(tenantB),
+    );
+
+    // A child owned by tenant A pointing at tenant B's parent (cross-tenant FK).
+    const childCross = await createRecord(
+      app,
+      '/tenant-items',
+      {
+        name: 'Child cross',
+        email: 'rel-child-cross@conformance.test',
+        role: 'user',
+        age: 10,
+        parentId: parentB.id,
+      },
+      asTenant(tenantA),
+    );
+
+    // Tenant A's include must NOT expose tenant B's parent.
+    expect(await readParent(childCross.id, tenantA)).toBeNull();
+
+    // A same-tenant parent IS embedded.
+    const parentA = await createRecord(
+      app,
+      '/tenant-items',
+      { name: 'Parent A', email: 'rel-parent-a@conformance.test', role: 'user', age: 41 },
+      asTenant(tenantA),
+    );
+    const childSame = await createRecord(
+      app,
+      '/tenant-items',
+      {
+        name: 'Child same',
+        email: 'rel-child-same@conformance.test',
+        role: 'user',
+        age: 11,
+        parentId: parentA.id,
+      },
+      asTenant(tenantA),
+    );
+    expect((await readParent(childSame.id, tenantA)) as ConformanceRecord | null).toMatchObject({
+      id: parentA.id,
+    });
+
+    // Soft-delete the parent → now omitted from the include (deletedAt IS NULL).
+    await app.request(`/tenant-items/${parentA.id}`, {
+      method: 'DELETE',
+      headers: asTenant(tenantA),
+    });
+    expect(await readParent(childSame.id, tenantA)).toBeNull();
+  });
+}

--- a/tests/conformance/contract.ts
+++ b/tests/conformance/contract.ts
@@ -67,6 +67,14 @@ export interface ConformanceCapabilities {
    *   (memory adapter, `MEMORY_NOOP_TX`).
    */
   transactionalHooks: 'rollback' | 'noop-sentinel';
+  /**
+   * Whether this leg's conformance model carries an owner-scoped self-relation
+   * (`parent` belongsTo via `parentId`, `scope` tied to the tenant + soft-delete
+   * columns), so the relation-include scoping cell can run. False on the prisma
+   * leg — it reuses the fixed examples `users` schema, which has no self-relation
+   * column; the skip is named.
+   */
+  relationScoping: boolean;
 }
 
 export interface HookObservation {

--- a/tests/relation-orchestrator.test.ts
+++ b/tests/relation-orchestrator.test.ts
@@ -693,3 +693,63 @@ describe('include scope filtering (owner-scope + soft-delete)', () => {
     expect(value).toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Fetch-scope push-down — the orchestrator hands the resolved scope to
+// `fetchRelated` so adapters can filter in SQL (the orchestrator's post-fetch
+// `applyRelationScope` stays as a defense-in-depth net).
+// ---------------------------------------------------------------------------
+
+describe('fetch-scope push-down to fetchRelated', () => {
+  const scopedRel = belongsTo({
+    foreignKey: 'postId',
+    localKey: 'id',
+    scope: { tenantField: 'authorId', softDeleteField: 'deletedAt' },
+  });
+
+  function recordingAdapter() {
+    const scopes: unknown[] = [];
+    const adapter: RelationLoaderAdapter<string> = {
+      resolveRelation: () => 'HANDLE',
+      fetchRelated: (_h, _k, _values, scope) => {
+        scopes.push(scope);
+        return [];
+      },
+    };
+    return { adapter, scopes };
+  }
+
+  it('passes the resolved tenant + soft-delete scope', async () => {
+    const { adapter, scopes } = recordingAdapter();
+    await batchLoadRelations([{ id: 'c1', postId: 'p1' }], metaWith({ post: scopedRel }), adapter, {
+      relations: ['post'],
+      scope: { tenantId: 'A' },
+    });
+    expect(scopes[0]).toEqual({
+      tenantField: 'authorId',
+      tenantValue: 'A',
+      excludeDeletedField: 'deletedAt',
+    });
+  });
+
+  it('drops the soft-delete field when includeDeleted is set', async () => {
+    const { adapter, scopes } = recordingAdapter();
+    await batchLoadRelations([{ id: 'c1', postId: 'p1' }], metaWith({ post: scopedRel }), adapter, {
+      relations: ['post'],
+      scope: { tenantId: 'A', includeDeleted: true },
+    });
+    expect(scopes[0]).toMatchObject({ tenantField: 'authorId', tenantValue: 'A' });
+    expect((scopes[0] as { excludeDeletedField?: string }).excludeDeletedField).toBeUndefined();
+  });
+
+  it('passes undefined when the relation declares no scope', async () => {
+    const { adapter, scopes } = recordingAdapter();
+    await batchLoadRelations(
+      [{ id: 'c1', postId: 'p1' }],
+      metaWith({ post: belongsTo({ foreignKey: 'postId', localKey: 'id' }) }),
+      adapter,
+      { relations: ['post'], scope: { tenantId: 'A' } },
+    );
+    expect(scopes[0]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

The owner-scope on relation includes (from #75) ran as a **post-fetch** filter in the core orchestrator: related rows were fetched by foreign key, then cross-tenant / soft-deleted ones were dropped before the response. Correct and leak-free, but it over-fetched.

This pushes the scope into the adapter query: the resolved scope (tenant column + value, soft-delete column) is threaded into each adapter's `fetchRelated`, so it becomes a **WHERE clause** (drizzle / prisma) or a store-scan predicate (memory). Disallowed rows are never fetched.

```ts
// core/relations/batch-loader.ts
const fetchScope = resolveFetchScope(config, requestScope);   // { tenantField, tenantValue, excludeDeletedField } | undefined
const fetched = await adapter.fetchRelated(handle, keyField, values, fetchScope);
const records = applyRelationScope(fetched, config, requestScope); // defense-in-depth net stays
```

The orchestrator keeps its post-fetch `applyRelationScope` as a **defense-in-depth net** — adapters that ignore the scope arg are still filtered there, so correctness never depends on the push-down.

## API

- New internal `RelationFetchScope` type + `resolveFetchScope` helper.
- `FetchRelated` / `SyncFetchRelated` gain an optional 4th `scope` argument. **Backward-compatible**: a 3-arg adapter `fetchRelated` is still assignable.
- drizzle (`eq` + `isNull` into the WHERE), prisma (extra `where` keys), memory (store-scan filter) apply the scope.

## Tests

- 3 new orchestrator cases: the resolved scope (tenant + soft-delete) is passed to `fetchRelated`; the soft-delete field drops out under `includeDeleted`; `undefined` when the relation has no `scope`.
- A cross-adapter **relation-scoping conformance cell** (a `parent` self-relation, `scope` tied to `tenantId` + `deletedAt`): a cross-tenant parent and a soft-deleted parent both resolve to `null` through `?include=parent`. Runs on memory + drizzle; **named skip** on the prisma leg (its fixed examples `users` schema has no self-relation column).
- `pnpm test:unit` → **1233 passed**; `pnpm -r build` + `pnpm -r typecheck` clean (clean build, no DTS-cache masking).

## Versioning

Changeset is **all patch** (core + the three adapters). Core stays in the sub-packages' `workspace:^` peer range → no version cascade (the lesson from #77).

Completes the upstream follow-ups flagged in #75 (push-down) and #78 (the deferred relation-scoping conformance cell).