### PR TITLE
fix(security): scope batch verbs to the caller's tenant

### DIFF
--- a/.changeset/batch-owner-scoping.md
+++ b/.changeset/batch-owner-scoping.md
@@ -1,0 +1,20 @@
+---
+"hono-crud": patch
+"@hono-crud/drizzle": patch
+"@hono-crud/memory": patch
+"@hono-crud/prisma": patch
+---
+
+fix(security): scope batch verbs to the caller's tenant
+
+`batchDelete`, `batchUpdate`, and `batchRestore` operated on a client-supplied
+id list without applying the model's `multiTenant` owner filter — unlike the
+single-row verbs, which get it via core-injected `additionalFilters`. A caller
+could delete, update, or restore **another tenant's rows** by passing their ids.
+
+Core now enforces tenant presence in each batch handler (`validateTenantId`,
+400 `TENANT_REQUIRED` when required), and exposes `getTenantScopeFilter()` which
+each adapter ANDs into its batch WHERE (drizzle/memory) or `findMany` lookup
+(prisma). Cross-tenant ids now fall through to `notFound`; the row is untouched.
+
+Covered by a new cross-adapter conformance cell (`batch-tenant-scoping`).

--- a/packages/core/src/endpoints/base.ts
+++ b/packages/core/src/endpoints/base.ts
@@ -273,6 +273,21 @@ export abstract class CrudEndpoint<
   }
 
   /**
+   * The owner/tenant equality filter for the current request, or `undefined`
+   * when multi-tenancy is off or no tenant is resolved. Adapters AND it into
+   * batch-operation WHERE clauses so `batchUpdate` / `batchDelete` /
+   * `batchRestore` only ever touch the caller's own rows — single-row verbs get
+   * this via core-injected `additionalFilters`, but the batch verbs operate on a
+   * client-supplied id list and must constrain it the same way.
+   */
+  protected getTenantScopeFilter(): { field: string; value: string } | undefined {
+    const config = this.getMultiTenantConfig();
+    if (!config.enabled) return undefined;
+    const tenantId = this.getTenantId();
+    return tenantId == null ? undefined : { field: config.field, value: tenantId };
+  }
+
+  /**
    * Validates that tenant ID is present when required.
    * Throws a 400 `TENANT_REQUIRED` ApiException if missing and required.
    */

--- a/packages/core/src/endpoints/batch-delete.ts
+++ b/packages/core/src/endpoints/batch-delete.ts
@@ -157,6 +157,9 @@ export abstract class BatchDeleteEndpoint<
    * Main handler for the batch delete operation.
    */
   async handle(): Promise<Response> {
+    // Enforce tenant presence (required tenants 400 instead of touching every
+    // row); the adapter's `batchDelete` AND-s the tenant filter into its WHERE.
+    this.validateTenantId();
     const ids = await this.getIds();
     const errors: Array<{ id: string; error: string }> = [];
 

--- a/packages/core/src/endpoints/batch-restore.ts
+++ b/packages/core/src/endpoints/batch-restore.ts
@@ -166,6 +166,9 @@ export abstract class BatchRestoreEndpoint<
       );
     }
 
+    // Enforce tenant presence; the adapter's `batchRestore` AND-s the tenant
+    // filter into its WHERE so a caller can't restore another tenant's rows.
+    this.validateTenantId();
     const ids = await this.getIds();
     const errors: Array<{ id: string; error: string }> = [];
 

