### PR TITLE
fix(security): scope aggregate/search/export/bulk-patch verbs to the caller's tenant

### DIFF
--- a/.changeset/extended-verb-owner-scoping.md
+++ b/.changeset/extended-verb-owner-scoping.md
@@ -1,0 +1,36 @@
+---
+"hono-crud": patch
+"@hono-crud/drizzle": patch
+"@hono-crud/memory": patch
+"@hono-crud/prisma": patch
+---
+
+fix(security): scope aggregate/search/export/bulk-patch verbs to the caller's tenant
+
+`GET /resource/aggregate`, `GET /resource/search`, `GET /resource/export`, and
+`PATCH /resource/bulk` built their WHERE clause from the parsed request filters
+**without** applying the model's `multiTenant` owner filter. Only `ListEndpoint`
+re-applied the tenant scope in its handler; these four verbs did not (and
+`ExportEndpoint` overrides `ListEndpoint.handle`, so it didn't inherit it). A
+caller could therefore aggregate, search, export, or bulk-patch across **every
+tenant's rows**, regardless of `Model.multiTenant`.
+
+Owner-scoping is now centralized in a single auditable core helper,
+`applyTenantScope` (plus `applyTenantScopeToAggregateFilters` for the aggregate
+`Record`-shaped WHERE), which `ListEndpoint` and all four verbs call after
+parsing filters and before running the query. Each verb now enforces tenant
+presence (`validateTenantId`, 400 `TENANT_REQUIRED` when required) and ANDs the
+owner equality into the adapter WHERE — so a tenant's aggregate counts, search
+hits, export rows, and bulk-patch matches are confined to its own rows.
+
+A second leak on the same verbs is also closed: `search` and `export` loaded
+`?include=` relations WITHOUT the owner `scope` that `list`/`read` pass, so an
+embedded related row could cross tenants even when the parent rows were scoped.
+All three adapters (drizzle, memory, prisma) now thread `getRelationScope(...)`
+into the search/export relation loader, matching List.
+
+Covered by a new cross-adapter conformance cell (`extended-verb-tenant-scoping`)
+asserting per-tenant aggregate counts (incl. a grouped aggregation), search /
+export / bulk-patch isolation, the `TENANT_REQUIRED` contract, AND that
+`?include=` on search/export never embeds another tenant's related row — across
+the memory and drizzle legs.

--- a/packages/core/src/endpoints/aggregate.ts
+++ b/packages/core/src/endpoints/aggregate.ts
@@ -268,6 +268,11 @@ export abstract class AggregateEndpoint<
   async handle(): Promise<Response> {
     const options = await this.getAggregateOptions();
 
+    // Force the owner field to the caller's tenant so aggregations only ever
+    // span the caller's own rows. The aggregate WHERE clause is a Record, so
+    // this overwrites any client-supplied value for the owner field.
+    options.filters = this.applyTenantScopeToAggregateFilters(options.filters);
+
     // Ensure at least one aggregation is requested
     if (options.aggregations.length === 0) {
       // Default to COUNT(*)

--- a/packages/core/src/endpoints/base.ts
+++ b/packages/core/src/endpoints/base.ts
@@ -34,6 +34,7 @@ import { getSoftDeleteConfig } from '../core/soft-delete';
 import {
   type FilterCondition,
   type HookContext,
+  type ListFilters,
   type MetaInput,
   type ModelPolicies,
   type NormalizedAuditConfig,
@@ -285,6 +286,47 @@ export abstract class CrudEndpoint<
     if (!config.enabled) return undefined;
     const tenantId = this.getTenantId();
     return tenantId == null ? undefined : { field: config.field, value: tenantId };
+  }
+
+  /**
+   * Constrain a parsed `ListFilters` to the caller's tenant by appending the
+   * owner equality condition. This is the single, auditable owner-scope
+   * injection that EVERY read/bulk verb building a `ListFilters` and handing it
+   * to the adapter (`list`, `search`, `export`, `bulkPatch`) MUST call AFTER
+   * parsing filters and BEFORE running the query, so the owner equality is
+   * `AND`ed into the adapter WHERE clause and a client cannot read or mutate
+   * another tenant's rows. Centralizing it here prevents the per-verb drift
+   * that produced the recurring multi-tenant leak class — a new verb that
+   * forgets to call it is the only way to reintroduce the hole.
+   *
+   * No-op when multi-tenancy is disabled. Throws `TENANT_REQUIRED` (400) when a
+   * tenant is required but absent — identical contract to {@link validateTenantId},
+   * which List already relies on.
+   */
+  protected applyTenantScope(filters: ListFilters): void {
+    const tenantId = this.validateTenantId();
+    if (!tenantId) return;
+    filters.filters.push({
+      field: this.getMultiTenantConfig().field,
+      operator: 'eq',
+      value: tenantId,
+    });
+  }
+
+  /**
+   * Aggregate-shaped owner scope. The aggregate WHERE clause is a
+   * `Record<field, value>` map (not `FilterCondition[]`), so this forces the
+   * owner field to the caller's tenant — overwriting any client-supplied value
+   * for that field — making cross-tenant aggregation impossible. Returns the
+   * scoped record. Same no-op / `TENANT_REQUIRED` contract as
+   * {@link applyTenantScope}.
+   */
+  protected applyTenantScopeToAggregateFilters(
+    filters: Record<string, unknown> | undefined,
+  ): Record<string, unknown> | undefined {
+    const tenantId = this.validateTenantId();
+    if (!tenantId) return filters;
+    return { ...(filters ?? {}), [this.getMultiTenantConfig().field]: tenantId };
   }
 
   /**

--- a/packages/core/src/endpoints/bulk-patch.ts
+++ b/packages/core/src/endpoints/bulk-patch.ts
@@ -150,6 +150,11 @@ export abstract class BulkPatchEndpoint<
       } as ListFilterParseOptions,
     );
 
+    // Constrain the matched set to the caller's tenant BEFORE counting or
+    // patching — both countMatching and applyPatch receive these filters, so a
+    // bulk patch can never count, dry-run, or mutate another tenant's rows.
+    this.applyTenantScope(filters);
+
     // Count matching records
     const matchedCount = await this.countMatching(filters);
 

--- a/packages/core/src/endpoints/export.ts
+++ b/packages/core/src/endpoints/export.ts
@@ -366,6 +366,12 @@ export abstract class ExportEndpoint<
     const exportOptions = await this.getExportOptions();
     const filters = await this.getFilters();
 
+    // ExportEndpoint overrides ListEndpoint.handle and therefore does NOT
+    // inherit List's tenant injection — apply it explicitly so neither the
+    // streaming nor the buffered path can export another tenant's rows. Both
+    // paths below consume this same `filters` object.
+    this.applyTenantScope(filters);
+
     // Use paginated streaming for CSV when streaming is requested
     if (exportOptions.format === 'csv' && exportOptions.stream) {
       return this.exportAsCsvStreamPaginated(filters, exportOptions.format);

--- a/packages/core/src/endpoints/list.ts
+++ b/packages/core/src/endpoints/list.ts
@@ -381,20 +381,18 @@ export abstract class ListEndpoint<
       );
     }
 
-    // Validate tenant ID if multi-tenancy is enabled
-    const tenantId = this.validateTenantId();
+    // Validate tenant presence BEFORE parsing the query so a missing required
+    // tenant surfaces TENANT_REQUIRED ahead of any query-validation error
+    // (parity with the pre-refactor List contract).
+    this.validateTenantId();
 
     const filters = await this.getFilters();
 
-    // Inject tenant filter if multi-tenancy is enabled
-    if (tenantId) {
-      const config = this.getMultiTenantConfig();
-      filters.filters.push({
-        field: config.field,
-        operator: 'eq',
-        value: tenantId,
-      });
-    }
+    // Constrain results to the caller's tenant. Shared with search/export/
+    // bulk-patch via `applyTenantScope` so owner-scoping has a single auditable
+    // implementation and cannot drift per verb (`applyTenantScope` re-validates
+    // the tenant idempotently, then performs the owner-scope injection).
+    this.applyTenantScope(filters);
 
     // Inject policy `readPushdown` filters (cheap perf opt-in: lets the
     // adapter exclude rows at the SQL level rather than post-fetch).

--- a/packages/core/src/endpoints/search.ts
+++ b/packages/core/src/endpoints/search.ts
@@ -510,6 +510,10 @@ export abstract class SearchEndpoint<
     let searchOptions = await this.getSearchOptions();
     const filters = await this.getFilters();
 
+    // Constrain the search to the caller's tenant before the adapter runs the
+    // query. Without this, GET /resource/search reads across all tenants.
+    this.applyTenantScope(filters);
+
     // Validate query length
     if (!searchOptions.query || searchOptions.query.length < this.minQueryLength) {
       throw new ApiException(

--- a/packages/drizzle/src/advanced.ts
+++ b/packages/drizzle/src/advanced.ts
@@ -873,7 +873,13 @@ export abstract class DrizzleSearchEndpoint<
     const searchResults = searchInMemory(records, scoringOptions, searchableFields);
 
     // Load relations if requested using batch loading to avoid N+1 queries
-    const includeOptions: IncludeOptions = { relations: filters.options.include || [] };
+    const includeOptions: IncludeOptions = {
+      relations: filters.options.include || [],
+      // Owner-scope the included relations exactly as List/Read do — without
+      // this, `?include=` on search/export loads related rows cross-tenant even
+      // though the parent rows are scoped (the multi-tenant include-leak class).
+      scope: this.getRelationScope(filters.options.withDeleted),
+    };
 
     // Extract items for batch relation loading
     const items = searchResults.map((r) => r.item);
@@ -942,7 +948,13 @@ export abstract class DrizzleExportEndpoint<
     });
 
     // Load relations if requested using batch loading to avoid N+1 queries
-    const includeOptions: IncludeOptions = { relations: filters.options.include || [] };
+    const includeOptions: IncludeOptions = {
+      relations: filters.options.include || [],
+      // Owner-scope the included relations exactly as List/Read do — without
+      // this, `?include=` on search/export loads related rows cross-tenant even
+      // though the parent rows are scoped (the multi-tenant include-leak class).
+      scope: this.getRelationScope(filters.options.withDeleted),
+    };
     const itemsWithRelations = await batchLoadDrizzleRelations(
       this.getDb(),
       queryResult.records,

--- a/packages/memory/src/advanced.ts
+++ b/packages/memory/src/advanced.ts
@@ -552,7 +552,13 @@ export abstract class MemorySearchEndpoint<
     const paginatedResults = searchResults.slice(start, start + perPage);
 
     // Load relations if requested
-    const includeOptions: IncludeOptions = { relations: filters.options.include || [] };
+    const includeOptions: IncludeOptions = {
+      relations: filters.options.include || [],
+      // Owner-scope the included relations exactly as List/Read do — without
+      // this, `?include=` on search/export loads related rows cross-tenant even
+      // though the parent rows are scoped (the multi-tenant include-leak class).
+      scope: this.getRelationScope(filters.options.withDeleted),
+    };
     const resultsWithRelations = paginatedResults.map((result) => ({
       ...result,
       item: loadRelations(
@@ -589,7 +595,13 @@ export abstract class MemoryExportEndpoint<
     const paginatedItems = items.slice(start, start + perPage);
 
     // Load relations if requested
-    const includeOptions: IncludeOptions = { relations: filters.options.include || [] };
+    const includeOptions: IncludeOptions = {
+      relations: filters.options.include || [],
+      // Owner-scope the included relations exactly as List/Read do — without
+      // this, `?include=` on search/export loads related rows cross-tenant even
+      // though the parent rows are scoped (the multi-tenant include-leak class).
+      scope: this.getRelationScope(filters.options.withDeleted),
+    };
     const itemsWithRelations = paginatedItems.map(
       (item) =>
         loadRelations(item as Record<string, unknown>, this._meta, includeOptions) as ModelObject<

--- a/packages/prisma/src/advanced.ts
+++ b/packages/prisma/src/advanced.ts
@@ -162,7 +162,13 @@ export abstract class PrismaSearchEndpoint<
     const searchResults = searchInMemory(records, scoringOptions, this.getSearchableFields());
 
     // Load relations if requested using batch loading to avoid N+1 queries
-    const includeOptions: IncludeOptions = { relations: filters.options.include || [] };
+    const includeOptions: IncludeOptions = {
+      relations: filters.options.include || [],
+      // Owner-scope the included relations exactly as List/Read do — without
+      // this, `?include=` on search/export loads related rows cross-tenant even
+      // though the parent rows are scoped (the multi-tenant include-leak class).
+      scope: this.getRelationScope(filters.options.withDeleted),
+    };
     const items = searchResults.map((r) => r.item);
     const itemsWithRelations = await batchLoadPrismaRelations(
       getPrismaClient(this),
@@ -209,7 +215,13 @@ export abstract class PrismaExportEndpoint<
     });
 
     // Load relations if requested using batch loading to avoid N+1 queries
-    const includeOptions: IncludeOptions = { relations: filters.options.include || [] };
+    const includeOptions: IncludeOptions = {
+      relations: filters.options.include || [],
+      // Owner-scope the included relations exactly as List/Read do — without
+      // this, `?include=` on search/export loads related rows cross-tenant even
+      // though the parent rows are scoped (the multi-tenant include-leak class).
+      scope: this.getRelationScope(filters.options.withDeleted),
+    };
     const itemsWithRelations = await batchLoadPrismaRelations(
       getPrismaClient(this),
       queryResult.records,

--- a/tests/conformance/adapters/drizzle.ts
+++ b/tests/conformance/adapters/drizzle.ts
@@ -14,6 +14,7 @@ import { join } from 'node:path';
  *   `db.transaction(...)`; an after-hook throw rolls the INSERT back.
  */
 import {
+  DrizzleAggregateEndpoint,
   DrizzleBatchCreateEndpoint,
   DrizzleBatchDeleteEndpoint,
   DrizzleBatchRestoreEndpoint,
@@ -23,9 +24,11 @@ import {
   DrizzleCreateEndpoint,
   type DrizzleDatabaseConstraint,
   DrizzleDeleteEndpoint,
+  DrizzleExportEndpoint,
   DrizzleListEndpoint,
   DrizzleReadEndpoint,
   DrizzleRestoreEndpoint,
+  DrizzleSearchEndpoint,
   DrizzleUpdateEndpoint,
   DrizzleUpsertEndpoint,
 } from '@hono-crud/drizzle';
@@ -227,6 +230,29 @@ class TenantBatchRestore extends DrizzleBatchRestoreEndpoint {
   _meta = tenantMeta;
   db = DB;
 }
+class TenantAggregate extends DrizzleAggregateEndpoint {
+  _meta = tenantMeta;
+  db = DB;
+  protected override filterFields = ['role'];
+}
+class TenantSearch extends DrizzleSearchEndpoint {
+  _meta = tenantMeta;
+  db = DB;
+  protected override searchFields = ['name'];
+  protected override filterFields = ['role'];
+  protected override allowedIncludes = ['parent'];
+}
+class TenantExport extends DrizzleExportEndpoint {
+  _meta = tenantMeta;
+  db = DB;
+  protected override filterFields = ['role'];
+  protected override allowedIncludes = ['parent'];
+}
+class TenantBulkPatch extends DrizzleBulkPatchEndpoint {
+  _meta = tenantMeta;
+  db = DB;
+  protected override filterFields = ['role'];
+}
 
 class FinalizeCreate extends DrizzleCreateEndpoint {
   _meta = finalizeMeta;
@@ -336,6 +362,10 @@ async function setup(): Promise<AdapterContext> {
     batchUpdate: TenantBatchUpdate,
     batchDelete: TenantBatchDelete,
     batchRestore: TenantBatchRestore,
+    aggregate: TenantAggregate,
+    search: TenantSearch,
+    export: TenantExport,
+    bulkPatch: TenantBulkPatch,
   });
   registerCrud(app, '/finalize-items', {
     create: FinalizeCreate,
@@ -369,6 +399,7 @@ export const drizzleConformance: AdapterDescriptor = {
     transactionalHooks: 'rollback',
     relationScoping: true,
     batchTenantScoping: true,
+    extendedVerbTenantScoping: true,
   },
   tenant: {
     field: 'tenantId',

--- a/tests/conformance/adapters/memory.ts
+++ b/tests/conformance/adapters/memory.ts
@@ -11,6 +11,7 @@
  */
 import {
   MEMORY_NOOP_TX,
+  MemoryAggregateEndpoint,
   MemoryBatchCreateEndpoint,
   MemoryBatchDeleteEndpoint,
   MemoryBatchRestoreEndpoint,
@@ -19,9 +20,11 @@ import {
   MemoryBulkPatchEndpoint,
   MemoryCreateEndpoint,
   MemoryDeleteEndpoint,
+  MemoryExportEndpoint,
   MemoryListEndpoint,
   MemoryReadEndpoint,
   MemoryRestoreEndpoint,
+  MemorySearchEndpoint,
   MemoryUpdateEndpoint,
   MemoryUpsertEndpoint,
   clearStorage,
@@ -166,6 +169,25 @@ class TenantBatchUpdate extends MemoryBatchUpdateEndpoint {
 class TenantBatchRestore extends MemoryBatchRestoreEndpoint {
   _meta = tenantMeta;
 }
+class TenantAggregate extends MemoryAggregateEndpoint {
+  _meta = tenantMeta;
+  protected override filterFields = ['role'];
+}
+class TenantSearch extends MemorySearchEndpoint {
+  _meta = tenantMeta;
+  protected override searchFields = ['name'];
+  protected override filterFields = ['role'];
+  protected override allowedIncludes = ['parent'];
+}
+class TenantExport extends MemoryExportEndpoint {
+  _meta = tenantMeta;
+  protected override filterFields = ['role'];
+  protected override allowedIncludes = ['parent'];
+}
+class TenantBulkPatch extends MemoryBulkPatchEndpoint {
+  _meta = tenantMeta;
+  protected override filterFields = ['role'];
+}
 
 class FinalizeCreate extends MemoryCreateEndpoint {
   _meta = finalizeMeta;
@@ -254,6 +276,10 @@ async function setup(): Promise<AdapterContext> {
     batchUpdate: TenantBatchUpdate,
     batchDelete: TenantBatchDelete,
     batchRestore: TenantBatchRestore,
+    aggregate: TenantAggregate,
+    search: TenantSearch,
+    export: TenantExport,
+    bulkPatch: TenantBulkPatch,
   });
   registerCrud(app, '/finalize-items', {
     create: FinalizeCreate,
@@ -283,6 +309,7 @@ export const memoryConformance: AdapterDescriptor = {
     transactionalHooks: 'noop-sentinel',
     relationScoping: true,
     batchTenantScoping: true,
+    extendedVerbTenantScoping: true,
   },
   tenant: {
     field: 'tenantId',

--- a/tests/conformance/adapters/prisma.ts
+++ b/tests/conformance/adapters/prisma.ts
@@ -332,6 +332,10 @@ export const prismaConformance: AdapterDescriptor = {
     // No batch verbs are registered on the prisma tenant variant; the
     // batch owner-scoping cell is a named skip here.
     batchTenantScoping: false,
+    // Likewise the extended read/bulk verbs (aggregate/search/export/bulkPatch)
+    // are not registered on the prisma tenant variant; the extended-verb
+    // owner-scoping cell is a named skip here.
+    extendedVerbTenantScoping: false,
   },
   tenant: {
     field: 'status',

--- a/tests/conformance/cells/extended-verb-tenant-scoping.ts
+++ b/tests/conformance/cells/extended-verb-tenant-scoping.ts
@@ -1,0 +1,233 @@
+/**
+ * Cell — extended-verb owner-scoping (`aggregate` / `search` / `export` /
+ * `bulkPatch`).
+ *
+ * These four verbs build their WHERE clause from a parsed filter set (a
+ * `ListFilters` for search/export/bulkPatch, an `AggregateOptions.filters`
+ * record for aggregate) rather than from a client-supplied id list. Unlike the
+ * single-row verbs they do NOT receive a core-injected `additionalFilters`, and
+ * unlike List they used to run their handler without re-applying the tenant
+ * scope at all — so each could read, aggregate, or mutate across every tenant.
+ *
+ * The contract under test (core `applyTenantScope` / `applyTenantScopeToAggregateFilters`):
+ *   - aggregate counts only the caller's rows,
+ *   - search never returns another tenant's rows,
+ *   - export never includes another tenant's rows,
+ *   - bulkPatch never matches or mutates another tenant's rows,
+ *   - and each verb 400s with TENANT_REQUIRED when the tenant is absent.
+ *
+ * Skipped (named) on the prisma leg: its tenant variant reuses the fixed
+ * examples schema and registers none of these verbs.
+ */
+import { expect, test } from 'vitest';
+import {
+  type AdapterDescriptor,
+  type ConformanceRecord,
+  type CtxGetter,
+  createRecord,
+  expectError,
+  expectSuccess,
+  jsonInit,
+  readJson,
+} from '../contract';
+
+interface AggregateCountResult {
+  values: { count: number };
+}
+
+interface AggregateGroupResult {
+  groups: Array<{ key: Record<string, unknown>; values: { count?: number } }>;
+}
+
+interface SearchEnvelope {
+  success: true;
+  result: Array<{ item: ConformanceRecord; score?: number }>;
+}
+
+interface ExportResult {
+  data: ConformanceRecord[];
+  count: number;
+  format: string;
+  exportedAt: string;
+}
+
+interface BulkPatchResponse {
+  success: true;
+  matched: number;
+  updated: number;
+  dryRun: boolean;
+}
+
+export function registerExtendedVerbTenantScopingCells(
+  descriptor: AdapterDescriptor,
+  ctx: CtxGetter,
+): void {
+  const { headerName, tenantA, tenantB } = descriptor.tenant;
+  const asTenant = (tenant: string): Record<string, string> => ({ [headerName]: tenant });
+
+  const title =
+    'extended-verb owner-scoping: aggregate/search/export/bulkPatch never cross tenants';
+
+  if (!descriptor.capabilities.extendedVerbTenantScoping) {
+    test.skip(`${title} [skipped: ${descriptor.name} registers no aggregate/search/export/bulkPatch on the tenant model]`, () => {});
+    return;
+  }
+
+  test(title, async () => {
+    const { app } = ctx();
+
+    // Tenant A: two rows (one `user`, one `admin`). Tenant B: one `user` row.
+    await createRecord(
+      app,
+      '/tenant-items',
+      { name: 'Alpha One', email: 'ev-a1@conformance.test', role: 'user', age: 10 },
+      asTenant(tenantA),
+    );
+    await createRecord(
+      app,
+      '/tenant-items',
+      { name: 'Alpha Two', email: 'ev-a2@conformance.test', role: 'admin', age: 20 },
+      asTenant(tenantA),
+    );
+    await createRecord(
+      app,
+      '/tenant-items',
+      { name: 'Bravo Solo', email: 'ev-b1@conformance.test', role: 'user', age: 30 },
+      asTenant(tenantB),
+    );
+
+    // --- aggregate: COUNT(*) is per-tenant -----------------------------------
+    const aggA = await expectSuccess<AggregateCountResult>(
+      await app.request('/tenant-items/aggregate?count=*', { headers: asTenant(tenantA) }),
+      200,
+    );
+    expect(aggA.values.count).toBe(2);
+
+    const aggB = await expectSuccess<AggregateCountResult>(
+      await app.request('/tenant-items/aggregate?count=*', { headers: asTenant(tenantB) }),
+      200,
+    );
+    expect(aggB.values.count).toBe(1);
+
+    // Grouped aggregation is per-tenant too (not just COUNT(*)): tenant A's
+    // groups (one `user`, one `admin`) sum to its own two rows, never B's.
+    const aggGroupA = await expectSuccess<AggregateGroupResult>(
+      await app.request('/tenant-items/aggregate?count=*&groupBy=role', { headers: asTenant(tenantA) }),
+      200,
+    );
+    expect(aggGroupA.groups.reduce((sum, group) => sum + (group.values.count ?? 0), 0)).toBe(2);
+
+    // --- search: tenant B cannot find tenant A's rows ------------------------
+    const searchBforA = await app.request('/tenant-items/search?q=Alpha', {
+      headers: asTenant(tenantB),
+    });
+    expect(searchBforA.status).toBe(200);
+    expect((await readJson<SearchEnvelope>(searchBforA)).result).toEqual([]);
+
+    // Positive control: tenant A finds both of its own 'Alpha' rows.
+    const searchAforA = await app.request('/tenant-items/search?q=Alpha', {
+      headers: asTenant(tenantA),
+    });
+    expect(searchAforA.status).toBe(200);
+    const aHits = await readJson<SearchEnvelope>(searchAforA);
+    expect(aHits.result).toHaveLength(2);
+    expect(aHits.result.every((hit) => hit.item.tenantId === tenantA)).toBe(true);
+
+    // --- export: tenant B's export excludes tenant A's rows ------------------
+    const exportB = await expectSuccess<ExportResult>(
+      await app.request('/tenant-items/export?format=json', { headers: asTenant(tenantB) }),
+      200,
+    );
+    expect(exportB.count).toBe(1);
+    expect(exportB.data).toHaveLength(1);
+    expect(exportB.data[0].email).toBe('ev-b1@conformance.test');
+    expect(exportB.data.every((row) => row.tenantId === tenantB)).toBe(true);
+
+    // --- bulkPatch: tenant B patching role=user does NOT touch A's user row --
+    // Without owner-scoping, `?role=user` would match Alpha One AND Bravo Solo
+    // (matched: 2). Scoped, it matches only tenant B's own row.
+    const bulkB = await readJson<BulkPatchResponse>(
+      await app.request(
+        '/tenant-items/bulk?role=user',
+        jsonInit('PATCH', { age: 99 }, asTenant(tenantB)),
+      ),
+    );
+    expect(bulkB.matched).toBe(1);
+    expect(bulkB.updated).toBe(1);
+
+    // Tenant A is untouched: still two rows, and its `user` row keeps age 10.
+    const aggAAfter = await expectSuccess<AggregateCountResult>(
+      await app.request('/tenant-items/aggregate?count=*', { headers: asTenant(tenantA) }),
+      200,
+    );
+    expect(aggAAfter.values.count).toBe(2);
+
+    const aUserRow = await expectSuccess<ExportResult>(
+      await app.request('/tenant-items/export?format=json', { headers: asTenant(tenantA) }),
+      200,
+    );
+    const alphaOne = aUserRow.data.find((row) => row.email === 'ev-a1@conformance.test');
+    expect(alphaOne?.age).toBe(10);
+  });
+
+  test('extended-verb owner-scoping: each verb without the tenant header → 400 TENANT_REQUIRED', async () => {
+    const { app } = ctx();
+
+    await expectError(await app.request('/tenant-items/aggregate?count=*'), 400, 'TENANT_REQUIRED');
+    await expectError(await app.request('/tenant-items/search?q=Alpha'), 400, 'TENANT_REQUIRED');
+    await expectError(
+      await app.request('/tenant-items/export?format=json'),
+      400,
+      'TENANT_REQUIRED',
+    );
+    await expectError(
+      await app.request('/tenant-items/bulk?role=user', jsonInit('PATCH', { age: 1 })),
+      400,
+      'TENANT_REQUIRED',
+    );
+  });
+
+  test('extended-verb owner-scoping: search/export `?include=` never embeds another tenant`s related row', async () => {
+    const { app } = ctx();
+
+    // Tenant A owns a row; tenant B owns a row whose `parentId` POINTS AT A's row.
+    const parentA = await createRecord(
+      app,
+      '/tenant-items',
+      { name: 'Include Parent A', email: 'ev-inc-a@conformance.test', role: 'user', age: 50 },
+      asTenant(tenantA),
+    );
+    await createRecord(
+      app,
+      '/tenant-items',
+      {
+        name: 'Include Child B',
+        email: 'ev-inc-b@conformance.test',
+        role: 'user',
+        age: 51,
+        parentId: parentA.id,
+      },
+      asTenant(tenantB),
+    );
+
+    // search?include=parent as tenant B: the parent belongs to tenant A, so the
+    // owner-scoped include must resolve it to null — NOT embed A's row.
+    const searchB = await app.request('/tenant-items/search?q=Child&include=parent', {
+      headers: asTenant(tenantB),
+    });
+    expect(searchB.status).toBe(200);
+    const searchHits = await readJson<SearchEnvelope>(searchB);
+    expect(searchHits.result).toHaveLength(1);
+    expect(searchHits.result[0].item.parent ?? null).toBeNull();
+
+    // export?include=parent as tenant B: same — the foreign parent must not embed.
+    const exportB = await expectSuccess<ExportResult>(
+      await app.request('/tenant-items/export?format=json&include=parent', {
+        headers: asTenant(tenantB),
+      }),
+      200,
+    );
+    const child = exportB.data.find((row) => row.email === 'ev-inc-b@conformance.test');
+    expect(child?.parent ?? null).toBeNull();
+  });
+}

--- a/tests/conformance/cells/index.ts
+++ b/tests/conformance/cells/index.ts
@@ -11,6 +11,7 @@ import { registerBatchTenantScopingCells } from './batch-tenant-scoping';
 import { registerBulkPatchCells } from './bulk-patch';
 import { registerCursorPaginationCells } from './cursor-pagination';
 import { registerEtagConcurrencyCells } from './etag-concurrency';
+import { registerExtendedVerbTenantScopingCells } from './extended-verb-tenant-scoping';
 import { registerFilterOperatorCells } from './filter-operators';
 import { registerFinalizePipelineCells } from './finalize-pipeline';
 import { registerManagedFieldCells } from './managed-fields';
@@ -53,6 +54,7 @@ export function registerConformanceCells(descriptor: AdapterDescriptor): void {
   registerTenantScopingCells(descriptor, ctx);
   registerRelationScopingCells(descriptor, ctx);
   registerBatchTenantScopingCells(descriptor, ctx);
+  registerExtendedVerbTenantScopingCells(descriptor, ctx);
   registerFinalizePipelineCells(descriptor, ctx);
   registerUpsertRestoreCells(descriptor, ctx);
   registerTransactionalHookCells(descriptor, ctx);

--- a/tests/conformance/contract.ts
+++ b/tests/conformance/contract.ts
@@ -83,6 +83,18 @@ export interface ConformanceCapabilities {
    * registers no batch verbs there; the skip is named.
    */
   batchTenantScoping: boolean;
+  /**
+   * Whether this leg registers the extended read/bulk verbs (`aggregate` /
+   * `search` / `export` / `bulkPatch`) on the multi-tenant model, so the
+   * extended-verb owner-scoping cell can assert none of them ever read,
+   * aggregate, or mutate another tenant's rows. These verbs build their WHERE
+   * from a parsed filter set (not a client id list), so the contract is: core's
+   * `applyTenantScope` injects the owner equality into that set before the
+   * adapter runs the query. False on the prisma leg — its tenant variant reuses
+   * the fixed examples schema and registers none of these verbs there; the skip
+   * is named.
+   */
+  extendedVerbTenantScoping: boolean;
 }
 
 export interface HookObservation {


### PR DESCRIPTION
## Summary

Security fix: the `aggregate` / `search` / `export` / `bulk-patch` verbs did not apply the model's `multiTenant` owner filter — they read, aggregated, or mutated across **every tenant's rows** regardless of `Model.multiTenant`. Only `ListEndpoint` re-applied the tenant scope in its handler.

## The leak

- The owner equality is injected at the **core** layer, but only `ListEndpoint.handle()` did it (`validateTenantId()` + pushing the tenant `eq` filter). `AggregateEndpoint`, `SearchEndpoint`, `ExportEndpoint` (which overrides `List.handle`, so it didn't even inherit it), and `BulkPatchEndpoint` had zero tenant logic — `GET /resource/aggregate|search|export` and `PATCH /resource/bulk` spanned all tenants.
- A **second** leak on the same verbs: `search`/`export` loaded `?include=` relations **without** the owner `scope` that `list`/`read` pass, so an embedded related row could cross tenants even when the parent rows were scoped.

## The fix

- One auditable core helper `applyTenantScope` (+ `applyTenantScopeToAggregateFilters` for the aggregate `Record`-shaped WHERE), called by `ListEndpoint` and all four verbs after parsing filters and before the adapter query. Each verb enforces tenant presence (`validateTenantId` / 400 `TENANT_REQUIRED`) and ANDs the owner equality into the adapter WHERE. `List` was refactored onto the same helper (single source of truth — a new verb that forgets to call it is now the only way to reintroduce the hole).
- All three adapters (`drizzle` / `memory` / `prisma`) now thread `getRelationScope(...)` into the search/export relation loader, matching List/Read.

## Tests

New cross-adapter conformance cell `extended-verb-tenant-scoping` (memory + drizzle legs; prisma named-skip) asserting:
- per-tenant aggregate `COUNT(*)` **and** a grouped (`groupBy`) aggregation,
- `search` / `export` / `bulk-patch` row isolation,
- `400 TENANT_REQUIRED` when the tenant header is absent,
- `?include=` on search/export never embeds another tenant's related row.

Reverse-checked while authoring: neutering the core helper makes the count assertion fail (`expected 3 to be 2`); neutering the include scope makes the include assertion fail (tenant B's search embeds tenant A's row) — so the cell is not vacuously green.

## Verification

- `pnpm -r typecheck` ✓ · `pnpm -r lint` ✓ · `pnpm run test:unit` → **1243 passed / 42 skipped** ✓
- `tsc -p tests/conformance/tsconfig.typecheck.json` ✓

## Release

Patch changeset for `hono-crud` + `@hono-crud/{drizzle,memory,prisma}` (matches the prior `fix/batch-owner-scoping` precedent — core fix that every adapter inherits, released together so each adapter changelog records the security fix).
