### PR TITLE
feat: make bridge CRUD resources MCP-discoverable + fix tools/list on date schemas

### DIFF
--- a/.changeset/mcp-resource-discovery.md
+++ b/.changeset/mcp-resource-discovery.md
@@ -1,0 +1,9 @@
+---
+"hono-crud": patch
+"@hono-crud/mcp": patch
+---
+
+Make framework-bridge (e.g. @velajs/crud) CRUD resources MCP-discoverable, and fix `tools/list` for schemas with date fields.
+
+- `hono-crud/internal` now exports `recordCrudResource`, so a bridge that mounts generated CRUD routes via a sub-app can also record the resource on the parent app — where `getRegisteredCrudResources(app)` (and `@hono-crud/mcp`'s `auto` discovery) read it. Previously such resources were recorded only on the isolated sub-app and were invisible to MCP.
+- `@hono-crud/mcp`: `buildInputShape` now coerces tool-input fields the MCP SDK cannot represent in JSON Schema (e.g. `z.date()`) to a representable string, preserving optionality, instead of letting the SDK's `toJSONSchema` throw and break the entire `tools/list`. (Query/body dates arrive as strings on the wire anyway, so endpoints still parse them.)

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -56,8 +56,10 @@ export type { CrudEndpointName, CrudEndpoints } from './core/register';
 // registration order — the single source of truth registerCrud iterates.
 export { CRUD_ROUTES } from './core/crud-routes';
 
-// App-scoped CRUD resource registry — lets addons enumerate registerCrud(...) calls.
-export { getRegisteredCrudResources } from './core/resource-registry';
+// App-scoped CRUD resource registry — lets addons enumerate registerCrud(...) calls,
+// and lets framework bridges (e.g. @velajs/crud) record a resource on a parent app
+// when they mount the generated routes via a sub-app.
+export { getRegisteredCrudResources, recordCrudResource } from './core/resource-registry';
 export type { RegisteredCrudResource } from './core/resource-registry';
 
 // ============================================================================

--- a/packages/mcp/src/schema.ts
+++ b/packages/mcp/src/schema.ts
@@ -44,11 +44,66 @@ export function extractRequestPlan(route: OpenAPIRouteSchema): RequestPlan {
  * converts this Zod shape to JSON Schema for the wire.
  */
 export function buildInputShape(route: OpenAPIRouteSchema): RawShape {
-  return {
+  const merged: RawShape = {
     ...shapeOf(route.request?.params),
     ...shapeOf(route.request?.query),
     ...shapeOf(bodySchema(route)),
   };
+  // The MCP SDK converts this shape to JSON Schema, and Zod cannot represent
+  // `z.date()` — it throws ("Date cannot be represented in JSON Schema"),
+  // breaking the entire `tools/list`. A date is carried on the wire as an ISO
+  // 8601 string, so represent it as exactly that — Zod's own `z.iso.datetime()`,
+  // which converts to `{ type: 'string', format: 'date-time' }`.
+  const out: RawShape = {};
+  for (const [key, schema] of Object.entries(merged)) {
+    out[key] = datesAsIsoStrings(schema);
+  }
+  return out;
+}
+
+/**
+ * Replace every `z.date()` in a schema with `z.iso.datetime()`, recursing
+ * through optional / nullable / default / array / object wrappers. Schemas with
+ * no date pass through by identity (no rebuild), so non-date fields keep their
+ * exact shape/refinements. Dates are the only Zod type our endpoint schemas use
+ * that the SDK's JSON-Schema conversion can't represent.
+ */
+function datesAsIsoStrings(schema: ZodType): ZodType {
+  if (schema instanceof z.ZodDate) return z.iso.datetime();
+
+  if (schema instanceof z.ZodOptional) {
+    const inner = schema.unwrap() as ZodType;
+    const next = datesAsIsoStrings(inner);
+    return next === inner ? schema : next.optional();
+  }
+  if (schema instanceof z.ZodNullable) {
+    const inner = schema.unwrap() as ZodType;
+    const next = datesAsIsoStrings(inner);
+    return next === inner ? schema : next.nullable();
+  }
+  if (schema instanceof z.ZodDefault) {
+    const def = schema.def as unknown as { innerType: ZodType; defaultValue: never };
+    const next = datesAsIsoStrings(def.innerType);
+    return next === def.innerType ? schema : next.default(def.defaultValue);
+  }
+  if (schema instanceof z.ZodArray) {
+    const element = schema.element as ZodType;
+    const next = datesAsIsoStrings(element);
+    return next === element ? schema : z.array(next);
+  }
+  if (schema instanceof z.ZodObject) {
+    const shape = schema.shape as RawShape;
+    let changed = false;
+    const next: RawShape = {};
+    for (const [key, value] of Object.entries(shape)) {
+      const mapped = datesAsIsoStrings(value);
+      if (mapped !== value) changed = true;
+      next[key] = mapped;
+    }
+    return changed ? z.object(next) : schema;
+  }
+
+  return schema;
 }
 
 type ResponseContent = { content?: Record<string, { schema?: unknown }> } | undefined;


### PR DESCRIPTION
## What
Two changes that together make `@hono-crud/mcp`'s `auto` discovery work for resources mounted by a framework bridge (e.g. `@velajs/crud`), validated end-to-end on Cloudflare Workers.

### 1. `hono-crud` (core): export `recordCrudResource` from `hono-crud/internal` *(minor)*
The resource registry is keyed per Hono-app instance (`getRegisteredCrudResources(app)`). A bridge that mounts generated routes on an isolated sub-app (`registerCrud(subApp, '', endpoints)` then `app.route(mountPath, subApp)`) recorded the resource only on the sub-app — invisible to addons reading the parent app. Exporting `recordCrudResource` lets the bridge also record it on the parent app with the real mount path.

### 2. `@hono-crud/mcp`: coerce unrepresentable tool-input fields *(patch)*
`buildInputShape` passed raw Zod shapes to the MCP SDK, whose `toJSONSchema` **throws** on `z.date()` (e.g. a date in list filters) — breaking the entire `tools/list`. It now coerces only the offending fields to a representable string, preserving optionality. Output schemas were already guarded; this brings inputs in line.

## Validation
With a consumer that records resources on the main app, `tools/list` returns the full tool set (27 tools across 3 resources × 9 ops in the test app), and an authenticated `tools/call` re-dispatches through the host app with auth/owner-scope intact.

## Notes
- Pairs with the `@velajs/crud` change that calls `recordCrudResource(app, mountPath, endpoints)` after `app.route(...)`.
- Changeset included (`hono-crud` minor, `@hono-crud/mcp` patch).