### PR TITLE
feat(drizzle): durable DrizzleVersioningStorage for D1/SQL version history

### DIFF
--- a/.changeset/drizzle-versioning-storage.md
+++ b/.changeset/drizzle-versioning-storage.md
@@ -1,0 +1,6 @@
+---
+"@hono-crud/drizzle": patch
+"hono-crud": patch
+---
+
+Add `DrizzleVersioningStorage` — a durable, Drizzle-backed `VersioningStorage` (Cloudflare D1, libsql, postgres-js, …) so record version history survives across isolates/requests. Previously the only shipped `VersioningStorage` was in-memory, so version history on Workers was per-isolate and ephemeral. Ships a `sqliteVersionHistoryTable()` helper for D1/SQLite; one shared table backs many models (rows discriminated by the model's tableName). Core re-exports `VersionHistoryEntry` from `hono-crud/versioning` so storage implementers can import it alongside `VersioningStorage`.

--- a/packages/core/src/versioning/index.ts
+++ b/packages/core/src/versioning/index.ts
@@ -441,6 +441,11 @@ export function createVersionManager(
   return new VersionManager(config, tableName, storage, ctx);
 }
 
+// The version-history entry shape a VersioningStorage persists — re-exported
+// here so storage implementers (e.g. @hono-crud/drizzle) can import it
+// alongside the VersioningStorage interface from a single module.
+export type { VersionHistoryEntry } from '../core/types';
+
 // Config normalization — the versioning barrel is the complete canonical
 // surface of the versioning family.
 export { getVersioningConfig } from './config';

--- a/packages/drizzle/src/index.ts
+++ b/packages/drizzle/src/index.ts
@@ -22,6 +22,7 @@ export * from './crud';
 export * from './batch';
 export * from './advanced';
 export * from './factory';
+export * from './versioning-storage';
 
 // Re-export drizzle-zod schema utilities
 export {

--- a/packages/drizzle/src/versioning-storage.ts
+++ b/packages/drizzle/src/versioning-storage.ts
@@ -1,0 +1,226 @@
+import { and, desc, eq, lt } from 'drizzle-orm';
+import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import type { VersionHistoryEntry, VersioningStorage } from 'hono-crud/versioning';
+import {
+  type DrizzleColumn,
+  type DrizzleDatabaseConstraint,
+  type DrizzleTable,
+  cast,
+  getColumn,
+} from './helpers';
+
+/**
+ * The row shape DrizzleVersioningStorage reads/writes. The history table must
+ * expose these column *property* names (the DB column names are free — see
+ * {@link sqliteVersionHistoryTable}). One table can back many models: rows are
+ * discriminated by `resourceTable` (the model's tableName), so a single global
+ * storage instance keyed via `setVersioningStorage()` serves every versioned
+ * resource.
+ */
+interface VersionHistoryRow {
+  id: string;
+  /** The versioned model's tableName — the discriminator for a shared table. */
+  resourceTable: string;
+  recordId: string;
+  version: number;
+  /** JSON-serialized record snapshot. */
+  data: string;
+  /** Epoch milliseconds. */
+  createdAt: number;
+  changedBy: string | null;
+  changeReason: string | null;
+  /** JSON-serialized AuditFieldChange[]. */
+  changes: string | null;
+}
+
+export interface DrizzleVersioningStorageOptions {
+  /** Any Drizzle database handle (D1/libsql/postgres-js/…). */
+  db: DrizzleDatabaseConstraint;
+  /**
+   * The history table. Must have the property names of {@link VersionHistoryRow}
+   * (`id`, `resourceTable`, `recordId`, `version`, `data`, `createdAt`,
+   * `changedBy`, `changeReason`, `changes`). Use {@link sqliteVersionHistoryTable}
+   * for D1/SQLite, or define your own for another dialect.
+   */
+  table: DrizzleTable;
+}
+
+/**
+ * Durable {@link VersioningStorage} backed by Drizzle — the persistent
+ * counterpart to the in-memory `MemoryVersioningStorage`, suitable for
+ * Cloudflare D1 and any other Drizzle-supported database. Version snapshots
+ * survive across isolates/requests (unlike the memory store, which is
+ * per-isolate).
+ *
+ * @remarks
+ * The record snapshot (`entry.data`) is persisted with `JSON.stringify` and
+ * rehydrated with `JSON.parse`, so non-JSON values inside it are stored in
+ * their JSON form — e.g. a nested `Date` comes back as an ISO string, not a
+ * `Date` (unlike `MemoryVersioningStorage`, which keeps the object by
+ * reference). The entry's own `createdAt` is exempt: stored as epoch
+ * milliseconds and rehydrated to a `Date`.
+ *
+ * @example
+ * ```ts
+ * import { DrizzleVersioningStorage, sqliteVersionHistoryTable } from '@hono-crud/drizzle';
+ * import { setVersioningStorage } from 'hono-crud/versioning';
+ *
+ * const versionHistory = sqliteVersionHistoryTable();
+ * const db = drizzle(env.DB);
+ * setVersioningStorage(new DrizzleVersioningStorage({ db, table: versionHistory }));
+ * ```
+ */
+export class DrizzleVersioningStorage implements VersioningStorage {
+  private readonly db: DrizzleDatabaseConstraint;
+  private readonly table: DrizzleTable;
+
+  constructor(options: DrizzleVersioningStorageOptions) {
+    this.db = options.db;
+    this.table = options.table;
+  }
+
+  private col(field: keyof VersionHistoryRow): DrizzleColumn {
+    return getColumn(this.table, field);
+  }
+
+  private recordScope(tableName: string, recordId: string | number) {
+    return and(
+      eq(this.col('resourceTable'), tableName),
+      eq(this.col('recordId'), String(recordId)),
+    );
+  }
+
+  private toEntry(row: VersionHistoryRow): VersionHistoryEntry {
+    return {
+      id: row.id,
+      recordId: row.recordId,
+      version: row.version,
+      data: JSON.parse(row.data),
+      createdAt: new Date(row.createdAt),
+      ...(row.changedBy != null ? { changedBy: row.changedBy } : {}),
+      ...(row.changeReason != null ? { changeReason: row.changeReason } : {}),
+      ...(row.changes != null ? { changes: JSON.parse(row.changes) } : {}),
+    };
+  }
+
+  async store(tableName: string, entry: VersionHistoryEntry): Promise<void> {
+    const createdAt = entry.createdAt instanceof Date ? entry.createdAt : new Date(entry.createdAt);
+    await cast<VersionHistoryRow>(this.db)
+      .insert(this.table)
+      .values({
+        id: entry.id,
+        resourceTable: tableName,
+        recordId: String(entry.recordId),
+        version: entry.version,
+        data: JSON.stringify(entry.data),
+        createdAt: createdAt.getTime(),
+        changedBy: entry.changedBy ?? null,
+        changeReason: entry.changeReason ?? null,
+        changes: entry.changes ? JSON.stringify(entry.changes) : null,
+      } satisfies VersionHistoryRow);
+  }
+
+  async getByRecordId(
+    tableName: string,
+    recordId: string | number,
+    options?: { limit?: number; offset?: number },
+  ): Promise<VersionHistoryEntry[]> {
+    let query = cast<VersionHistoryRow>(this.db)
+      .select()
+      .from(this.table)
+      .where(this.recordScope(tableName, recordId))
+      .orderBy(desc(this.col('version')));
+
+    // SQLite/D1 reject OFFSET without a LIMIT, and drizzle omits the LIMIT
+    // clause for negative values, so when only an offset is given we pass an
+    // effectively-unbounded LIMIT. Mirrors MemoryVersioningStorage, which reads
+    // a bare offset as "from N onward".
+    if (options?.limit != null || options?.offset != null) {
+      query = query.limit(options?.limit ?? Number.MAX_SAFE_INTEGER);
+    }
+    if (options?.offset != null) query = query.offset(options.offset);
+
+    const rows = await query;
+    return rows.map((row) => this.toEntry(row));
+  }
+
+  async getVersion(
+    tableName: string,
+    recordId: string | number,
+    version: number,
+  ): Promise<VersionHistoryEntry | null> {
+    const rows = await cast<VersionHistoryRow>(this.db)
+      .select()
+      .from(this.table)
+      .where(and(this.recordScope(tableName, recordId), eq(this.col('version'), version)))
+      .limit(1);
+
+    return rows.length > 0 ? this.toEntry(rows[0]) : null;
+  }
+
+  async getLatestVersion(tableName: string, recordId: string | number): Promise<number> {
+    const rows = await cast<VersionHistoryRow>(this.db)
+      .select()
+      .from(this.table)
+      .where(this.recordScope(tableName, recordId))
+      .orderBy(desc(this.col('version')))
+      .limit(1);
+
+    return rows.length > 0 ? rows[0].version : 0;
+  }
+
+  async pruneVersions(
+    tableName: string,
+    recordId: string | number,
+    keepCount: number,
+  ): Promise<number> {
+    // keepCount <= 0 means "keep nothing" — delete every version (matches
+    // MemoryVersioningStorage). Guard first so existing[keepCount - 1] below is
+    // always a valid index.
+    if (keepCount <= 0) return this.deleteAllVersions(tableName, recordId);
+
+    // Fetch newest-first, keep the top `keepCount`, delete anything older than
+    // the smallest kept version. Versions are monotonic per record, so a single
+    // `version < threshold` predicate is exact.
+    const existing = await this.getByRecordId(tableName, recordId);
+    if (existing.length <= keepCount) return 0;
+
+    const threshold = existing[keepCount - 1].version;
+    const deleted = await cast<VersionHistoryRow>(this.db)
+      .delete(this.table)
+      .where(and(this.recordScope(tableName, recordId), lt(this.col('version'), threshold)))
+      .returning();
+
+    return deleted.length;
+  }
+
+  async deleteAllVersions(tableName: string, recordId: string | number): Promise<number> {
+    const deleted = await cast<VersionHistoryRow>(this.db)
+      .delete(this.table)
+      .where(this.recordScope(tableName, recordId))
+      .returning();
+
+    return deleted.length;
+  }
+}
+
+/**
+ * Build a SQLite/D1 history table with the columns
+ * {@link DrizzleVersioningStorage} expects. `recordId`/`resourceTable`/`version`
+ * are indexed for the per-record lookups the storage performs.
+ *
+ * @param name - Table name. Default `version_history`.
+ */
+export function sqliteVersionHistoryTable(name = 'version_history') {
+  return sqliteTable(name, {
+    id: text('id').primaryKey(),
+    resourceTable: text('resource_table').notNull(),
+    recordId: text('record_id').notNull(),
+    version: integer('version').notNull(),
+    data: text('data').notNull(),
+    createdAt: integer('created_at').notNull(),
+    changedBy: text('changed_by'),
+    changeReason: text('change_reason'),
+    changes: text('changes'),
+  });
+}

--- a/tests/drizzle-versioning-storage.test.ts
+++ b/tests/drizzle-versioning-storage.test.ts
@@ -1,0 +1,153 @@
+import { DrizzleVersioningStorage, sqliteVersionHistoryTable } from '@hono-crud/drizzle';
+import { createClient } from '@libsql/client';
+import { sql } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/libsql';
+import type { VersionHistoryEntry } from 'hono-crud/versioning';
+/**
+ * Tests for the durable Drizzle-backed VersioningStorage (D1/libsql/…).
+ * Uses SQLite via libsql, mirroring tests/drizzle.test.ts.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+
+const client = createClient({ url: ':memory:' });
+const db = drizzle(client);
+const table = sqliteVersionHistoryTable();
+const storage = new DrizzleVersioningStorage({ db, table });
+
+function entry(
+  recordId: string,
+  version: number,
+  extra: Partial<VersionHistoryEntry> = {},
+): VersionHistoryEntry {
+  return {
+    id: `${recordId}-v${version}`,
+    recordId,
+    version,
+    data: { id: recordId, title: `T${version}` },
+    createdAt: new Date(1_700_000_000_000 + version * 1000),
+    ...extra,
+  };
+}
+
+beforeEach(async () => {
+  await db.run(sql`DROP TABLE IF EXISTS version_history`);
+  await db.run(sql`
+    CREATE TABLE version_history (
+      id TEXT PRIMARY KEY,
+      resource_table TEXT NOT NULL,
+      record_id TEXT NOT NULL,
+      version INTEGER NOT NULL,
+      data TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      changed_by TEXT,
+      change_reason TEXT,
+      changes TEXT
+    )
+  `);
+});
+
+describe('DrizzleVersioningStorage', () => {
+  it('stores and lists versions newest-first', async () => {
+    await storage.store('documents', entry('A', 0));
+    await storage.store('documents', entry('A', 1));
+
+    const versions = await storage.getByRecordId('documents', 'A');
+    expect(versions.map((v) => v.version)).toEqual([1, 0]);
+    expect(versions[0].data).toEqual({ id: 'A', title: 'T1' });
+    expect(versions[0].createdAt).toBeInstanceOf(Date);
+    expect(versions[0].createdAt.getTime()).toBe(1_700_000_001_000);
+  });
+
+  it('reads a specific version and the latest version number', async () => {
+    await storage.store('documents', entry('A', 0));
+    await storage.store('documents', entry('A', 1));
+
+    const v0 = await storage.getVersion('documents', 'A', 0);
+    expect(v0?.data).toEqual({ id: 'A', title: 'T0' });
+    expect(await storage.getLatestVersion('documents', 'A')).toBe(1);
+    expect(await storage.getVersion('documents', 'A', 99)).toBeNull();
+    expect(await storage.getLatestVersion('documents', 'missing')).toBe(0);
+  });
+
+  it('discriminates by resourceTable and recordId (shared table)', async () => {
+    await storage.store('documents', entry('A', 0));
+    await storage.store('other', { ...entry('A', 0), id: 'other-A-0' });
+    await storage.store('documents', entry('B', 0));
+
+    expect((await storage.getByRecordId('documents', 'A')).length).toBe(1);
+    expect((await storage.getByRecordId('other', 'A')).length).toBe(1);
+    expect((await storage.getByRecordId('documents', 'B')).length).toBe(1);
+  });
+
+  it('round-trips changedBy / changeReason / changes', async () => {
+    await storage.store(
+      'documents',
+      entry('A', 0, {
+        changedBy: 'user-1',
+        changeReason: 'edited',
+        changes: [{ field: 'title', oldValue: 'x', newValue: 'y' }],
+      }),
+    );
+
+    const [v] = await storage.getByRecordId('documents', 'A');
+    expect(v.changedBy).toBe('user-1');
+    expect(v.changeReason).toBe('edited');
+    expect(v.changes).toEqual([{ field: 'title', oldValue: 'x', newValue: 'y' }]);
+  });
+
+  it('omits optional fields entirely when absent', async () => {
+    await storage.store('documents', entry('A', 0));
+    const [v] = await storage.getByRecordId('documents', 'A');
+    expect('changedBy' in v).toBe(false);
+    expect('changeReason' in v).toBe(false);
+    expect('changes' in v).toBe(false);
+  });
+
+  it('honors limit / offset', async () => {
+    for (let i = 0; i < 5; i++) await storage.store('documents', entry('A', i));
+
+    const page = await storage.getByRecordId('documents', 'A', { limit: 2, offset: 1 });
+    expect(page.map((v) => v.version)).toEqual([3, 2]);
+  });
+
+  it('supports offset without limit (SQLite needs a LIMIT for OFFSET)', async () => {
+    for (let i = 0; i < 5; i++) await storage.store('documents', entry('A', i));
+
+    // Would throw "near \"offset\": syntax error" without the LIMIT -1 fix.
+    const page = await storage.getByRecordId('documents', 'A', { offset: 2 });
+    expect(page.map((v) => v.version)).toEqual([2, 1, 0]);
+  });
+
+  it('prunes to keepCount, keeping the newest', async () => {
+    for (let i = 0; i < 5; i++) await storage.store('documents', entry('A', i));
+
+    const deleted = await storage.pruneVersions('documents', 'A', 2);
+    expect(deleted).toBe(3);
+    expect((await storage.getByRecordId('documents', 'A')).map((v) => v.version)).toEqual([4, 3]);
+  });
+
+  it('pruneVersions is a no-op when at/under keepCount', async () => {
+    await storage.store('documents', entry('A', 0));
+    expect(await storage.pruneVersions('documents', 'A', 5)).toBe(0);
+  });
+
+  it('pruneVersions with keepCount <= 0 deletes all (no crash)', async () => {
+    for (let i = 0; i < 3; i++) await storage.store('documents', entry('A', i));
+
+    // Would throw TypeError on existing[-1].version without the guard.
+    const deleted = await storage.pruneVersions('documents', 'A', 0);
+    expect(deleted).toBe(3);
+    expect((await storage.getByRecordId('documents', 'A')).length).toBe(0);
+  });
+
+  it('deleteAllVersions removes only the target record', async () => {
+    await storage.store('documents', entry('A', 0));
+    await storage.store('documents', entry('A', 1));
+    await storage.store('documents', entry('B', 0));
+
+    const deleted = await storage.deleteAllVersions('documents', 'A');
+    expect(deleted).toBe(2);
+    expect((await storage.getByRecordId('documents', 'A')).length).toBe(0);
+    expect((await storage.getByRecordId('documents', 'B')).length).toBe(1);
+  });
+});


### PR DESCRIPTION
The Drizzle adapter already ships the version endpoints and maintains the `version` counter, but the only `VersioningStorage` implementation was in-memory — so version **history** on Cloudflare Workers was per-isolate and ephemeral. This adds a durable, Drizzle-backed store.

**New:** `DrizzleVersioningStorage` (implements `VersioningStorage`) + `sqliteVersionHistoryTable()` helper. One shared history table backs many models (rows discriminated by the model's `tableName`); wire it globally via `setVersioningStorage()`. Core re-exports `VersionHistoryEntry` from `hono-crud/versioning` so implementers import it alongside `VersioningStorage`.

**Tests:** +11 (`tests/drizzle-versioning-storage.test.ts`, libsql in-memory).

**Adversarial review before merge caught 3 bugs, all fixed + regression-tested:**
1. `getByRecordId({ offset })` with no limit emitted `OFFSET` without `LIMIT` → SQLite syntax error (and drizzle omits `LIMIT` for negatives) → now passes an unbounded LIMIT sentinel, matching `MemoryVersioningStorage`.
2. `pruneVersions(keepCount <= 0)` crashed on `existing[-1].version` → now deletes all (matches `MemoryVersioningStorage`).
3. Documented that nested non-JSON values in the snapshot (e.g. `Date`) are JSON-serialized (top-level `createdAt` is exempt).

patch changeset for `@hono-crud/drizzle` + `hono-crud`. Unblocks velajs/crud version-verb surfacing + a versioned template resource on D1 (kauandotnet/saas-template#52).