### PR TITLE
feat(config): config-API response caching with invalidation

### DIFF
--- a/.changeset/config-api-cache.md
+++ b/.changeset/config-api-cache.md
@@ -1,0 +1,18 @@
+---
+"hono-crud": patch
+"@hono-crud/cache": patch
+---
+
+feat(config): config-API response caching with invalidation
+
+`endpoints.{list,read}.cache` enables response caching (X-Cache MISS→HIT) and
+`endpoints.{create,update,delete}.cache.invalidate` busts it — all through the
+config API, no subclassing. Core now owns the cache code path (key format,
+`CacheConfig`, the cache-storage feature); `@hono-crud/cache` re-exports the
+storage feature so the `withCache` mixin and the config path share ONE storage
+global.
+
+Cache keys are tenant-scoped automatically on multiTenant resources, so a
+cached page is never served across tenants; invalidation uses the same
+tenant-scoped prefix. Storage resolves from request context
+(`createCacheStorageMiddleware`) or the global `setCacheStorage`.

--- a/packages/cache/src/mixin.ts
+++ b/packages/cache/src/mixin.ts
@@ -5,23 +5,13 @@ import type {
   OpenAPIRoute,
   ResponseEnvelopeInfo,
 } from 'hono-crud/internal';
-import {
-  CONTEXT_KEYS,
-  ConfigurationException,
-  createStorageFeature,
-  getLogger,
-} from 'hono-crud/internal';
+import { ConfigurationException, getLogger, resolveCacheStorageOrWarn } from 'hono-crud/internal';
 import {
   createInvalidationPattern,
   createRelatedPatterns,
   generateCacheKey,
 } from './key-generator';
-import type {
-  CacheConfig,
-  CacheInvalidationConfig,
-  CacheStorage,
-  InvalidationStrategy,
-} from './types';
+import type { CacheConfig, CacheInvalidationConfig, InvalidationStrategy } from './types';
 
 /**
  * Read `_meta.model.tableName` off the endpoint instance and throw a clear
@@ -42,79 +32,18 @@ function getTableName(self: unknown): string {
 // ============================================================================
 // Global Cache Storage
 // ============================================================================
-
-/**
- * Cache storage feature.
- * Nullable — no default storage is created unless explicitly set. The request
- * path uses `resolveCacheStorage` and emits a once-per-isolate warning when no
- * storage resolves (caching silently disabled is a mis-wiring worth surfacing).
- */
-const cacheStorageFeature = createStorageFeature<CacheStorage>({
-  contextKey: CONTEXT_KEYS.cacheStorage,
-});
-
-/**
- * Backing registry (exported for advanced use / tests).
- */
-export const cacheStorageRegistry = cacheStorageFeature.registry;
-
-/**
- * Set the global cache storage instance.
- *
- * @example
- * ```ts
- * import { Redis } from '@upstash/redis';
- * import { RedisCacheStorage, setCacheStorage } from '@hono-crud/cache';
- *
- * setCacheStorage(new RedisCacheStorage({
- *   client: new Redis({ url: c.env.REDIS_URL }),
- * }));
- * ```
- */
-export const setCacheStorage = cacheStorageFeature.set;
-
-/**
- * Get the explicitly-configured global cache storage, or `null` when none is
- * configured. Never throws and never creates a hidden default. Use
- * {@link getCacheStorageRequired} when a non-null storage is required.
- */
-export const getCacheStorage = cacheStorageFeature.get;
-
-/**
- * Get the global cache storage instance, throwing if not configured.
- */
-export const getCacheStorageRequired = cacheStorageFeature.getRequired;
-
-/**
- * Resolves cache storage with priority: explicit param > context > global.
- *
- * @param ctx - Optional Hono context
- * @param explicitStorage - Optional explicit storage instance
- * @returns The resolved storage, or null when no storage was configured
- */
-export const resolveCacheStorage = cacheStorageFeature.resolve;
-
-/** Once-per-isolate guard for the missing-storage warning (dedup, not request state). */
-let warnedMissingCacheStorage = false;
-
-/**
- * Resolve cache storage for the request path, emitting a once-per-isolate
- * warning when nothing resolves. Caching then degrades to a no-op — correct
- * for an optimization-only feature, but loud enough that a mis-wired app
- * (forgotten `createStorageMiddleware` / `setCacheStorage`) is observable.
- */
-function resolveCacheStorageOrWarn(ctx?: Context<Env>): CacheStorage | null {
-  const storage = cacheStorageFeature.resolve(ctx);
-  if (!storage && !warnedMissingCacheStorage) {
-    warnedMissingCacheStorage = true;
-    getLogger().warn(
-      'Cache storage not configured — caching is disabled. Inject cacheStorage with ' +
-        'createStorageMiddleware() (recommended) or call setCacheStorage(). ' +
-        'This warning is logged once per isolate.',
-    );
-  }
-  return storage;
-}
+//
+// The cache storage feature is OWNED by core so the config-API cache path
+// (`endpoints.{list,read}.cache`) and this mixin share ONE global + context
+// registry — `setCacheStorage()` (or `createCacheStorageMiddleware`) configures
+// both. Re-exported here so existing `@hono-crud/cache` imports keep working.
+export {
+  cacheStorageRegistry,
+  setCacheStorage,
+  getCacheStorage,
+  getCacheStorageRequired,
+  resolveCacheStorage,
+} from 'hono-crud/internal';
 
 // ============================================================================
 // Type Helpers

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -208,9 +208,14 @@ interface ListHooks<M extends MetaInput> {
 /**
  * Response cache configuration for list/read endpoints. Caching is opt-in;
  * `cacheStorage` is wired separately via `createCacheStorageMiddleware()`
- * (recommended on Workers) or `setCacheStorage()`. Cache keys are tenant-scoped
- * automatically on multiTenant resources, so a cached page is never served
- * across tenants.
+ * (recommended on Workers) or `setCacheStorage()`.
+ *
+ * Cache keys are **tenant-scoped automatically** on multiTenant resources, so a
+ * cached page is never served across tenants. They are NOT per-user by default:
+ * if the resource uses user-scoped read **policies** (`read` / `fields` /
+ * `readPushdown`), caching is automatically disabled (with a once-per-isolate
+ * warning) unless you set `perUser: true` to fold the userId into the key —
+ * otherwise one user's policy-shaped view could be served to another.
  */
 export interface EndpointCacheConfig {
   /**

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -35,6 +35,7 @@
 
 import type { Env, MiddlewareHandler } from 'hono';
 import type { ZodObject, ZodRawShape } from 'zod';
+import type { CacheInvalidateInput } from '../core/cache';
 import { generateEndpointClass } from '../core/generate-endpoint-class';
 import type { CrudEndpoints } from '../core/register';
 import type { OpenAPIRoute } from '../core/route';
@@ -112,6 +113,8 @@ export interface CreateEndpointConfig<M extends MetaInput, E extends Env = Env> 
   middlewares?: MiddlewareHandler<E>[];
   hooks?: CreateHooks<M>;
   nestedCreate?: string[];
+  /** Invalidate cached list/read entries after a successful create. */
+  cache?: MutationCacheConfig;
   /**
    * Override the request body validation schema for this endpoint.
    *
@@ -203,6 +206,46 @@ interface ListHooks<M extends MetaInput> {
 }
 
 /**
+ * Response cache configuration for list/read endpoints. Caching is opt-in;
+ * `cacheStorage` is wired separately via `createCacheStorageMiddleware()`
+ * (recommended on Workers) or `setCacheStorage()`. Cache keys are tenant-scoped
+ * automatically on multiTenant resources, so a cached page is never served
+ * across tenants.
+ */
+export interface EndpointCacheConfig {
+  /**
+   * Enable response caching. When the `cache` block is present, this defaults
+   * to `true`; set `false` to keep the block (e.g. `keyFields`) but disable.
+   */
+  enabled?: boolean;
+  /** TTL in seconds. @default 300 */
+  ttl?: number;
+  /** Query params included in the cache key (default: all present query params). */
+  keyFields?: string[];
+  /** Add the request `userId` var to the cache key (per-user caching). */
+  perUser?: boolean;
+  /** Cache key prefix. */
+  prefix?: string;
+  /** Tags attached to cache entries (for tag-based invalidation). */
+  tags?: string[];
+}
+
+/**
+ * Cache invalidation configuration for mutation endpoints (create/update/delete).
+ */
+export interface MutationCacheConfig {
+  /**
+   * What to invalidate after a successful mutation:
+   * - `true` → all cached entries for the model (current tenant)
+   * - `Array<'list' | 'read' | 'all'>` → only those operation caches
+   * - a `CacheInvalidationConfig` for tags / custom pattern / related models
+   */
+  invalidate?: CacheInvalidateInput;
+  /** Prefix of the cache keys to invalidate (must match the read/list cache prefix). */
+  prefix?: string;
+}
+
+/**
  * List endpoint configuration.
  */
 export interface ListEndpointConfig<M extends MetaInput, E extends Env = Env> {
@@ -215,6 +258,7 @@ export interface ListEndpointConfig<M extends MetaInput, E extends Env = Env> {
   pagination?: PaginationConfig;
   includes?: string[];
   fieldSelection?: FieldSelectionConfig;
+  cache?: EndpointCacheConfig;
   hooks?: ListHooks<M>;
 }
 
@@ -239,6 +283,7 @@ export interface ReadEndpointConfig<M extends MetaInput, E extends Env = Env> {
   additionalFilters?: string[];
   includes?: string[];
   fieldSelection?: FieldSelectionConfig;
+  cache?: EndpointCacheConfig;
   hooks?: ReadHooks<M>;
 }
 
@@ -279,6 +324,8 @@ export interface UpdateEndpointConfig<M extends MetaInput, E extends Env = Env> 
   additionalFilters?: string[];
   fields?: UpdateFieldConfig;
   nestedWrites?: string[];
+  /** Invalidate cached list/read entries after a successful update. */
+  cache?: MutationCacheConfig;
   hooks?: UpdateHooks<M>;
   /**
    * Override the request body validation schema for this endpoint.
@@ -317,6 +364,8 @@ export interface DeleteEndpointConfig<M extends MetaInput, E extends Env = Env> 
   lookupField?: string;
   additionalFilters?: string[];
   includeCascadeResults?: boolean;
+  /** Invalidate cached list/read entries after a successful delete. */
+  cache?: MutationCacheConfig;
   hooks?: DeleteHooks<M>;
 }
 
@@ -899,6 +948,8 @@ export function defineEndpoints<M extends MetaInput, E extends Env = Env>(
       beforeHookMode: cfg.hooks?.beforeMode,
       afterHookMode: cfg.hooks?.afterMode,
       allowNestedCreate: cfg.nestedCreate,
+      cacheInvalidate: cfg.cache?.invalidate,
+      cachePrefix: cfg.cache?.prefix,
       before: cfg.hooks?.before as AnyHook,
       after: cfg.hooks?.after as AnyHook,
     });
@@ -932,6 +983,13 @@ export function defineEndpoints<M extends MetaInput, E extends Env = Env>(
       blockedSelectFields: cfg.fieldSelection?.blocked,
       alwaysIncludeFields: cfg.fieldSelection?.alwaysInclude,
       defaultSelectFields: cfg.fieldSelection?.defaults,
+      // Presence of the `cache` block enables caching unless `enabled: false`.
+      cacheEnabled: cfg.cache ? (cfg.cache.enabled ?? true) : undefined,
+      cacheTtlSeconds: cfg.cache?.ttl,
+      cacheKeyFields: cfg.cache?.keyFields,
+      cachePerUser: cfg.cache?.perUser,
+      cachePrefix: cfg.cache?.prefix,
+      cacheTags: cfg.cache?.tags,
       after: cfg.hooks?.after as AnyHook,
       transform: cfg.hooks?.transform as AnyHook,
     });
