### PR TITLE
feat(cache): preserve a generic endpoint's <Env, Meta> through the cache mixins

### DIFF
--- a/.changeset/cache-mixin-explicit-instance.md
+++ b/.changeset/cache-mixin-explicit-instance.md
@@ -1,0 +1,25 @@
+---
+"@hono-crud/cache": patch
+---
+
+feat(cache): let `withCache`/`withCacheInvalidation` preserve a generic endpoint's `<Env, Meta>`
+
+The cache mixins typed their result as `AbstractConstructor<InstanceType<TBase> & …>`,
+which collapses a generic base class to its DEFAULT type params — so wrapping a
+`Hono<AuthEnv>` endpoint widened its env back to `Env`. Downstream that breaks a
+typed `CrudEndpoints<AuthEnv>` registration (`Context<Env>` is not assignable to
+`Context<AuthEnv>`), forcing consumers to hand-cast the wrapped class.
+
+Both mixins now accept an OPTIONAL explicit instance type (defaulting to `never`,
+so existing `withCache(Base)` calls are unchanged). Pass it to preserve the generics
+with no cast:
+
+```ts
+class UserRead extends withCache<MemoryReadEndpoint<AuthEnv, typeof meta>>(MemoryReadEndpoint) {
+  _meta = meta;
+  // …
+}
+```
+
+Covered by a type-level regression assertion (`src/mixin.type-assertions.ts`) that
+fails `tsc` if the env is ever widened again.

