### PR TITLE
feat(config): expose keyset (cursor) pagination via the list config API

### DIFF
--- a/.changeset/cursor-config-api.md
+++ b/.changeset/cursor-config-api.md
@@ -1,0 +1,13 @@
+---
+"hono-crud": patch
+---
+
+feat(config): expose keyset (cursor) pagination through the list config API
+
+`ListEndpointConfig.pagination` now accepts `cursor: { enabled, field }`, so
+config-based consumers can opt into keyset pagination without subclassing an
+endpoint. `defineEndpoints` forwards it to the generated endpoint as
+`cursorPaginationEnabled` / `cursorField`. `supportsCursorPagination` stays
+adapter-owned, so enabling cursor on an adapter without keyset support still
+throws the loud `ConfigurationException` (no silent fallback to offset). Default
+cursor field is `id`.

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -165,6 +165,20 @@ interface SortingConfig {
 interface PaginationConfig {
   defaultPerPage?: number;
   maxPerPage?: number;
+  /**
+   * Opt into keyset (cursor) pagination for this list endpoint. When enabled
+   * and the adapter supports it, `?cursor`/`?limit` drive a forward-only
+   * keyset walk ordered by `field` (default `'id'`), and responses carry a
+   * `next_cursor`. Plain `?page`/`?per_page` requests stay offset-paginated.
+   *
+   * If the adapter does not support cursor pagination, enabling this throws a
+   * `ConfigurationException` at request time (never a silent fallback).
+   */
+  cursor?: {
+    enabled?: boolean;
+    /** Keyset column — must be unique + monotonic (e.g. a ULID id). Default `'id'`. */
+    field?: string;
+  };
 }
 
 /**
@@ -910,6 +924,8 @@ export function defineEndpoints<M extends MetaInput, E extends Env = Env>(
         : undefined,
       defaultPerPage: cfg.pagination?.defaultPerPage,
       maxPerPage: cfg.pagination?.maxPerPage,
+      cursorPaginationEnabled: cfg.pagination?.cursor?.enabled,
+      cursorField: cfg.pagination?.cursor?.field,
       allowedIncludes: cfg.includes,
       fieldSelectionEnabled: cfg.fieldSelection?.enabled,
       allowedSelectFields: cfg.fieldSelection?.allowed,

--- a/packages/core/src/core/generate-endpoint-class.ts
+++ b/packages/core/src/core/generate-endpoint-class.ts
@@ -66,6 +66,11 @@ export interface NormalizedEndpointConfig {
   blockedSelectFields?: string[];
   alwaysIncludeFields?: string[];
   defaultSelectFields?: string[];
+  // Keyset (cursor) pagination opt-in. `supportsCursorPagination` stays
+  // adapter-owned — the loud ConfigurationException must still fire when an
+  // adapter without keyset support is asked to cursor-paginate.
+  cursorPaginationEnabled?: boolean;
+  cursorField?: string;
 
   // Verb-specific protected field overrides for endpoints whose
   // configuration shape isn't part of the shared 5-verb surface
@@ -180,6 +185,10 @@ export function generateEndpointClass<B extends abstract new () => unknown>(
     protected blockedSelectFields: string[] = config.blockedSelectFields ?? [];
     protected alwaysIncludeFields: string[] = config.alwaysIncludeFields ?? [];
     protected defaultSelectFields: string[] = config.defaultSelectFields ?? [];
+    // Keyset pagination opt-in (config bridge). Only the enable flag + field
+    // are config-settable; `supportsCursorPagination` remains adapter-owned.
+    protected cursorPaginationEnabled: boolean = config.cursorPaginationEnabled ?? false;
+    protected cursorField: string | undefined = config.cursorField;
 
     async before(...args: unknown[]): Promise<unknown> {
       if (config.before) return config.before(...args);

--- a/tests/new-features.test.ts
+++ b/tests/new-features.test.ts
@@ -1,6 +1,7 @@
 import { createIdempotencyMiddleware } from '@hono-crud/idempotency/middleware';
 import { MemoryIdempotencyStorage } from '@hono-crud/idempotency/storage/memory';
 import {
+  MemoryAdapters,
   MemoryCloneEndpoint,
   MemoryCreateEndpoint,
   MemoryDeleteEndpoint,
@@ -10,7 +11,7 @@ import {
   clearStorage,
 } from '@hono-crud/memory';
 import { Hono } from 'hono';
-import { fromHono, registerCrud } from 'hono-crud';
+import { defineEndpoints, fromHono, registerCrud } from 'hono-crud';
 import type { MetaInput, Model } from 'hono-crud';
 import { generateETag, matchesIfMatch, matchesIfNoneMatch } from 'hono-crud';
 import { decodeCursor, encodeCursor } from 'hono-crud';
@@ -186,6 +187,76 @@ describe('Cursor-Based Pagination', () => {
     expect(body.success).toBe(false);
     expect(body.error.code).toBe('CONFIGURATION_ERROR');
     expect(body.error.message).toContain('supportsCursorPagination');
+  });
+});
+
+// ============================================================================
+// Cursor Pagination via the CONFIG API (defineEndpoints)
+// ============================================================================
+// The block above drives cursor pagination through an imperative subclass
+// (`cursorPaginationEnabled = true`). These pin the config-API bridge: setting
+// `list.pagination.cursor.{enabled,field}` must reach the generated endpoint
+// so config-only consumers (e.g. the @velajs/crud @Crud bridge) get keyset
+// pagination without subclassing.
+
+describe('Cursor-Based Pagination (config API)', () => {
+  let app: ReturnType<typeof fromHono>;
+
+  beforeEach(async () => {
+    clearStorage();
+    app = fromHono(new Hono());
+    const endpoints = defineEndpoints(
+      {
+        meta: userMeta,
+        create: {},
+        list: { pagination: { cursor: { enabled: true, field: 'id' } } },
+      },
+      MemoryAdapters,
+    );
+    registerCrud(app, '/cfg-users', endpoints as any);
+
+    for (const user of [
+      { name: 'Alice', email: 'alice@cfg.com', age: 30 },
+      { name: 'Bob', email: 'bob@cfg.com', age: 25 },
+      { name: 'Charlie', email: 'charlie@cfg.com', age: 35 },
+      { name: 'Diana', email: 'diana@cfg.com', age: 28 },
+    ]) {
+      await app.request('/cfg-users', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(user),
+      });
+    }
+  });
+
+  it('enables keyset pagination through list.pagination.cursor', async () => {
+    const res = await app.request('/cfg-users?limit=2');
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as any;
+    expect(data.result.length).toBe(2);
+    expect(data.result_info.page).toBe(0);
+    expect(data.result_info.has_next_page).toBe(true);
+    expect(data.result_info.next_cursor).toBeDefined();
+    expect('prev_cursor' in data.result_info).toBe(false);
+  });
+
+  it('walks every row exactly once via the config-enabled cursor', async () => {
+    const res1 = await app.request('/cfg-users?limit=2');
+    const data1 = (await res1.json()) as any;
+    const res2 = await app.request(`/cfg-users?cursor=${data1.result_info.next_cursor}&limit=2`);
+    const data2 = (await res2.json()) as any;
+    const allIds = [...data1.result.map((r: any) => r.id), ...data2.result.map((r: any) => r.id)];
+    expect(new Set(allIds).size).toBe(4);
+    expect(data2.result_info.has_next_page).toBe(false);
+  });
+
+  it('still uses offset pagination on plain page/per_page', async () => {
+    const res = await app.request('/cfg-users?page=1&per_page=2');
+    const data = (await res.json()) as any;
+    expect(data.result.length).toBe(2);
+    expect(data.result_info.page).toBe(1);
+    expect(data.result_info.total_count).toBe(4);
+    expect('next_cursor' in data.result_info).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Problem

Keyset (cursor) pagination is fully implemented end-to-end — the codecs (`buildCursorPage`), the `ListEndpoint` handler branch (`cursorPaginationEnabled`/`cursorField` + the loud guard), and the keyset query in all three adapters (memory/drizzle/prisma). But it was only reachable by **subclassing** an endpoint and setting `cursorPaginationEnabled = true`. Config-based consumers (`defineEndpoints` / `registerCrud`) had **no** way to turn it on — `ListEndpointConfig.pagination` only exposed `defaultPerPage`/`maxPerPage`, and the config bridge never forwarded the cursor fields.

## Fix (3 small edits in `packages/core`, no adapter changes)

1. **`config/index.ts`** — `PaginationConfig` gains `cursor?: { enabled?: boolean; field?: string }`.
2. **`config/index.ts`** — the `defineEndpoints` list arm forwards `cursorPaginationEnabled: cfg.pagination?.cursor?.enabled` and `cursorField: cfg.pagination?.cursor?.field`.
3. **`core/generate-endpoint-class.ts`** — `NormalizedEndpointConfig` gains the two fields and the generated subclass writes them as protected fields.

`supportsCursorPagination` stays **adapter-owned** — enabling cursor on an adapter without keyset support still throws the existing loud `ConfigurationException` (no silent fallback). Default cursor field is `id`.

Data flow: `list.pagination.cursor.{enabled,field}` → `defineEndpoints` → generated subclass → `isCursorPaginationActive()` → existing keyset query + `buildCursorPage`.

## Tests

Adds a `Cursor-Based Pagination (config API)` block to `tests/new-features.test.ts`: enables cursor through `list.pagination.cursor`, asserts `next_cursor` + the walk visits every row once + `has_next_page` falsing on the last page, and that plain `?page/?per_page` stays offset. Full suite green except a pre-existing, unrelated Prisma `db-comprehensive` env failure (fails identically on `main`).

patch changeset included.