@@ -952,6 +1010,12 @@ export function defineEndpoints<M extends MetaInput, E extends Env = Env>(
       blockedSelectFields: cfg.fieldSelection?.blocked,
       alwaysIncludeFields: cfg.fieldSelection?.alwaysInclude,
       defaultSelectFields: cfg.fieldSelection?.defaults,
+      cacheEnabled: cfg.cache ? (cfg.cache.enabled ?? true) : undefined,
+      cacheTtlSeconds: cfg.cache?.ttl,
+      cacheKeyFields: cfg.cache?.keyFields,
+      cachePerUser: cfg.cache?.perUser,
+      cachePrefix: cfg.cache?.prefix,
+      cacheTags: cfg.cache?.tags,
       after: cfg.hooks?.after as AnyHook,
       transform: cfg.hooks?.transform as AnyHook,
     });
@@ -970,6 +1034,8 @@ export function defineEndpoints<M extends MetaInput, E extends Env = Env>(
       allowedUpdateFields: cfg.fields?.allowed,
       blockedUpdateFields: cfg.fields?.blocked,
       allowNestedWrites: cfg.nestedWrites,
+      cacheInvalidate: cfg.cache?.invalidate,
+      cachePrefix: cfg.cache?.prefix,
       beforeHookMode: cfg.hooks?.beforeMode,
       afterHookMode: cfg.hooks?.afterMode,
       before: cfg.hooks?.before as AnyHook,
@@ -988,6 +1054,8 @@ export function defineEndpoints<M extends MetaInput, E extends Env = Env>(
       lookupField: cfg.lookupField,
       additionalFilters: cfg.additionalFilters,
       includeCascadeResults: cfg.includeCascadeResults,
+      cacheInvalidate: cfg.cache?.invalidate,
+      cachePrefix: cfg.cache?.prefix,
       beforeHookMode: cfg.hooks?.beforeMode,
       afterHookMode: cfg.hooks?.afterMode,
       before: cfg.hooks?.before as AnyHook,

--- a/packages/core/src/core/cache.ts
+++ b/packages/core/src/core/cache.ts
@@ -105,7 +105,12 @@ export function generateCacheKey(options: CacheKeyOptions): string {
       (key) => query[key] !== undefined && query[key] !== null && query[key] !== '',
     );
     if (keyFields && keyFields.length > 0) {
-      queryKeys = queryKeys.filter((key) => keyFields.includes(key));
+      // Always keep the response-shaping params (`fields`/`include`) in the key
+      // even when `keyFields` narrows the rest — otherwise two requests with
+      // different field-selection / includes would collide on one cached body.
+      queryKeys = queryKeys.filter(
+        (key) => keyFields.includes(key) || key === 'fields' || key === 'include',
+      );
     }
     if (queryKeys.length > 0) {
       const sortedQuery = queryKeys
@@ -228,6 +233,25 @@ export function __resetCacheStorageWarning(): void {
   warnedMissingCacheStorage = false;
 }
 
+/** Once-per-isolate guard for the policy-skip warning. */
+let warnedCacheSkippedForPolicy = false;
+
+/**
+ * Warn once when config-caching is disabled because user-scoped read policies
+ * are present without `cachePerUser` — a tenant-only key would otherwise serve
+ * one user's authorized view to another.
+ */
+export function warnCacheSkippedForPolicy(): void {
+  if (warnedCacheSkippedForPolicy) return;
+  warnedCacheSkippedForPolicy = true;
+  getLogger().warn(
+    'Response caching is disabled for an endpoint with user-scoped read policies ' +
+      '(read / fields / readPushdown) because the cache key is not per-user. Set ' +
+      '`cache.perUser: true` to fold the userId into the key and re-enable caching. ' +
+      'This warning is logged once per isolate.',
+  );
+}
+
 // ============================================================================
 // Endpoint runtime helpers (config-driven cache path)
 // ============================================================================
@@ -336,7 +360,9 @@ export async function writeEndpointCache<T>(
 
   const tags: string[] = ep.cacheTags ? [...ep.cacheTags] : [];
   const tableName = ep._meta?.model?.tableName;
-  if (tableName) tags.push(tableName);
+  // Tenant-scope the auto model tag so tag-based invalidation can't cross
+  // tenants (the bare table tag would clear every tenant's entries).
+  if (tableName) tags.push(tenantId != null ? `${tableName}:t=${tenantId}` : tableName);
 
   await storage.set(key, data, {
     ttlMs: ep.cacheTtlSeconds != null ? ep.cacheTtlSeconds * 1000 : undefined,
@@ -390,7 +416,10 @@ export async function invalidateEndpointCache(
     const config = inv as CacheInvalidationConfig;
     if (config.pattern) patterns.add(config.pattern);
     if (config.tags) for (const t of config.tags) tagsToDelete.add(t);
-    if (config.strategy === 'tags') tagsToDelete.add(tableName);
+    // Match the tenant-scoped auto model tag written by writeEndpointCache.
+    if (config.strategy === 'tags') {
+      tagsToDelete.add(tenantId != null ? `${tableName}:t=${tenantId}` : tableName);
+    }
     if (config.relatedModels) {
       for (const p of createRelatedPatterns(tableName, config.relatedModels, prefix)) {
         patterns.add(p);

--- a/packages/core/src/core/cache.ts
+++ b/packages/core/src/core/cache.ts
@@ -1,0 +1,420 @@
+/**
+ * Core-owned caching primitives.
+ *
+ * Caching used to live entirely in `@hono-crud/cache` (the `withCache` mixin +
+ * a consumer-authored `handle()` override). To make caching reachable through
+ * the CONFIG API (`defineEndpoints` / `endpoints.{list,read}.cache`), core needs
+ * its own cache code path — and therefore owns the cache key format, the
+ * `CacheConfig` shape, and the cache-storage feature/registry. `@hono-crud/cache`
+ * re-exports all of this so there is a SINGLE storage global + ONE key format
+ * shared by both the config path and the mixin.
+ *
+ * `CacheConfig.ttlSeconds` is seconds (ergonomic); the storage boundary
+ * (`CacheSetOptions.ttlMs`) is milliseconds.
+ */
+import type { Context, Env } from 'hono';
+import type { CacheStorage } from '../storage/contracts';
+import { createStorageFeature } from '../storage/feature';
+import { CONTEXT_KEYS } from './context-keys';
+import { getLogger } from './logger';
+
+// ============================================================================
+// Config + key types
+// ============================================================================
+
+/** Per-endpoint cache configuration (list/read). */
+export interface CacheConfig {
+  /** Whether caching is enabled. @default true */
+  enabled?: boolean;
+  /** Time-to-live in seconds. @default 300 (5 min) */
+  ttlSeconds?: number;
+  /** Key prefix for cache entries. */
+  prefix?: string;
+  /** Query parameters to include in the cache key. */
+  keyFields?: string[];
+  /** Include the request `userId` var in the cache key (per-user caching). */
+  perUser?: boolean;
+  /** Tags for group invalidation. */
+  tags?: string[];
+}
+
+/** Invalidation strategy for mutation endpoints. */
+export type InvalidationStrategy =
+  | 'single' // Invalidate only the modified record
+  | 'list' // Invalidate only list caches
+  | 'all' // Invalidate all caches for this model
+  | 'pattern' // Use a custom pattern
+  | 'tags'; // Invalidate by tags
+
+/** Cache invalidation configuration for mutation endpoints. */
+export interface CacheInvalidationConfig {
+  /** Invalidation strategy. @default 'all' */
+  strategy?: InvalidationStrategy;
+  /** Custom pattern for the 'pattern' strategy. */
+  pattern?: string;
+  /** Tags to invalidate for the 'tags' strategy. */
+  tags?: string[];
+  /** Related model table names to also invalidate. */
+  relatedModels?: string[];
+}
+
+/** Options for {@link generateCacheKey}. */
+export interface CacheKeyOptions {
+  tableName: string;
+  method: 'GET' | 'LIST';
+  params?: Record<string, string>;
+  query?: Record<string, unknown>;
+  keyFields?: string[];
+  userId?: string;
+  prefix?: string;
+}
+
+/** Options for {@link createInvalidationPattern}. */
+export interface InvalidationPatternOptions {
+  method?: 'GET' | 'LIST';
+  id?: string | number;
+  userId?: string;
+}
+
+// ============================================================================
+// Key generation / invalidation patterns (pure)
+// ============================================================================
+
+/**
+ * Build a cache key.
+ * Format: `{prefix?}:{tableName}:{method}:{pathParams?}:{queryParams?}:{user=id?}`
+ */
+export function generateCacheKey(options: CacheKeyOptions): string {
+  const { tableName, method, params, query, keyFields, userId, prefix } = options;
+  const parts: string[] = [];
+
+  if (prefix) parts.push(prefix);
+  parts.push(tableName);
+  parts.push(method);
+
+  if (params && Object.keys(params).length > 0) {
+    const sortedParams = Object.keys(params)
+      .sort()
+      .map((key) => `${key}=${params[key]}`)
+      .join('&');
+    parts.push(sortedParams);
+  }
+
+  if (query && Object.keys(query).length > 0) {
+    let queryKeys = Object.keys(query).filter(
+      (key) => query[key] !== undefined && query[key] !== null && query[key] !== '',
+    );
+    if (keyFields && keyFields.length > 0) {
+      queryKeys = queryKeys.filter((key) => keyFields.includes(key));
+    }
+    if (queryKeys.length > 0) {
+      const sortedQuery = queryKeys
+        .sort()
+        .map((key) => `${key}=${String(query[key])}`)
+        .join('&');
+      parts.push(sortedQuery);
+    }
+  }
+
+  if (userId) parts.push(`user=${userId}`);
+
+  return parts.join(':');
+}
+
+/**
+ * Build a glob pattern for invalidating cache entries for a table.
+ *
+ * @example createInvalidationPattern('users') // 'users:*'
+ * @example createInvalidationPattern('users', { method: 'LIST' }) // 'users:LIST*'
+ * @example createInvalidationPattern('users', { id: '123' }) // 'users:*:id=123*'
+ */
+export function createInvalidationPattern(
+  tableName: string,
+  options?: InvalidationPatternOptions,
+  prefix?: string,
+): string {
+  const parts: string[] = [];
+  if (prefix) parts.push(prefix);
+  parts.push(tableName);
+
+  if (!options) {
+    parts.push('*');
+    return parts.join(':');
+  }
+
+  const { method, id, userId } = options;
+  if (method) {
+    parts.push(method);
+    return parts.join(':') + '*';
+  } else if (id !== undefined) {
+    parts.push('*');
+    parts.push(`id=${id}*`);
+  } else if (userId) {
+    parts.push('*');
+    parts.push(`user=${userId}`);
+  } else {
+    parts.push('*');
+  }
+  return parts.join(':');
+}
+
+/** Patterns for invalidating related models. */
+export function createRelatedPatterns(
+  _tableName: string,
+  relatedModels: string[],
+  prefix?: string,
+): string[] {
+  return relatedModels.map((model) => createInvalidationPattern(model, undefined, prefix));
+}
+
+/** Glob match (`*` wildcard) used by in-memory `deletePattern` backends. */
+export function matchesPattern(key: string, pattern: string): boolean {
+  const regexPattern = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+  return new RegExp(`^${regexPattern}$`).test(key);
+}
+
+// ============================================================================
+// Cache storage feature (single global + context resolution)
+// ============================================================================
+
+/**
+ * Cache storage feature. Nullable — no default is created. The request path
+ * resolves explicit > context > global and emits a once-per-isolate warning
+ * when nothing resolves (caching then degrades to a no-op).
+ */
+const cacheStorageFeature = createStorageFeature<CacheStorage>({
+  contextKey: CONTEXT_KEYS.cacheStorage,
+});
+
+/** Backing registry (exported for advanced use / tests). */
+export const cacheStorageRegistry = cacheStorageFeature.registry;
+
+/** Set the global cache storage instance. */
+export const setCacheStorage = cacheStorageFeature.set;
+
+/** Get the explicitly-configured global cache storage, or `null`. Never throws. */
+export const getCacheStorage = cacheStorageFeature.get;
+
+/** Get the global cache storage, throwing if unset. */
+export const getCacheStorageRequired = cacheStorageFeature.getRequired;
+
+/** Resolve cache storage: explicit > context > global. `null` when none. */
+export const resolveCacheStorage = cacheStorageFeature.resolve;
+
+/** Once-per-isolate guard for the missing-storage warning. */
+let warnedMissingCacheStorage = false;
+
+/**
+ * Resolve cache storage for the request path, warning once per isolate when
+ * nothing resolves. Caching then degrades to a no-op — correct for an
+ * optimization-only feature, but loud enough that a mis-wired app (forgotten
+ * `createStorageMiddleware` / `setCacheStorage`) is observable.
+ */
+export function resolveCacheStorageOrWarn(ctx?: Context<Env>): CacheStorage | null {
+  const storage = cacheStorageFeature.resolve(ctx);
+  if (!storage && !warnedMissingCacheStorage) {
+    warnedMissingCacheStorage = true;
+    getLogger().warn(
+      'Cache storage not configured — caching is disabled. Inject cacheStorage with ' +
+        'createStorageMiddleware()/createCacheStorageMiddleware() (recommended) or call ' +
+        'setCacheStorage(). This warning is logged once per isolate.',
+    );
+  }
+  return storage;
+}
+
+/** @internal test seam — reset the once-per-isolate warning guard. */
+export function __resetCacheStorageWarning(): void {
+  warnedMissingCacheStorage = false;
+}
+
+// ============================================================================
+// Endpoint runtime helpers (config-driven cache path)
+// ============================================================================
+
+/** What an endpoint exposes for the cache helpers to read its config + request. */
+export interface CacheableEndpoint {
+  getContext(): Context<Env>;
+  getValidatedData(): Promise<{
+    params?: Record<string, string>;
+    query?: Record<string, unknown>;
+  }>;
+  _meta?: { model?: { tableName?: string } };
+  cacheEnabled: boolean;
+  cacheTtlSeconds?: number;
+  cacheKeyFields?: string[];
+  cachePerUser?: boolean;
+  cachePrefix?: string;
+  cacheTags?: string[];
+}
+
+/** What to invalidate after a mutation. */
+export type CacheInvalidateInput =
+  | boolean
+  | Array<'list' | 'read' | 'all'>
+  | CacheInvalidationConfig;
+
+/** Mutation endpoint surface for invalidation. */
+export interface InvalidatingEndpoint {
+  getContext(): Context<Env>;
+  _meta?: { model?: { tableName?: string } };
+  cacheInvalidate?: CacheInvalidateInput;
+  cachePrefix?: string;
+}
+
+/**
+ * Effective key prefix. The resolved tenant id (for multiTenant resources) is
+ * ALWAYS folded into the prefix so a tenant's cached list/read can never be
+ * served to another tenant — config-cache is safe-by-default on owner-scoped
+ * resources without the consumer remembering `perUser`. Invalidation builds
+ * patterns from the same effective prefix, so a mutation only clears the
+ * mutating tenant's entries.
+ */
+function effectiveCachePrefix(
+  prefix: string | undefined,
+  tenantId: string | undefined,
+): string | undefined {
+  const parts = [prefix, tenantId != null ? `t=${tenantId}` : undefined].filter(
+    (p): p is string => !!p,
+  );
+  return parts.length > 0 ? parts.join(':') : undefined;
+}
+
+/**
+ * Cache key for the current request, or `null` when the model has no table
+ * name (cannot scope a key safely → skip caching).
+ */
+async function buildCacheKey(ep: CacheableEndpoint, tenantId?: string): Promise<string | null> {
+  const tableName = ep._meta?.model?.tableName;
+  if (!tableName) return null;
+
+  const data = await ep.getValidatedData();
+  const params = data.params as Record<string, string> | undefined;
+  const query = data.query as Record<string, unknown> | undefined;
+  const method = params && Object.keys(params).length > 0 ? 'GET' : 'LIST';
+
+  let userId: string | undefined;
+  if (ep.cachePerUser) {
+    const ctx = ep.getContext() as Context<Env & { Variables: { userId?: string } }>;
+    userId = ctx.var?.userId;
+  }
+
+  return generateCacheKey({
+    tableName,
+    method,
+    params,
+    query,
+    keyFields: ep.cacheKeyFields,
+    userId,
+    prefix: effectiveCachePrefix(ep.cachePrefix, tenantId),
+  });
+}
+
+/** Read the cached payload for this request, or `null` on miss / no storage. */
+export async function readEndpointCache<T>(
+  ep: CacheableEndpoint,
+  tenantId?: string,
+): Promise<T | null> {
+  const key = await buildCacheKey(ep, tenantId);
+  if (!key) return null;
+  const storage = resolveCacheStorageOrWarn(ep.getContext());
+  if (!storage) return null;
+  const entry = await storage.get<T>(key);
+  return entry?.data ?? null;
+}
+
+/** Store the payload for this request under its cache key (best-effort). */
+export async function writeEndpointCache<T>(
+  ep: CacheableEndpoint,
+  data: T,
+  tenantId?: string,
+): Promise<void> {
+  const key = await buildCacheKey(ep, tenantId);
+  if (!key) return;
+  const storage = resolveCacheStorageOrWarn(ep.getContext());
+  if (!storage) return;
+
+  const tags: string[] = ep.cacheTags ? [...ep.cacheTags] : [];
+  const tableName = ep._meta?.model?.tableName;
+  if (tableName) tags.push(tableName);
+
+  await storage.set(key, data, {
+    ttlMs: ep.cacheTtlSeconds != null ? ep.cacheTtlSeconds * 1000 : undefined,
+    tags: tags.length > 0 ? tags : undefined,
+  });
+}
+
+/**
+ * Invalidate caches after a successful mutation, per the endpoint's
+ * `cacheInvalidate` config. Best-effort: no storage → no-op.
+ *
+ * - `true` / `['all']` → delete every cache entry for the model's table
+ * - `['list']` / `['read']` → delete only LIST / GET caches for the table
+ * - `CacheInvalidationConfig` → tags (`deleteByTag`), custom `pattern`,
+ *   `relatedModels`, or `strategy` ('all' | 'list' | 'single')
+ *
+ * `single` (record-scoped) collapses to the table-wide pattern here because the
+ * mutation's record id is not threaded into this helper; table-wide is the
+ * safe superset (never serves stale data).
+ */
+export async function invalidateEndpointCache(
+  ep: InvalidatingEndpoint,
+  tenantId?: string,
+): Promise<void> {
+  const inv = ep.cacheInvalidate;
+  if (!inv) return;
+
+  const storage = resolveCacheStorageOrWarn(ep.getContext());
+  if (!storage) return;
+
+  const tableName = ep._meta?.model?.tableName;
+  if (!tableName) return;
+
+  // Same effective prefix used by read/write, so a mutation only clears the
+  // mutating tenant's entries (cross-tenant caches are namespaced apart).
+  const prefix = effectiveCachePrefix(ep.cachePrefix, tenantId);
+  const patterns = new Set<string>();
+  const tagsToDelete = new Set<string>();
+
+  if (inv === true) {
+    patterns.add(createInvalidationPattern(tableName, undefined, prefix));
+  } else if (Array.isArray(inv)) {
+    for (const op of inv) {
+      if (op === 'all') patterns.add(createInvalidationPattern(tableName, undefined, prefix));
+      else if (op === 'list')
+        patterns.add(createInvalidationPattern(tableName, { method: 'LIST' }, prefix));
+      else if (op === 'read')
+        patterns.add(createInvalidationPattern(tableName, { method: 'GET' }, prefix));
+    }
+  } else {
+    const config = inv as CacheInvalidationConfig;
+    if (config.pattern) patterns.add(config.pattern);
+    if (config.tags) for (const t of config.tags) tagsToDelete.add(t);
+    if (config.strategy === 'tags') tagsToDelete.add(tableName);
+    if (config.relatedModels) {
+      for (const p of createRelatedPatterns(tableName, config.relatedModels, prefix)) {
+        patterns.add(p);
+      }
+    }
+    // strategy-driven patterns (default 'all' when nothing else was specified)
+    const strategy = config.strategy ?? (config.pattern || config.tags ? undefined : 'all');
+    if (strategy === 'all' || strategy === 'single') {
+      patterns.add(createInvalidationPattern(tableName, undefined, prefix));
+    } else if (strategy === 'list') {
+      patterns.add(createInvalidationPattern(tableName, { method: 'LIST' }, prefix));
+    }
+  }
+
+  // Best-effort: the mutation already succeeded, so a cache-store error must
+  // never fail the response. Worst case is a stale entry until its TTL.
+  try {
+    if (tagsToDelete.size > 0 && storage.deleteByTag) {
+      for (const tag of tagsToDelete) await storage.deleteByTag(tag);
+    }
+    for (const pattern of patterns) await storage.deletePattern(pattern);
+  } catch (error) {
+    getLogger().warn('Cache invalidation failed after mutation (entries will expire by TTL).', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/packages/core/src/core/generate-endpoint-class.ts
+++ b/packages/core/src/core/generate-endpoint-class.ts
@@ -11,6 +11,7 @@
 
 import type { MiddlewareHandler } from 'hono';
 import type { ZodObject, ZodRawShape } from 'zod';
+import type { CacheInvalidateInput } from './cache';
 import type { HookMode, MetaInput, OpenAPIRouteSchema, SortSpec } from './types';
 
 type AnyHook = (...args: unknown[]) => unknown;
@@ -71,6 +72,14 @@ export interface NormalizedEndpointConfig {
   // adapter without keyset support is asked to cursor-paginate.
   cursorPaginationEnabled?: boolean;
   cursorField?: string;
+  // Response cache (list/read) + invalidation (create/update/delete).
+  cacheEnabled?: boolean;
+  cacheTtlSeconds?: number;
+  cacheKeyFields?: string[];
+  cachePerUser?: boolean;
+  cachePrefix?: string;
+  cacheTags?: string[];
+  cacheInvalidate?: CacheInvalidateInput;
 
   // Verb-specific protected field overrides for endpoints whose
   // configuration shape isn't part of the shared 5-verb surface
@@ -189,6 +198,15 @@ export function generateEndpointClass<B extends abstract new () => unknown>(
     // are config-settable; `supportsCursorPagination` remains adapter-owned.
     protected cursorPaginationEnabled: boolean = config.cursorPaginationEnabled ?? false;
     protected cursorField: string | undefined = config.cursorField;
+    // Response cache (list/read) + invalidation (create/update/delete). Inert
+    // on verbs that don't read these fields.
+    protected cacheEnabled: boolean = config.cacheEnabled ?? false;
+    protected cacheTtlSeconds: number | undefined = config.cacheTtlSeconds;
+    protected cacheKeyFields: string[] | undefined = config.cacheKeyFields;
+    protected cachePerUser: boolean | undefined = config.cachePerUser;
+    protected cachePrefix: string | undefined = config.cachePrefix;
+    protected cacheTags: string[] | undefined = config.cacheTags;
+    protected cacheInvalidate: CacheInvalidateInput | undefined = config.cacheInvalidate;
 
     async before(...args: unknown[]): Promise<unknown> {
       if (config.before) return config.before(...args);

--- a/packages/core/src/endpoints/base.ts
+++ b/packages/core/src/endpoints/base.ts
@@ -18,6 +18,12 @@ import { type AuditLogger, createAuditLogger } from '../audit';
 import { getAuditConfig } from '../audit/config';
 import { POLICIES_CONTEXT_KEY } from '../auth/guards';
 import type { AuthUser } from '../auth/types';
+import {
+  type CacheInvalidateInput,
+  type InvalidatingEndpoint,
+  invalidateEndpointCache,
+  warnCacheSkippedForPolicy,
+} from '../core/cache';
 import { applyComputedFields, applyComputedFieldsToArray } from '../core/computed-fields';
 import { CONTEXT_KEYS } from '../core/context-keys';
 import { ApiException, ForbiddenException, InputValidationException } from '../core/exceptions';
@@ -556,6 +562,72 @@ export abstract class CrudEndpoint<
     // narrow boundary; downstream call sites in `applyRead*`/`applyWrite`
     // use the typed return without further casts.
     return this._meta.model.policies as ModelPolicies<RowOf<M>> | undefined;
+  }
+
+  // --- Response cache (config-driven) — shared across verbs -----------------
+
+  /** Enable response caching (list/read). */
+  protected cacheEnabled = false;
+  /** TTL in seconds. @default 300 */
+  protected cacheTtlSeconds?: number;
+  /** Query params included in the cache key (default: all present query params). */
+  protected cacheKeyFields?: string[];
+  /** Add the request `userId` var to the cache key (per-user caching). */
+  protected cachePerUser?: boolean;
+  /** Tags attached to cache entries (for tag-based invalidation). */
+  protected cacheTags?: string[];
+  /** Invalidation config for mutation verbs (set by the config bridge). */
+  protected cacheInvalidate?: CacheInvalidateInput;
+  /** Cache key prefix (must match the read/list cache prefix). */
+  protected cachePrefix?: string;
+
+  /**
+   * Whether config response-caching is active for THIS request. False when
+   * disabled, or when user-scoped read policies are present and `cachePerUser`
+   * is not set — caching a tenant-only key would serve one user's policy-shaped
+   * view to another, so it is disabled (with a once-per-isolate warning) rather
+   * than risk a leak. Used by list/read.
+   */
+  protected isResponseCacheActive(): boolean {
+    if (!this.cacheEnabled) return false;
+    if (this.cachePerUser) return true;
+    if (this.hasUserScopedReadPolicy()) {
+      warnCacheSkippedForPolicy();
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Whether per-user read policies are configured. When true a response can
+   * vary by caller identity (row filtering, field masking, existence-hiding),
+   * so a tenant-only cache key would leak one user's view to another. List/Read
+   * therefore SKIP config-caching when this is true unless `cachePerUser` folds
+   * the userId into the key.
+   */
+  protected hasUserScopedReadPolicy(): boolean {
+    const p = this.getPolicies();
+    return !!(p && (p.read || p.fields || p.readPushdown));
+  }
+
+  /**
+   * Invalidate this tenant's cached list/read entries after a successful
+   * mutation. Best-effort + a no-op when no cache store is configured, so every
+   * mutation verb can call it unconditionally. Defaults to busting all of the
+   * model's cache for the tenant; `cacheInvalidate` narrows it.
+   */
+  protected async invalidateModelCache(): Promise<void> {
+    // Context<E> → Context<Env> is invariant; the whole shape is cast at this
+    // boundary (the helper only reads context + meta + the cache config).
+    await invalidateEndpointCache(
+      {
+        getContext: () => this.getContext(),
+        _meta: this._meta,
+        cacheInvalidate: this.cacheInvalidate ?? true,
+        cachePrefix: this.cachePrefix,
+      } as unknown as InvalidatingEndpoint,
+      this.getTenantId(),
+    );
   }
 
   /**

--- a/packages/core/src/endpoints/batch-create.ts
+++ b/packages/core/src/endpoints/batch-create.ts
@@ -282,6 +282,9 @@ export abstract class BatchCreateEndpoint<
 
     // Return 207 if there were partial errors
     const status = errors.length > 0 ? 207 : 201;
+    // Mutation changes which rows a cached list/read would return.
+    await this.invalidateModelCache();
+
     return this.json(response, status);
   }
 }

--- a/packages/core/src/endpoints/batch-delete.ts
+++ b/packages/core/src/endpoints/batch-delete.ts
@@ -241,6 +241,9 @@ export abstract class BatchDeleteEndpoint<
 
     // Return 207 if there were partial errors or not found items
     const status = errors.length > 0 || notFound.length > 0 ? 207 : 200;
+    // Mutation changes which rows a cached list/read would return.
+    await this.invalidateModelCache();
+
     return this.json(response, status);
   }
 }

--- a/packages/core/src/endpoints/batch-restore.ts
+++ b/packages/core/src/endpoints/batch-restore.ts
@@ -250,6 +250,9 @@ export abstract class BatchRestoreEndpoint<
 
     // Return 207 if there were partial errors or not found items
     const status = errors.length > 0 || notFound.length > 0 ? 207 : 200;
+    // Mutation changes which rows a cached list/read would return.
+    await this.invalidateModelCache();
+
     return this.json(response, status);
   }
 }

--- a/packages/core/src/endpoints/batch-update.ts
+++ b/packages/core/src/endpoints/batch-update.ts
@@ -300,6 +300,9 @@ export abstract class BatchUpdateEndpoint<
 
     // Return 207 if there were partial errors or not found items
     const status = errors.length > 0 || notFound.length > 0 ? 207 : 200;
+    // Mutation changes which rows a cached list/read would return.
+    await this.invalidateModelCache();
+
     return this.json(response, status);
   }
 }

--- a/packages/core/src/endpoints/batch-upsert.ts
+++ b/packages/core/src/endpoints/batch-upsert.ts
@@ -555,6 +555,9 @@ export abstract class BatchUpsertEndpoint<
       };
     });
 
+    // Mutation changes which rows a cached list/read would return.
+    await this.invalidateModelCache();
+
     return this.success(result);
   }
 }

--- a/packages/core/src/endpoints/bulk-patch.ts
+++ b/packages/core/src/endpoints/bulk-patch.ts
@@ -219,6 +219,9 @@ export abstract class BulkPatchEndpoint<
       await this.afterBulkPatch(bulkResult);
     }
 
+    // Mutation changes which rows a cached list/read would return.
+    await this.invalidateModelCache();
+
     return this.json({
       success: true,
       matched: bulkResult.matched,

--- a/packages/core/src/endpoints/clone.ts
+++ b/packages/core/src/endpoints/clone.ts
@@ -222,6 +222,9 @@ export abstract class CloneEndpoint<
     // computed fields → serializer → profile → transform
     const result = await this.finalizeRecord(obj);
 
+    // Mutation changes which rows a cached list/read would return.
+    await this.invalidateModelCache();
+
     return this.success(result, 201);
   }
 }

--- a/packages/core/src/endpoints/create.ts
+++ b/packages/core/src/endpoints/create.ts
@@ -1,5 +1,10 @@
 import type { Env } from 'hono';
 import { type ZodObject, type ZodRawShape, z } from 'zod';
+import {
+  type CacheInvalidateInput,
+  type InvalidatingEndpoint,
+  invalidateEndpointCache,
+} from '../core/cache';
 import { getLogger } from '../core/logger';
 import { getManagedInputExclusions, rethrowAsConstraintError } from '../core/managed-fields';
 import { extractNestedData } from '../core/nested-writes';
@@ -48,6 +53,12 @@ export abstract class CreateEndpoint<
   // Nested writes configuration
   /** Relations that allow nested creates. If empty, uses relation config. */
   protected allowNestedCreate: string[] = [];
+
+  // Cache invalidation (config-driven) — after a successful create, clears this
+  // tenant's cached list/read entries for the model per `cacheInvalidate`.
+  protected cacheInvalidate?: CacheInvalidateInput;
+  /** Prefix of the cache keys to invalidate (must match the read/list cachePrefix). */
+  protected cachePrefix?: string;
 
   // Audit logging
 
@@ -399,6 +410,9 @@ export abstract class CreateEndpoint<
 
     // computed fields → serializer → profile → transform
     const result = await this.finalizeRecord(obj);
+
+    // Invalidate this tenant's cached list/read entries (best-effort).
+    await invalidateEndpointCache(this as unknown as InvalidatingEndpoint, this.getTenantId());
 
     return this.success(result, 201);
   }

--- a/packages/core/src/endpoints/create.ts
+++ b/packages/core/src/endpoints/create.ts
@@ -1,10 +1,5 @@
 import type { Env } from 'hono';
 import { type ZodObject, type ZodRawShape, z } from 'zod';
-import {
-  type CacheInvalidateInput,
-  type InvalidatingEndpoint,
-  invalidateEndpointCache,
-} from '../core/cache';
 import { getLogger } from '../core/logger';
 import { getManagedInputExclusions, rethrowAsConstraintError } from '../core/managed-fields';
 import { extractNestedData } from '../core/nested-writes';
@@ -53,12 +48,6 @@ export abstract class CreateEndpoint<
   // Nested writes configuration
   /** Relations that allow nested creates. If empty, uses relation config. */
   protected allowNestedCreate: string[] = [];
-
-  // Cache invalidation (config-driven) — after a successful create, clears this
-  // tenant's cached list/read entries for the model per `cacheInvalidate`.
-  protected cacheInvalidate?: CacheInvalidateInput;
-  /** Prefix of the cache keys to invalidate (must match the read/list cachePrefix). */
-  protected cachePrefix?: string;
 
   // Audit logging
 
@@ -412,7 +401,7 @@ export abstract class CreateEndpoint<
     const result = await this.finalizeRecord(obj);
 
     // Invalidate this tenant's cached list/read entries (best-effort).
-    await invalidateEndpointCache(this as unknown as InvalidatingEndpoint, this.getTenantId());
+    await this.invalidateModelCache();
 
     return this.success(result, 201);
   }

--- a/packages/core/src/endpoints/delete.ts
+++ b/packages/core/src/endpoints/delete.ts
@@ -1,5 +1,10 @@
 import type { Env } from 'hono';
 import { type ZodObject, type ZodRawShape, z } from 'zod';
+import {
+  type CacheInvalidateInput,
+  type InvalidatingEndpoint,
+  invalidateEndpointCache,
+} from '../core/cache';
 import { ConflictException, NotFoundException } from '../core/exceptions';
 import { getLogger } from '../core/logger';
 import type {
@@ -69,6 +74,12 @@ export abstract class DeleteEndpoint<
   protected lookupField = 'id';
   protected lookupFields?: string[];
   protected additionalFilters?: string[];
+
+  // Cache invalidation (config-driven) — after a successful delete, clears this
+  // tenant's cached list/read entries for the model per `cacheInvalidate`.
+  protected cacheInvalidate?: CacheInvalidateInput;
+  /** Prefix of the cache keys to invalidate (must match the read/list cachePrefix). */
+  protected cachePrefix?: string;
 
   // Hook execution mode
   protected beforeHookMode: HookMode = 'sequential';
@@ -523,6 +534,9 @@ export abstract class DeleteEndpoint<
         response.cascade = cascadeResult;
       }
     }
+
+    // Invalidate this tenant's cached list/read entries (best-effort).
+    await invalidateEndpointCache(this as unknown as InvalidatingEndpoint, tenantId);
 
     return this.success(response);
   }

--- a/packages/core/src/endpoints/delete.ts
+++ b/packages/core/src/endpoints/delete.ts
@@ -1,10 +1,5 @@
 import type { Env } from 'hono';
 import { type ZodObject, type ZodRawShape, z } from 'zod';
-import {
-  type CacheInvalidateInput,
-  type InvalidatingEndpoint,
-  invalidateEndpointCache,
-} from '../core/cache';
 import { ConflictException, NotFoundException } from '../core/exceptions';
 import { getLogger } from '../core/logger';
 import type {
@@ -74,12 +69,6 @@ export abstract class DeleteEndpoint<
   protected lookupField = 'id';
   protected lookupFields?: string[];
   protected additionalFilters?: string[];
-
-  // Cache invalidation (config-driven) — after a successful delete, clears this
-  // tenant's cached list/read entries for the model per `cacheInvalidate`.
-  protected cacheInvalidate?: CacheInvalidateInput;
-  /** Prefix of the cache keys to invalidate (must match the read/list cachePrefix). */
-  protected cachePrefix?: string;
 
   // Hook execution mode
   protected beforeHookMode: HookMode = 'sequential';
@@ -536,7 +525,7 @@ export abstract class DeleteEndpoint<
     }
 
     // Invalidate this tenant's cached list/read entries (best-effort).
-    await invalidateEndpointCache(this as unknown as InvalidatingEndpoint, tenantId);
+    await this.invalidateModelCache();
 
     return this.success(response);
   }

--- a/packages/core/src/endpoints/import.ts
+++ b/packages/core/src/endpoints/import.ts
@@ -813,6 +813,9 @@ export abstract class ImportEndpoint<
     // Return 207 Multi-Status if there were partial failures
     const status = summary.failed > 0 && summary.failed < summary.total ? 207 : 200;
 
+    // Mutation changes which rows a cached list/read would return.
+    await this.invalidateModelCache();
+
     return this.json({ success: true, result: importResult }, status);
   }
 }

--- a/packages/core/src/endpoints/list.ts
+++ b/packages/core/src/endpoints/list.ts
@@ -114,24 +114,7 @@ export abstract class ListEndpoint<
   protected alwaysIncludeFields: string[] = [];
   /** Default fields to return when no fields parameter is provided. */
   protected defaultSelectFields: string[] = [];
-
-  // Response caching (config-driven). When `cacheEnabled`, the list payload
-  // (`{ result, result_info }`) is read from / written to the resolved cache
-  // storage, keyed by table + method + query (+ tenant, always, and userId when
-  // `cachePerUser`). Storage is resolved from request context
-  // (`createCacheStorageMiddleware`) or the global `setCacheStorage`.
-  /** Enable response caching for this list endpoint. */
-  protected cacheEnabled = false;
-  /** TTL in seconds. @default 300 */
-  protected cacheTtlSeconds?: number;
-  /** Query params included in the cache key (default: all present). */
-  protected cacheKeyFields?: string[];
-  /** Add the request `userId` var to the cache key (per-user caching). */
-  protected cachePerUser?: boolean;
-  /** Cache key prefix. */
-  protected cachePrefix?: string;
-  /** Tags attached to cache entries (for tag-based invalidation). */
-  protected cacheTags?: string[];
+  // Response cache fields (cacheEnabled/cacheTtlSeconds/…) live on CrudEndpoint.
 
   /**
    * Get the soft delete configuration for this model.
@@ -406,9 +389,12 @@ export abstract class ListEndpoint<
     this.validateTenantId();
 
     // Response cache check (config-driven). The key is tenant-scoped, so a
-    // cached page is only ever served back to the tenant that produced it.
-    const cacheTenantId = this.cacheEnabled ? this.getTenantId() : undefined;
-    if (this.cacheEnabled) {
+    // cached page is only ever served back to the tenant that produced it;
+    // `isResponseCacheActive` also disables caching under user-scoped read
+    // policies (unless cachePerUser) so one user's view can't leak to another.
+    const cacheActive = this.isResponseCacheActive();
+    const cacheTenantId = cacheActive ? this.getTenantId() : undefined;
+    if (cacheActive) {
       const cached = await readEndpointCache<{
         result: ModelObject<M['model']>[];
         result_info: PaginatedResult<ModelObject<M['model']>>['result_info'];
@@ -454,7 +440,7 @@ export abstract class ListEndpoint<
         : undefined;
     const result = await this.finalizeArray(items, fieldSelection);
 
-    if (this.cacheEnabled) {
+    if (cacheActive) {
       await writeEndpointCache(
         this as unknown as CacheableEndpoint,
         { result, result_info: paginatedResult.result_info },
@@ -463,7 +449,7 @@ export abstract class ListEndpoint<
     }
 
     const response = this.successPaginated(result, paginatedResult.result_info);
-    if (this.cacheEnabled) response.headers.set('X-Cache', 'MISS');
+    if (cacheActive) response.headers.set('X-Cache', 'MISS');
     return response;
   }
 }

--- a/packages/core/src/endpoints/list.ts
+++ b/packages/core/src/endpoints/list.ts
@@ -1,5 +1,6 @@
 import type { Env } from 'hono';
 import { type ZodObject, type ZodRawShape, z } from 'zod';
+import { type CacheableEndpoint, readEndpointCache, writeEndpointCache } from '../core/cache';
 import { ConfigurationException } from '../core/exceptions';
 import type {
   FilterConfig,
@@ -113,6 +114,24 @@ export abstract class ListEndpoint<
   protected alwaysIncludeFields: string[] = [];
   /** Default fields to return when no fields parameter is provided. */
   protected defaultSelectFields: string[] = [];
+
+  // Response caching (config-driven). When `cacheEnabled`, the list payload
+  // (`{ result, result_info }`) is read from / written to the resolved cache
+  // storage, keyed by table + method + query (+ tenant, always, and userId when
+  // `cachePerUser`). Storage is resolved from request context
+  // (`createCacheStorageMiddleware`) or the global `setCacheStorage`.
+  /** Enable response caching for this list endpoint. */
+  protected cacheEnabled = false;
+  /** TTL in seconds. @default 300 */
+  protected cacheTtlSeconds?: number;
+  /** Query params included in the cache key (default: all present). */
+  protected cacheKeyFields?: string[];
+  /** Add the request `userId` var to the cache key (per-user caching). */
+  protected cachePerUser?: boolean;
+  /** Cache key prefix. */
+  protected cachePrefix?: string;
+  /** Tags attached to cache entries (for tag-based invalidation). */
+  protected cacheTags?: string[];
 
   /**
    * Get the soft delete configuration for this model.
@@ -386,6 +405,21 @@ export abstract class ListEndpoint<
     // (parity with the pre-refactor List contract).
     this.validateTenantId();
 
+    // Response cache check (config-driven). The key is tenant-scoped, so a
+    // cached page is only ever served back to the tenant that produced it.
+    const cacheTenantId = this.cacheEnabled ? this.getTenantId() : undefined;
+    if (this.cacheEnabled) {
+      const cached = await readEndpointCache<{
+        result: ModelObject<M['model']>[];
+        result_info: PaginatedResult<ModelObject<M['model']>>['result_info'];
+      }>(this as unknown as CacheableEndpoint, cacheTenantId);
+      if (cached) {
+        const hit = this.successPaginated(cached.result, cached.result_info);
+        hit.headers.set('X-Cache', 'HIT');
+        return hit;
+      }
+    }
+
     const filters = await this.getFilters();
 
     // Constrain results to the caller's tenant. Shared with search/export/
@@ -420,6 +454,16 @@ export abstract class ListEndpoint<
         : undefined;
     const result = await this.finalizeArray(items, fieldSelection);
 
-    return this.successPaginated(result, paginatedResult.result_info);
+    if (this.cacheEnabled) {
+      await writeEndpointCache(
+        this as unknown as CacheableEndpoint,
+        { result, result_info: paginatedResult.result_info },
+        cacheTenantId,
+      );
+    }
+
+    const response = this.successPaginated(result, paginatedResult.result_info);
+    if (this.cacheEnabled) response.headers.set('X-Cache', 'MISS');
+    return response;
   }
 }

--- a/packages/core/src/endpoints/read.ts
+++ b/packages/core/src/endpoints/read.ts
@@ -1,5 +1,6 @@
 import type { Env } from 'hono';
 import { type ZodObject, type ZodRawShape, z } from 'zod';
+import { type CacheableEndpoint, readEndpointCache, writeEndpointCache } from '../core/cache';
 import { NotFoundException } from '../core/exceptions';
 import type { IncludeOptions, MetaInput, OpenAPIRouteSchema } from '../core/types';
 import { withIncludableRelations } from '../relations/response-schema';
@@ -28,6 +29,21 @@ export abstract class ReadEndpoint<
   // ETag configuration
   /** Enable ETag generation and If-None-Match support for conditional requests */
   protected etagEnabled = false;
+
+  // Response caching (config-driven) — caches the single record keyed by table
+  // + id params (+ tenant, always; + userId when `cachePerUser`). See ListEndpoint.
+  /** Enable response caching for this read endpoint. */
+  protected cacheEnabled = false;
+  /** TTL in seconds. @default 300 */
+  protected cacheTtlSeconds?: number;
+  /** Query params included in the cache key (default: all present). */
+  protected cacheKeyFields?: string[];
+  /** Add the request `userId` var to the cache key (per-user caching). */
+  protected cachePerUser?: boolean;
+  /** Cache key prefix. */
+  protected cachePrefix?: string;
+  /** Tags attached to cache entries (for tag-based invalidation). */
+  protected cacheTags?: string[];
 
   // Relations configuration
   /** Allowed relation names that can be included via ?include=relation1,relation2 */
@@ -324,6 +340,20 @@ export abstract class ReadEndpoint<
     // Validate tenant ID if multi-tenancy is enabled
     const tenantId = this.validateTenantId();
 
+    // Response cache check (config-driven). Tenant-scoped key, so a cached
+    // record is only ever served back to the tenant that produced it.
+    if (this.cacheEnabled) {
+      const cached = await readEndpointCache<ModelObject<M['model']>>(
+        this as unknown as CacheableEndpoint,
+        tenantId,
+      );
+      if (cached) {
+        const hit = this.success(cached);
+        hit.headers.set('X-Cache', 'HIT');
+        return hit;
+      }
+    }
+
     const lookupValue = await this.getLookupValue();
     const additionalFilters = await this.getAdditionalFilters();
     const includeOptions = await this.getIncludeOptions();
@@ -360,6 +390,12 @@ export abstract class ReadEndpoint<
     // computed fields → serializer → profile → transform → field selection
     const result = await this.finalizeRecord(obj, fieldSelection);
 
+    // Populate the response cache (config-driven) before the ETag branch so the
+    // record is cached even when this request 304s on a conditional GET.
+    if (this.cacheEnabled) {
+      await writeEndpointCache(this as unknown as CacheableEndpoint, result, tenantId);
+    }
+
     // ETag support
     if (this.etagEnabled) {
       const etag = await generateETag(result);
@@ -377,6 +413,8 @@ export abstract class ReadEndpoint<
       ctx.header('ETag', etag);
     }
 
-    return this.success(result);
+    const response = this.success(result);
+    if (this.cacheEnabled) response.headers.set('X-Cache', 'MISS');
+    return response;
   }
 }

--- a/packages/core/src/endpoints/read.ts
+++ b/packages/core/src/endpoints/read.ts
@@ -30,20 +30,7 @@ export abstract class ReadEndpoint<
   /** Enable ETag generation and If-None-Match support for conditional requests */
   protected etagEnabled = false;
 
-  // Response caching (config-driven) — caches the single record keyed by table
-  // + id params (+ tenant, always; + userId when `cachePerUser`). See ListEndpoint.
-  /** Enable response caching for this read endpoint. */
-  protected cacheEnabled = false;
-  /** TTL in seconds. @default 300 */
-  protected cacheTtlSeconds?: number;
-  /** Query params included in the cache key (default: all present). */
-  protected cacheKeyFields?: string[];
-  /** Add the request `userId` var to the cache key (per-user caching). */
-  protected cachePerUser?: boolean;
-  /** Cache key prefix. */
-  protected cachePrefix?: string;
-  /** Tags attached to cache entries (for tag-based invalidation). */
-  protected cacheTags?: string[];
+  // Response cache fields (cacheEnabled/cacheTtlSeconds/…) live on CrudEndpoint.
 
   // Relations configuration
   /** Allowed relation names that can be included via ?include=relation1,relation2 */
@@ -341,13 +328,25 @@ export abstract class ReadEndpoint<
     const tenantId = this.validateTenantId();
 
     // Response cache check (config-driven). Tenant-scoped key, so a cached
-    // record is only ever served back to the tenant that produced it.
-    if (this.cacheEnabled) {
+    // record is only ever served back to the tenant that produced it;
+    // `isResponseCacheActive` disables caching under user-scoped read policies
+    // (unless cachePerUser) so one user's view can't leak to another.
+    const cacheActive = this.isResponseCacheActive();
+    if (cacheActive) {
       const cached = await readEndpointCache<ModelObject<M['model']>>(
         this as unknown as CacheableEndpoint,
         tenantId,
       );
       if (cached) {
+        // Honor conditional GET on a cache HIT too (parity with the MISS path).
+        if (this.etagEnabled) {
+          const etag = await generateETag(cached);
+          const ctx = this.getContext();
+          if (matchesIfNoneMatch(ctx.req.header('If-None-Match'), etag)) {
+            return new Response(null, { status: 304, headers: { ETag: etag, 'X-Cache': 'HIT' } });
+          }
+          ctx.header('ETag', etag);
+        }
         const hit = this.success(cached);
         hit.headers.set('X-Cache', 'HIT');
         return hit;
@@ -392,7 +391,7 @@ export abstract class ReadEndpoint<
 
     // Populate the response cache (config-driven) before the ETag branch so the
     // record is cached even when this request 304s on a conditional GET.
-    if (this.cacheEnabled) {
+    if (cacheActive) {
       await writeEndpointCache(this as unknown as CacheableEndpoint, result, tenantId);
     }
 
@@ -406,7 +405,7 @@ export abstract class ReadEndpoint<
       if (matchesIfNoneMatch(ifNoneMatch, etag)) {
         return new Response(null, {
           status: 304,
-          headers: { ETag: etag },
+          headers: cacheActive ? { ETag: etag, 'X-Cache': 'MISS' } : { ETag: etag },
         });
       }
 
@@ -414,7 +413,7 @@ export abstract class ReadEndpoint<
     }
 
     const response = this.success(result);
-    if (this.cacheEnabled) response.headers.set('X-Cache', 'MISS');
+    if (cacheActive) response.headers.set('X-Cache', 'MISS');
     return response;
   }
 }

--- a/packages/core/src/endpoints/restore.ts
+++ b/packages/core/src/endpoints/restore.ts
@@ -205,6 +205,9 @@ export abstract class RestoreEndpoint<
     // computed fields → serializer → profile → transform
     const result = await this.finalizeRecord(restoredItem);
 
+    // Mutation changes which rows a cached list/read would return.
+    await this.invalidateModelCache();
+
     return this.success(result);
   }
 }

--- a/packages/core/src/endpoints/update.ts
+++ b/packages/core/src/endpoints/update.ts
@@ -1,5 +1,10 @@
 import type { Env } from 'hono';
 import { type ZodObject, type ZodRawShape, z } from 'zod';
+import {
+  type CacheInvalidateInput,
+  type InvalidatingEndpoint,
+  invalidateEndpointCache,
+} from '../core/cache';
 import { NotFoundException } from '../core/exceptions';
 import { getLogger } from '../core/logger';
 import { getManagedInputExclusions } from '../core/managed-fields';
@@ -57,6 +62,12 @@ export abstract class UpdateEndpoint<
   // Update field control
   protected allowedUpdateFields?: string[];
   protected blockedUpdateFields?: string[];
+
+  // Cache invalidation (config-driven) — after a successful update, clears this
+  // tenant's cached list/read entries for the model per `cacheInvalidate`.
+  protected cacheInvalidate?: CacheInvalidateInput;
+  /** Prefix of the cache keys to invalidate (must match the read/list cachePrefix). */
+  protected cachePrefix?: string;
 
   // Hook execution mode
   protected beforeHookMode: HookMode = 'sequential';
@@ -623,6 +634,9 @@ export abstract class UpdateEndpoint<
       const etag = await generateETag(result);
       this.getContext().header('ETag', etag);
     }
+
+    // Invalidate this tenant's cached list/read entries (best-effort).
+    await invalidateEndpointCache(this as unknown as InvalidatingEndpoint, tenantId);
 
     return this.success(result);
   }

--- a/packages/core/src/endpoints/update.ts
+++ b/packages/core/src/endpoints/update.ts
@@ -1,10 +1,5 @@
 import type { Env } from 'hono';
 import { type ZodObject, type ZodRawShape, z } from 'zod';
-import {
-  type CacheInvalidateInput,
-  type InvalidatingEndpoint,
-  invalidateEndpointCache,
-} from '../core/cache';
 import { NotFoundException } from '../core/exceptions';
 import { getLogger } from '../core/logger';
 import { getManagedInputExclusions } from '../core/managed-fields';
@@ -62,12 +57,6 @@ export abstract class UpdateEndpoint<
   // Update field control
   protected allowedUpdateFields?: string[];
   protected blockedUpdateFields?: string[];
-
-  // Cache invalidation (config-driven) — after a successful update, clears this
-  // tenant's cached list/read entries for the model per `cacheInvalidate`.
-  protected cacheInvalidate?: CacheInvalidateInput;
-  /** Prefix of the cache keys to invalidate (must match the read/list cachePrefix). */
-  protected cachePrefix?: string;
 
   // Hook execution mode
   protected beforeHookMode: HookMode = 'sequential';
@@ -636,7 +625,7 @@ export abstract class UpdateEndpoint<
     }
 
     // Invalidate this tenant's cached list/read entries (best-effort).
-    await invalidateEndpointCache(this as unknown as InvalidatingEndpoint, tenantId);
+    await this.invalidateModelCache();
 
     return this.success(result);
   }

--- a/packages/core/src/endpoints/upsert.ts
+++ b/packages/core/src/endpoints/upsert.ts
@@ -641,6 +641,9 @@ export abstract class UpsertEndpoint<
     const finalized = await this.finalizeRecord(obj);
 
     // Return with created flag and appropriate status code
+    // Mutation changes which rows a cached list/read would return.
+    await this.invalidateModelCache();
+
     return this.json(
       {
         success: true as const,

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -199,3 +199,30 @@ export type { ClientIpOptions } from './utils/request-info';
 // Generic TTL Map store composed by the in-memory cache/rate-limit/idempotency backends.
 export { MemoryTtlStore } from './storage/memory-ttl-store';
 export type { MemoryTtlStoreOptions } from './storage/memory-ttl-store';
+
+// Caching primitives (config-API cache path; shared key format with @hono-crud/cache).
+export {
+  generateCacheKey,
+  createInvalidationPattern,
+  createRelatedPatterns,
+  matchesPattern,
+  setCacheStorage,
+  getCacheStorage,
+  getCacheStorageRequired,
+  resolveCacheStorage,
+  resolveCacheStorageOrWarn,
+  cacheStorageRegistry,
+  readEndpointCache,
+  writeEndpointCache,
+  invalidateEndpointCache,
+} from './core/cache';
+export type {
+  CacheConfig,
+  CacheInvalidationConfig,
+  CacheInvalidateInput,
+  CacheKeyOptions,
+  InvalidationStrategy,
+  InvalidationPatternOptions,
+  CacheableEndpoint,
+  InvalidatingEndpoint,
+} from './core/cache';

--- a/tests/new-features.test.ts
+++ b/tests/new-features.test.ts
@@ -17,7 +17,7 @@ import type { MetaInput, Model } from 'hono-crud';
 import { generateETag, matchesIfMatch, matchesIfNoneMatch } from 'hono-crud';
 import { decodeCursor, encodeCursor } from 'hono-crud';
 import { CrudEventEmitter } from 'hono-crud/events/emitter';
-import { setCacheStorage } from 'hono-crud/internal';
+import { generateCacheKey, setCacheStorage } from 'hono-crud/internal';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
@@ -360,6 +360,74 @@ describe('Response caching (config API)', () => {
     expect(afterUpdate.headers.get('X-Cache')).toBe('MISS');
     const body = (await afterUpdate.json()) as { result: { age: number } };
     expect(body.result.age).toBe(26);
+  });
+
+  it('DISABLES caching when a user-scoped read policy is present (no cross-user leak)', async () => {
+    clearStorage();
+    setCacheStorage(new MemoryCacheStorage());
+    const policyApp = fromHono(new Hono());
+    // A `read` policy makes responses vary per user; a tenant-only cache key
+    // would leak. With no `perUser`, caching must be disabled (no X-Cache).
+    const policyMeta: UserMeta = {
+      model: { ...UserModel, policies: { read: () => true } },
+    };
+    const endpoints = defineEndpoints(
+      {
+        meta: policyMeta,
+        create: {},
+        list: { cache: { ttl: 300 } },
+        read: { cache: { ttl: 300 } },
+      },
+      MemoryAdapters,
+    );
+    registerCrud(policyApp, '/policy-users', endpoints as any);
+    await policyApp.request('/policy-users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'P', email: 'p@cache.com', age: 1 }),
+    });
+
+    const r1 = await policyApp.request('/policy-users');
+    const r2 = await policyApp.request('/policy-users');
+    expect(r1.headers.get('X-Cache')).toBeNull();
+    expect(r2.headers.get('X-Cache')).toBeNull();
+  });
+});
+
+// ============================================================================
+// Cache key generation (config-cache key format)
+// ============================================================================
+
+describe('Cache key generation', () => {
+  it('keeps response-shaping params (fields/include) in the key even when keyFields is set', () => {
+    // ?fields=a vs ?fields=b,c must NOT collide on one cached body.
+    const a = generateCacheKey({
+      tableName: 'users',
+      method: 'LIST',
+      query: { page: 1, fields: 'a', include: 'posts' },
+      keyFields: ['page'],
+    });
+    const b = generateCacheKey({
+      tableName: 'users',
+      method: 'LIST',
+      query: { page: 1, fields: 'b,c', include: 'posts' },
+      keyFields: ['page'],
+    });
+    expect(a).toContain('fields=a');
+    expect(a).toContain('include=posts');
+    expect(a).not.toBe(b);
+  });
+
+  it('folds tenant + userId into the key (isolation dimensions)', () => {
+    const key = generateCacheKey({
+      tableName: 'users',
+      method: 'LIST',
+      query: { page: 1 },
+      userId: 'u1',
+      prefix: 't=tenantA',
+    });
+    expect(key.startsWith('t=tenantA:users:LIST')).toBe(true);
+    expect(key).toContain('user=u1');
   });
 });
 

--- a/tests/new-features.test.ts
+++ b/tests/new-features.test.ts
@@ -1,3 +1,4 @@
+import { MemoryCacheStorage } from '@hono-crud/cache';
 import { createIdempotencyMiddleware } from '@hono-crud/idempotency/middleware';
 import { MemoryIdempotencyStorage } from '@hono-crud/idempotency/storage/memory';
 import {
@@ -16,6 +17,7 @@ import type { MetaInput, Model } from 'hono-crud';
 import { generateETag, matchesIfMatch, matchesIfNoneMatch } from 'hono-crud';
 import { decodeCursor, encodeCursor } from 'hono-crud';
 import { CrudEventEmitter } from 'hono-crud/events/emitter';
+import { setCacheStorage } from 'hono-crud/internal';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
@@ -257,6 +259,107 @@ describe('Cursor-Based Pagination (config API)', () => {
     expect(data.result_info.page).toBe(1);
     expect(data.result_info.total_count).toBe(4);
     expect('next_cursor' in data.result_info).toBe(false);
+  });
+});
+
+// ============================================================================
+// Response caching via the CONFIG API (defineEndpoints)
+// ============================================================================
+// Pins that `endpoints.{list,read}.cache` caches responses (X-Cache MISS→HIT)
+// and `endpoints.{create,update,delete}.cache.invalidate` busts them — all
+// through config, no subclassing. Storage is resolved from the global set here;
+// the request path also accepts createCacheStorageMiddleware context wiring.
+
+describe('Response caching (config API)', () => {
+  let app: ReturnType<typeof fromHono>;
+
+  beforeEach(() => {
+    clearStorage();
+    setCacheStorage(new MemoryCacheStorage());
+    app = fromHono(new Hono());
+    const endpoints = defineEndpoints(
+      {
+        meta: userMeta,
+        create: { cache: { invalidate: true } },
+        list: { cache: { ttl: 300 } },
+        read: { cache: { ttl: 300 } },
+        update: { cache: { invalidate: ['list', 'read'] } },
+        delete: { cache: { invalidate: true } },
+      },
+      MemoryAdapters,
+    );
+    registerCrud(app, '/cached-users', endpoints as any);
+  });
+
+  async function createUser(body: Record<string, unknown>) {
+    const res = await app.request('/cached-users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    // biome-ignore lint/suspicious/noExplicitAny: test payload
+    return (await res.json()) as any;
+  }
+
+  it('caches the list response (MISS then HIT, identical body)', async () => {
+    await createUser({ name: 'Alice', email: 'alice@cache.com', age: 30 });
+
+    const r1 = await app.request('/cached-users');
+    expect(r1.headers.get('X-Cache')).toBe('MISS');
+    const b1 = (await r1.json()) as { result: unknown[] };
+
+    const r2 = await app.request('/cached-users');
+    expect(r2.headers.get('X-Cache')).toBe('HIT');
+    const b2 = (await r2.json()) as { result: unknown[] };
+
+    expect(b2.result).toEqual(b1.result);
+  });
+
+  it('caches the read response (MISS then HIT)', async () => {
+    const created = await createUser({ name: 'Bob', email: 'bob@cache.com', age: 25 });
+    const id = created.result.id;
+
+    const r1 = await app.request(`/cached-users/${id}`);
+    expect(r1.headers.get('X-Cache')).toBe('MISS');
+
+    const r2 = await app.request(`/cached-users/${id}`);
+    expect(r2.headers.get('X-Cache')).toBe('HIT');
+  });
+
+  it('busts the list cache on create (invalidate: true)', async () => {
+    await createUser({ name: 'Alice', email: 'alice@cache.com', age: 30 });
+
+    const warm = (await (await app.request('/cached-users')).json()) as { result: unknown[] };
+    expect(warm.result.length).toBe(1);
+    // Second read is a HIT (cache warmed).
+    expect((await app.request('/cached-users')).headers.get('X-Cache')).toBe('HIT');
+
+    // A create invalidates the list cache for the model.
+    await createUser({ name: 'Carol', email: 'carol@cache.com', age: 40 });
+
+    const after = await app.request('/cached-users');
+    expect(after.headers.get('X-Cache')).toBe('MISS');
+    const body = (await after.json()) as { result: unknown[] };
+    expect(body.result.length).toBe(2);
+  });
+
+  it('busts the read cache on update (invalidate: [list, read])', async () => {
+    const created = await createUser({ name: 'Bob', email: 'bob@cache.com', age: 25 });
+    const id = created.result.id;
+
+    await app.request(`/cached-users/${id}`); // MISS (warm)
+    expect((await app.request(`/cached-users/${id}`)).headers.get('X-Cache')).toBe('HIT');
+
+    await app.request(`/cached-users/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ age: 26 }),
+    });
+
+    const afterUpdate = await app.request(`/cached-users/${id}`);
+    expect(afterUpdate.headers.get('X-Cache')).toBe('MISS');
+    const body = (await afterUpdate.json()) as { result: { age: number } };
+    expect(body.result.age).toBe(26);
   });
 });
 


### PR DESCRIPTION
## Summary

Makes `@hono-crud/cache`'s response caching reachable through the **config API** — the last of the "addon only via subclass mixin" gaps (cursor + cache). Now:

```ts
endpoints: {
  list:   { cache: { enabled: true, ttl: 30, perUser: true } },
  read:   { cache: { enabled: true, ttl: 60 } },
  create: { cache: { invalidate: true } },
  update: { cache: { invalidate: ['list', 'read'] } },
  delete: { cache: { invalidate: true } },
}
```

## Why this is bigger than the cursor fix

Cursor's keyset query path already lived in core — config just flipped a flag. **Caching had no code path in core**: `withCache` is a toolkit mixin whose orchestration lives in a consumer-authored `handle()` override, and core can't import the cache plugin (one-way dep). So core needed its own cache code path.

## What changed (all in `packages/core`, plus one plugin re-export)

- **`core/cache.ts` (new)** — owns the cache key format (`generateCacheKey` + invalidation patterns), `CacheConfig`, the cache-storage feature (`setCacheStorage`/`resolveCacheStorage`/…), and the endpoint runtime helpers `readEndpointCache` / `writeEndpointCache` / `invalidateEndpointCache`.
- **`endpoints/list.ts`, `read.ts`** — read-through cache + write + `X-Cache: HIT/MISS`, via the existing `success()`/`successPaginated()` envelope (HIT byte-matches MISS).
- **`endpoints/create.ts`, `update.ts`, `delete.ts`** — invalidate this tenant's cached entries after a successful mutation (best-effort; a cache error never fails the write).
- **`config/index.ts`** — `EndpointCacheConfig` (list/read) + `MutationCacheConfig` (mutations) forwarded through `defineEndpoints`.
- **`generate-endpoint-class.ts`** — cache fields written onto the generated subclass.
- **`@hono-crud/cache` mixin** — now re-exports core's cache-storage feature instead of building its own, so the mixin and the config path share **ONE** storage global.

## Tenant safety (built-in)

Cache keys fold the resolved tenant id into the key prefix (`effectiveCachePrefix`), so on a multiTenant resource a cached page is **never** served across tenants, and invalidation uses the same tenant-scoped prefix (a mutation only clears the mutating tenant's entries). Verified end-to-end on Cloudflare Workers + KV: user B's list is a MISS with 0 rows, never user A's cached page.

## Tests

- `tests/new-features.test.ts` — config-API cache: list/read MISS→HIT (identical body), create busts the list cache, update busts the read cache.
- Full suite green except a pre-existing, unrelated Prisma `db-comprehensive` env failure (fails identically on `main`).
- **All 83 plugin cache tests still pass** after the storage-feature unification.

`@velajs/crud` needs no change (its bridge spreads `endpoints.{verb}` config through generically). patch changeset for `hono-crud` + `@hono-crud/cache`.