--- a/packages/cache/src/mixin.ts
+++ b/packages/cache/src/mixin.ts
@@ -161,6 +161,21 @@ export interface CacheInvalidationMethods {
 // ============================================================================
 
 /**
+ * Resolve a mixin's instance type. When the caller passes an explicit `TInstance`
+ * (e.g. `withCache<UserRead<AuthEnv, typeof meta>>(UserRead)`) it is preserved;
+ * otherwise it falls back to the base's own `InstanceType<TBase>`. This lets a
+ * GENERIC base class keep its `<Env, Meta>` type params — which `InstanceType<TBase>`
+ * alone erases to the class defaults, since TS cannot pass a parametrized class as a
+ * value, so a `Hono<AuthEnv>` endpoint would otherwise widen back to `Env` and fail
+ * a typed `CrudEndpoints<AuthEnv>` registration.
+ */
+type MixinInstance<TInstance, TBase extends AbstractConstructor<OpenAPIRoute>> = [
+  TInstance,
+] extends [never]
+  ? InstanceType<TBase>
+  : TInstance;
+
+/**
  * Mixin that adds caching capabilities to read/list endpoints.
  *
  * The route registrar calls `setContext(c)` before invoking `handle()`,
@@ -198,13 +213,23 @@ export interface CacheInvalidationMethods {
  * }
  * ```
  */
-export function withCache<TBase extends AbstractConstructor<OpenAPIRoute>>(
+export function withCache<
+  // Optional explicit instance type — defaults to `never`, which preserves the
+  // exact backward-compatible inference (`InstanceType<TBase>`). Pass it to keep a
+  // generic base's `<Env, Meta>` params: `withCache<UserRead<AuthEnv, typeof meta>>(UserRead)`.
+  // The constraint is env-agnostic (`<any>`): a non-default env like `AuthEnv` is
+  // NOT assignable to `OpenAPIRoute<Env>` (Context variance), which is the very
+  // widening this overload exists to prevent.
+  // biome-ignore lint/suspicious/noExplicitAny: env-agnostic constraint by design.
+  TInstance extends OpenAPIRoute<any> = never,
+  TBase extends AbstractConstructor<OpenAPIRoute> = AbstractConstructor<OpenAPIRoute>,
+>(
   Base: TBase,
   // A single construct signature (instance type intersected) — an
   // intersection of two constructor types (`TBase & Constructor<...>`)
   // cannot be extended (TS2510: base constructors must share a return
   // type), which would break `class X extends withCache(Base)`.
-): AbstractConstructor<InstanceType<TBase> & CacheEndpointMethods> {
+): AbstractConstructor<MixinInstance<TInstance, TBase> & CacheEndpointMethods> {
   // @ts-expect-error - TS mixin limitation: cannot access protected members of generic base class (TS#17744)
   class CachedRoute extends Base implements CacheEndpointMethods {
     /**
@@ -389,7 +414,9 @@ export function withCache<TBase extends AbstractConstructor<OpenAPIRoute>>(
     }
   }
 
-  return CachedRoute as unknown as AbstractConstructor<InstanceType<TBase> & CacheEndpointMethods>;
+  return CachedRoute as unknown as AbstractConstructor<
+    MixinInstance<TInstance, TBase> & CacheEndpointMethods
+  >;
 }
 
 // ============================================================================
@@ -412,10 +439,17 @@ export function withCache<TBase extends AbstractConstructor<OpenAPIRoute>>(
  * }
  * ```
  */
-export function withCacheInvalidation<TBase extends AbstractConstructor<OpenAPIRoute>>(
+export function withCacheInvalidation<
+  // Optional explicit instance type (see `withCache`): pass it to preserve a
+  // generic base's `<Env, Meta>` params, e.g.
+  // `withCacheInvalidation<UserUpdate<AuthEnv, typeof meta>>(UserUpdate)`.
+  // biome-ignore lint/suspicious/noExplicitAny: env-agnostic constraint by design.
+  TInstance extends OpenAPIRoute<any> = never,
+  TBase extends AbstractConstructor<OpenAPIRoute> = AbstractConstructor<OpenAPIRoute>,
+>(
   Base: TBase,
   // Single construct signature — see the `withCache` return-type note.
-): AbstractConstructor<InstanceType<TBase> & CacheInvalidationMethods> {
+): AbstractConstructor<MixinInstance<TInstance, TBase> & CacheInvalidationMethods> {
   // @ts-expect-error - TS mixin limitation: cannot access protected members of generic base class (TS#17744)
   class InvalidatingRoute extends Base implements CacheInvalidationMethods {
     /**
@@ -531,7 +565,7 @@ export function withCacheInvalidation<TBase extends AbstractConstructor<OpenAPIR
   }
 
   return InvalidatingRoute as unknown as AbstractConstructor<
-    InstanceType<TBase> & CacheInvalidationMethods
+    MixinInstance<TInstance, TBase> & CacheInvalidationMethods
   >;
 }
 

--- a/packages/cache/src/mixin.type-assertions.ts
+++ b/packages/cache/src/mixin.type-assertions.ts
@@ -1,0 +1,41 @@
+// Type-level regression guard for the cache mixins' explicit-instance overload.
+// Not an entry point (tsup bundles only `index.ts`) and never executed — it exists
+// purely so `tsc --noEmit` fails if the overload stops preserving a generic base's
+// non-default env through `withCache` / `withCacheInvalidation`.
+//
+// Why it matters: `withCache(GenericEndpoint)` collapses the endpoint to its DEFAULT
+// type params (`InstanceType<TBase>`), widening a `Hono<AuthEnv>` endpoint back to
+// `Env` — which then fails a typed `CrudEndpoints<AuthEnv>` registration downstream.
+// The explicit form `withCache<Endpoint<AuthEnv, Meta>>(Endpoint)` preserves it.
+import type { Env } from 'hono';
+import type { AbstractConstructor, OpenAPIRoute } from 'hono-crud/internal';
+import { withCache, withCacheInvalidation } from './mixin';
+
+interface AppEnv extends Env {
+  Variables: { userId?: string };
+}
+// A generic endpoint base parametrized on the env (mirrors `Drizzle*Endpoint<E, M>`).
+declare abstract class AppRoute<E extends Env = Env> extends OpenAPIRoute<E> {}
+
+// A registrar slot typed for AppEnv — mirrors `CrudEndpoints<AppEnv>`. If the mixin
+// widened the env back to `Env`, `OpenAPIRoute<Env>` would NOT be assignable to
+// `OpenAPIRoute<AppEnv>` (Context variance) and these assignments would fail.
+type EndpointSlot = AbstractConstructor<OpenAPIRoute<AppEnv>>;
+
+// Explicit instance type → env preserved + mixin methods present.
+const CachedBase = withCache<AppRoute<AppEnv>>(AppRoute);
+const _cachedKeepsEnv: EndpointSlot = CachedBase;
+const _cachedHasMethods: (i: InstanceType<typeof CachedBase>) => Promise<unknown> = (i) =>
+  i.getCachedResponse();
+
+const InvalidatingBase = withCacheInvalidation<AppRoute<AppEnv>>(AppRoute);
+const _invKeepsEnv: EndpointSlot = InvalidatingBase;
+const _invHasMethods: (i: InstanceType<typeof InvalidatingBase>) => Promise<void> = (i) =>
+  i.performCacheInvalidation();
+
+// Backward-compat: no explicit type arg still infers the base instance + methods.
+const CompatBase = withCache(AppRoute);
+const _compatHasMethods: (i: InstanceType<typeof CompatBase>) => Promise<unknown> = (i) =>
+  i.getCachedResponse();
+
+export { _cachedKeepsEnv, _cachedHasMethods, _invKeepsEnv, _invHasMethods, _compatHasMethods };


### PR DESCRIPTION
## Summary

The cache mixins typed their result as `AbstractConstructor<InstanceType<TBase> & …>`, which collapses a generic base class to its **default** type params. So `withCache(SomeEndpoint)` widens a `Hono<AuthEnv>` endpoint's env back to `Env`, and a downstream typed `CrudEndpoints<AuthEnv>` registration then fails (`Context<Env>` isn't assignable to `Context<AuthEnv>`) — forcing consumers to hand-cast the wrapped class. (Surfaced wiring `@hono-crud/cache` into a strongly-typed `defineCrudResource` SDK.)

## Change

Both `withCache` and `withCacheInvalidation` gain an **optional explicit instance type** `TInstance` (defaults to `never` → 100% backward-compatible via an `[TInstance] extends [never] ? InstanceType<TBase> : TInstance` resolver). Consumers preserve the generics with **no cast**:

```ts
class UserRead extends withCache<MemoryReadEndpoint<AuthEnv, typeof meta>>(MemoryReadEndpoint) {
  _meta = meta;
}
```

The one unavoidable mixin assertion stays inside the library (the pre-existing `as unknown as` return cast), not at every call site. The constraint is env-agnostic (`OpenAPIRoute<any>`) by design — a non-default env is *not* assignable to `OpenAPIRoute<Env>`, which is the very widening this prevents.

## Tests

- New type-level regression assertion `packages/cache/src/mixin.type-assertions.ts` (typechecked, not bundled — tsup builds only `index.ts`). Proven to **fail** `tsc` when the explicit type arg is dropped (env widens), and pass with it.
- Backward-compat: the existing **83 cache tests** pass unchanged; `pnpm -r typecheck` + full `test:unit` (1243 passed) green.

## Release

Patch changeset for `@hono-crud/cache` (typing-only; no runtime change).