--- a/packages/core/src/endpoints/batch-update.ts
+++ b/packages/core/src/endpoints/batch-update.ts
@@ -215,6 +215,9 @@ export abstract class BatchUpdateEndpoint<
    * Main handler for the batch update operation.
    */
   async handle(): Promise<Response> {
+    // Enforce tenant presence; the adapter's `batchUpdate` AND-s the tenant
+    // filter into each item's WHERE so cross-tenant rows are never updated.
+    this.validateTenantId();
     const items = await this.getItems();
     const errors: Array<{ id: string; error: string }> = [];
 

--- a/packages/drizzle/src/batch.ts
+++ b/packages/drizzle/src/batch.ts
@@ -93,6 +93,9 @@ export abstract class DrizzleBatchUpdateEndpoint<
     const softDeleteConfig = this.getSoftDeleteConfig();
     const updated: ModelObject<M['model']>[] = [];
     const notFound: string[] = [];
+    // Owner-scope: only the caller's own rows are updatable (cross-tenant ids fall
+    // through to `notFound`).
+    const tenant = this.getTenantScopeFilter();
 
     // Process each update individually (Drizzle doesn't have bulk update with different values)
     for (const item of items) {
@@ -101,6 +104,10 @@ export abstract class DrizzleBatchUpdateEndpoint<
       // Filter out soft-deleted records
       if (softDeleteConfig.enabled) {
         conditions.push(isNull(this.getColumn(softDeleteConfig.field)));
+      }
+
+      if (tenant) {
+        conditions.push(eq(this.getColumn(tenant.field), tenant.value));
       }
 
       const result = await cast<ModelObject<M['model']>>(this.getDb())
@@ -160,6 +167,12 @@ export abstract class DrizzleBatchDeleteEndpoint<
     // For soft delete, exclude already-deleted records
     if (softDeleteConfig.enabled) {
       conditions.push(isNull(this.getColumn(softDeleteConfig.field)));
+    }
+
+    // Owner-scope: only the caller's own rows are deletable.
+    const tenant = this.getTenantScopeFilter();
+    if (tenant) {
+      conditions.push(eq(this.getColumn(tenant.field), tenant.value));
     }
 
     let result: ModelObject<M['model']>[];
@@ -228,6 +241,12 @@ export abstract class DrizzleBatchRestoreEndpoint<
       inArray(lookupColumn, ids),
       isNotNull(this.getColumn(softDeleteConfig.field)),
     ];
+
+    // Owner-scope: only the caller's own rows are restorable.
+    const tenant = this.getTenantScopeFilter();
+    if (tenant) {
+      conditions.push(eq(this.getColumn(tenant.field), tenant.value));
+    }
 
     // Set deletedAt to null to restore the records
     const result = await cast<ModelObject<M['model']>>(this.getDb())

--- a/packages/memory/src/batch.ts
+++ b/packages/memory/src/batch.ts
@@ -58,11 +58,18 @@ export abstract class MemoryBatchUpdateEndpoint<
     const softDeleteConfig = this.getSoftDeleteConfig();
     const updated: ModelObject<M['model']>[] = [];
     const notFound: string[] = [];
+    const tenant = this.getTenantScopeFilter();
 
     for (const item of items) {
       const existing = store.get(item.id);
 
       if (!existing) {
+        notFound.push(item.id);
+        continue;
+      }
+
+      // Owner-scope: another tenant's row is not the caller's to update.
+      if (tenant && (existing as Record<string, unknown>)[tenant.field] !== tenant.value) {
         notFound.push(item.id);
         continue;
       }
@@ -99,11 +106,18 @@ export abstract class MemoryBatchDeleteEndpoint<
     const softDeleteConfig = this.getSoftDeleteConfig();
     const deleted: ModelObject<M['model']>[] = [];
     const notFound: string[] = [];
+    const tenant = this.getTenantScopeFilter();
 
     for (const id of ids) {
       const existing = store.get(id);
 
       if (!existing) {
+        notFound.push(id);
+        continue;
+      }
+
+      // Owner-scope: another tenant's row is not the caller's to delete.
+      if (tenant && (existing as Record<string, unknown>)[tenant.field] !== tenant.value) {
         notFound.push(id);
         continue;
       }
@@ -147,11 +161,18 @@ export abstract class MemoryBatchRestoreEndpoint<
     const softDeleteConfig = this.getSoftDeleteConfig();
     const restored: ModelObject<M['model']>[] = [];
     const notFound: string[] = [];
+    const tenant = this.getTenantScopeFilter();
 
     for (const id of ids) {
       const existing = store.get(id);
 
       if (!existing) {
+        notFound.push(id);
+        continue;
+      }
+
+      // Owner-scope: another tenant's row is not the caller's to restore.
+      if (tenant && (existing as Record<string, unknown>)[tenant.field] !== tenant.value) {
         notFound.push(id);
         continue;
       }

--- a/packages/prisma/src/batch.ts
+++ b/packages/prisma/src/batch.ts
@@ -151,6 +151,13 @@ export abstract class PrismaBatchUpdateEndpoint<
       where[softDeleteConfig.field] = null;
     }
 
+    // Owner-scope: only the caller's own rows are loaded, so cross-tenant ids
+    // never match and fall through to `notFound`.
+    const tenant = this.getTenantScopeFilter();
+    if (tenant) {
+      where[tenant.field] = tenant.value;
+    }
+
     // Batch lookup: Find all existing records in a single query (fixes N+1)
     const existingRecords = await model.findMany({ where });
 
@@ -215,6 +222,13 @@ export abstract class PrismaBatchDeleteEndpoint<
     // For soft delete, exclude already-deleted records
     if (softDeleteConfig.enabled) {
       where[softDeleteConfig.field] = null;
+    }
+
+    // Owner-scope: only the caller's own rows are loaded, so cross-tenant ids
+    // never match and fall through to `notFound`.
+    const tenant = this.getTenantScopeFilter();
+    if (tenant) {
+      where[tenant.field] = tenant.value;
     }
 
     // Batch lookup: Find all existing records in a single query (fixes N+1)
@@ -290,6 +304,13 @@ export abstract class PrismaBatchRestoreEndpoint<
       [this.lookupField]: { in: ids },
       [softDeleteConfig.field]: { not: null },
     };
+
+    // Owner-scope: only the caller's own rows are loaded, so cross-tenant ids
+    // never match and fall through to `notFound`.
+    const tenant = this.getTenantScopeFilter();
+    if (tenant) {
+      where[tenant.field] = tenant.value;
+    }
 
     // Batch lookup: Find all deleted records in a single query (fixes N+1)
     const existingRecords = await model.findMany({ where });

--- a/tests/conformance/adapters/drizzle.ts
+++ b/tests/conformance/adapters/drizzle.ts
@@ -16,6 +16,8 @@ import { join } from 'node:path';
 import {
   DrizzleBatchCreateEndpoint,
   DrizzleBatchDeleteEndpoint,
+  DrizzleBatchRestoreEndpoint,
+  DrizzleBatchUpdateEndpoint,
   DrizzleBatchUpsertEndpoint,
   DrizzleBulkPatchEndpoint,
   DrizzleCreateEndpoint,
@@ -213,6 +215,18 @@ class TenantList extends DrizzleListEndpoint {
   db = DB;
   protected override allowedIncludes = ['parent'];
 }
+class TenantBatchDelete extends DrizzleBatchDeleteEndpoint {
+  _meta = tenantMeta;
+  db = DB;
+}
+class TenantBatchUpdate extends DrizzleBatchUpdateEndpoint {
+  _meta = tenantMeta;
+  db = DB;
+}
+class TenantBatchRestore extends DrizzleBatchRestoreEndpoint {
+  _meta = tenantMeta;
+  db = DB;
+}
 
 class FinalizeCreate extends DrizzleCreateEndpoint {
   _meta = finalizeMeta;
@@ -319,6 +333,9 @@ async function setup(): Promise<AdapterContext> {
     read: TenantRead,
     update: TenantUpdate,
     delete: TenantDelete,
+    batchUpdate: TenantBatchUpdate,
+    batchDelete: TenantBatchDelete,
+    batchRestore: TenantBatchRestore,
   });
   registerCrud(app, '/finalize-items', {
     create: FinalizeCreate,
@@ -351,6 +368,7 @@ export const drizzleConformance: AdapterDescriptor = {
     timestampKind: 'epoch-ms',
     transactionalHooks: 'rollback',
     relationScoping: true,
+    batchTenantScoping: true,
   },
   tenant: {
     field: 'tenantId',

--- a/tests/conformance/adapters/memory.ts
+++ b/tests/conformance/adapters/memory.ts
@@ -13,6 +13,8 @@ import {
   MEMORY_NOOP_TX,
   MemoryBatchCreateEndpoint,
   MemoryBatchDeleteEndpoint,
+  MemoryBatchRestoreEndpoint,
+  MemoryBatchUpdateEndpoint,
   MemoryBatchUpsertEndpoint,
   MemoryBulkPatchEndpoint,
   MemoryCreateEndpoint,
@@ -155,6 +157,15 @@ class TenantList extends MemoryListEndpoint {
   _meta = tenantMeta;
   protected override allowedIncludes = ['parent'];
 }
+class TenantBatchDelete extends MemoryBatchDeleteEndpoint {
+  _meta = tenantMeta;
+}
+class TenantBatchUpdate extends MemoryBatchUpdateEndpoint {
+  _meta = tenantMeta;
+}
+class TenantBatchRestore extends MemoryBatchRestoreEndpoint {
+  _meta = tenantMeta;
+}
 
 class FinalizeCreate extends MemoryCreateEndpoint {
   _meta = finalizeMeta;
@@ -240,6 +251,9 @@ async function setup(): Promise<AdapterContext> {
     read: TenantRead,
     update: TenantUpdate,
     delete: TenantDelete,
+    batchUpdate: TenantBatchUpdate,
+    batchDelete: TenantBatchDelete,
+    batchRestore: TenantBatchRestore,
   });
   registerCrud(app, '/finalize-items', {
     create: FinalizeCreate,
@@ -268,6 +282,7 @@ export const memoryConformance: AdapterDescriptor = {
     timestampKind: 'epoch-ms',
     transactionalHooks: 'noop-sentinel',
     relationScoping: true,
+    batchTenantScoping: true,
   },
   tenant: {
     field: 'tenantId',

--- a/tests/conformance/adapters/prisma.ts
+++ b/tests/conformance/adapters/prisma.ts
@@ -329,6 +329,9 @@ export const prismaConformance: AdapterDescriptor = {
     // The prisma leg reuses the fixed examples `users` schema, which has no
     // self-relation column — the relation-scoping cell is a named skip here.
     relationScoping: false,
+    // No batch verbs are registered on the prisma tenant variant; the
+    // batch owner-scoping cell is a named skip here.
+    batchTenantScoping: false,
   },
   tenant: {
     field: 'status',

--- a/tests/conformance/cells/batch-tenant-scoping.ts
+++ b/tests/conformance/cells/batch-tenant-scoping.ts
@@ -1,0 +1,167 @@
+/**
+ * Cell — batch owner-scoping (`batchDelete` / `batchUpdate` / `batchRestore`).
+ *
+ * The single-row verbs get their tenant filter from core-injected
+ * `additionalFilters`, but the batch verbs operate on a client-supplied id list
+ * and so must constrain it themselves: core enforces tenant presence
+ * (`validateTenantId`) and each adapter ANDs the tenant equality into its WHERE
+ * (`getTenantScopeFilter`). The contract: a tenant can never delete / update /
+ * restore another tenant's row by id — the foreign id falls through to
+ * `notFound`, the row is untouched, and the caller's own ids still succeed.
+ *
+ * Skipped (named) on the prisma leg: its tenant variant reuses the fixed
+ * examples schema and registers no batch verbs.
+ */
+import { expect, test } from 'vitest';
+import {
+  type AdapterDescriptor,
+  type ConformanceRecord,
+  type CtxGetter,
+  createRecord,
+  expectError,
+  expectList,
+  expectSuccess,
+  jsonInit,
+  readJson,
+} from '../contract';
+
+interface BatchOpResult {
+  success: true;
+  result: {
+    count: number;
+    notFound?: string[];
+    deleted?: ConformanceRecord[];
+    updated?: ConformanceRecord[];
+    restored?: ConformanceRecord[];
+  };
+}
+
+export function registerBatchTenantScopingCells(
+  descriptor: AdapterDescriptor,
+  ctx: CtxGetter,
+): void {
+  const { headerName, tenantA, tenantB } = descriptor.tenant;
+  const asTenant = (tenant: string): Record<string, string> => ({ [headerName]: tenant });
+
+  const title =
+    'batch owner-scoping: tenant B cannot batchDelete/batchUpdate/batchRestore tenant A rows by id';
+
+  if (!descriptor.capabilities.batchTenantScoping) {
+    test.skip(`${title} [skipped: ${descriptor.name} registers no batch verbs on the tenant model]`, () => {});
+    return;
+  }
+
+  test(title, async () => {
+    const { app } = ctx();
+
+    const recordA = await createRecord(
+      app,
+      '/tenant-items',
+      { name: 'A Document', email: 'batch-tenant-a@conformance.test', role: 'user', age: 31 },
+      asTenant(tenantA),
+    );
+    const recordB = await createRecord(
+      app,
+      '/tenant-items',
+      { name: 'B Document', email: 'batch-tenant-b@conformance.test', role: 'user', age: 32 },
+      asTenant(tenantB),
+    );
+
+    // --- batchDelete: tenant B targets A's id ---------------------------------
+    const crossDelete = await readJson<BatchOpResult>(
+      await app.request(
+        '/tenant-items/batch',
+        jsonInit('DELETE', { ids: [recordA.id] }, asTenant(tenantB)),
+      ),
+    );
+    expect(crossDelete.result.count).toBe(0);
+    expect(crossDelete.result.deleted).toEqual([]);
+    expect(crossDelete.result.notFound).toEqual([recordA.id]);
+
+    // A is untouched — tenant A still reads it, alive.
+    const stillThere = await expectSuccess<ConformanceRecord>(
+      await app.request(`/tenant-items/${recordA.id}`, { headers: asTenant(tenantA) }),
+      200,
+    );
+    expect(stillThere.name).toBe('A Document');
+
+    // --- batchUpdate: tenant B targets A's id ---------------------------------
+    const crossUpdate = await readJson<BatchOpResult>(
+      await app.request(
+        '/tenant-items/batch',
+        jsonInit(
+          'PATCH',
+          { items: [{ id: recordA.id, data: { name: 'Hijacked' } }] },
+          asTenant(tenantB),
+        ),
+      ),
+    );
+    expect(crossUpdate.result.count).toBe(0);
+    expect(crossUpdate.result.updated).toEqual([]);
+    expect(crossUpdate.result.notFound).toEqual([recordA.id]);
+
+    // A's name is unchanged.
+    const reReadA = await expectSuccess<ConformanceRecord>(
+      await app.request(`/tenant-items/${recordA.id}`, { headers: asTenant(tenantA) }),
+      200,
+    );
+    expect(reReadA.name).toBe('A Document');
+
+    // --- batchRestore: tenant B targets A's soft-deleted id -------------------
+    // Tenant A soft-deletes its own row first.
+    await app.request(`/tenant-items/${recordA.id}`, {
+      method: 'DELETE',
+      headers: asTenant(tenantA),
+    });
+
+    const crossRestore = await readJson<BatchOpResult>(
+      await app.request(
+        '/tenant-items/batch/restore',
+        jsonInit('POST', { ids: [recordA.id] }, asTenant(tenantB)),
+      ),
+    );
+    expect(crossRestore.result.count).toBe(0);
+    expect(crossRestore.result.restored).toEqual([]);
+    expect(crossRestore.result.notFound).toEqual([recordA.id]);
+
+    // Still deleted for tenant A (positive control: A *can* restore its own row).
+    await expectError(
+      await app.request(`/tenant-items/${recordA.id}`, { headers: asTenant(tenantA) }),
+      404,
+      'NOT_FOUND',
+    );
+    const ownRestore = await readJson<BatchOpResult>(
+      await app.request(
+        '/tenant-items/batch/restore',
+        jsonInit('POST', { ids: [recordA.id] }, asTenant(tenantA)),
+      ),
+    );
+    expect(ownRestore.result.count).toBe(1);
+    expect(ownRestore.result.restored).toHaveLength(1);
+
+    // --- positive control: tenant B deletes its OWN row ----------------------
+    const ownDelete = await readJson<BatchOpResult>(
+      await app.request(
+        '/tenant-items/batch',
+        jsonInit('DELETE', { ids: [recordB.id] }, asTenant(tenantB)),
+      ),
+    );
+    expect(ownDelete.result.count).toBe(1);
+    expect(ownDelete.result.deleted).toHaveLength(1);
+
+    // Tenant A's list is back to exactly its one (restored) row.
+    const listA = await expectList(
+      await app.request('/tenant-items', { headers: asTenant(tenantA) }),
+    );
+    expect(listA.result.map((record) => record.id)).toEqual([recordA.id]);
+  });
+
+  test('batch owner-scoping: batch request without the tenant header → 400 TENANT_REQUIRED', async () => {
+    const { app } = ctx();
+    await expectError(
+      await app.request('/tenant-items/batch', jsonInit('DELETE', { ids: ['nonexistent'] })),
+      400,
+      'TENANT_REQUIRED',
+    );
+  });
+}

--- a/tests/conformance/cells/index.ts
+++ b/tests/conformance/cells/index.ts
@@ -7,6 +7,7 @@
  */
 import { afterAll, beforeAll, beforeEach } from 'vitest';
 import type { AdapterContext, AdapterDescriptor, CtxGetter } from '../contract';
+import { registerBatchTenantScopingCells } from './batch-tenant-scoping';
 import { registerBulkPatchCells } from './bulk-patch';
 import { registerCursorPaginationCells } from './cursor-pagination';
 import { registerEtagConcurrencyCells } from './etag-concurrency';
@@ -51,6 +52,7 @@ export function registerConformanceCells(descriptor: AdapterDescriptor): void {
   registerUniqueConflictCells(descriptor, ctx);
   registerTenantScopingCells(descriptor, ctx);
   registerRelationScopingCells(descriptor, ctx);
+  registerBatchTenantScopingCells(descriptor, ctx);
   registerFinalizePipelineCells(descriptor, ctx);
   registerUpsertRestoreCells(descriptor, ctx);
   registerTransactionalHookCells(descriptor, ctx);

--- a/tests/conformance/contract.ts
+++ b/tests/conformance/contract.ts
@@ -75,6 +75,14 @@ export interface ConformanceCapabilities {
    * column; the skip is named.
    */
   relationScoping: boolean;
+  /**
+   * Whether this leg registers batch verbs (`batchDelete` / `batchUpdate` /
+   * `batchRestore`) on the multi-tenant model, so the batch owner-scoping cell
+   * can assert a tenant cannot batch-mutate another tenant's rows by id. False
+   * on the prisma leg — its tenant variant reuses the fixed examples schema and
+   * registers no batch verbs there; the skip is named.
+   */
+  batchTenantScoping: boolean;
 }
 
 export interface HookObservation {


### PR DESCRIPTION
## The vulnerability

`batchDelete`, `batchUpdate`, and `batchRestore` operated on a **client-supplied id list** without applying the model's `multiTenant` owner filter. The single-row verbs (`delete`/`update`/`restore`) are owner-scoped because core injects the tenant equality into their `additionalFilters` — but the batch verbs never did. A caller could **delete, update, or restore another tenant's rows** simply by passing their ids.

This is the batch-write sibling of the relation include-leak fixed in 0.13.15.

## The fix

**Core** (`hono-crud`):
- Each batch handler now calls `validateTenantId()` up front → `400 TENANT_REQUIRED` when a tenant is required but absent (no longer scans every row first).
- New `getTenantScopeFilter()` on `CrudEndpoint` returns the `{ field, value }` equality for the current request (or `undefined` when multi-tenancy is off / no tenant resolved).

**Adapters** AND that filter into the batch query:
- `@hono-crud/drizzle` — `eq(getColumn(field), value)` pushed into each `batchUpdate`/`batchDelete`/`batchRestore` WHERE.
- `@hono-crud/memory` — per-row ownership check; foreign rows go to `notFound`.
- `@hono-crud/prisma` — `where[field] = value` on the `findMany` lookup, so cross-tenant ids never load and fall through to `notFound`.

Result: cross-tenant ids are reported in `notFound`, the rows are untouched; the caller's own ids still succeed.

## Tests

New cross-adapter conformance cell `batch-tenant-scoping` (capability `batchTenantScoping`, registered on the memory + drizzle tenant models; named-skip on the prisma leg which registers no batch verbs there). It asserts tenant B cannot batchDelete/batchUpdate/batchRestore tenant A's rows by id, with positive controls (B operates on its own rows; A restores its own row) and the missing-tenant `400`.

- `pnpm -r build` ✓
- `pnpm -r typecheck` ✓
- `pnpm test:unit` → **1237 passed | 41 skipped** (+4 new)

Changeset: all **`patch`** (core stays 0.x → no peer-cascade to 1.0.0).