### PR TITLE
fix(versioning): owner-scope the version endpoints (cross-tenant leak)

### DIFF
--- a/.changeset/version-endpoints-owner-scope.md
+++ b/.changeset/version-endpoints-owner-scope.md
@@ -1,0 +1,15 @@
+---
+"hono-crud": patch
+"@hono-crud/drizzle": patch
+"@hono-crud/memory": patch
+---
+
+Fix a cross-tenant data leak in the version endpoints. `versionHistory`,
+`versionRead`, `versionCompare`, and `versionRollback` did not apply the model's
+`multiTenant` owner-scope, so any authenticated user who knew a record id could
+read (or roll back) another tenant's version history — while the base CRUD reads
+correctly 404'd. All four endpoints now gate on a tenant-scoped `recordExists`
+(the parent record must exist AND belong to the caller's tenant), matching base
+reads; owning the record implies owning its versions since record ids are
+unique. New `CrudEndpoint#getTenantScope()` helper; the Drizzle and Memory
+adapters scope their existence check by the tenant field.

--- a/packages/core/src/endpoints/base.ts
+++ b/packages/core/src/endpoints/base.ts
@@ -336,6 +336,20 @@ export abstract class CrudEndpoint<
   }
 
   /**
+   * The owner scope as a `{ field, value }` pair, for endpoints whose existence
+   * check isn't a `ListFilters` — notably the version endpoints' `recordExists`,
+   * which must 404 a record in another tenant so its history/rollback stay
+   * private (same leak class the {@link applyTenantScope} comment describes).
+   * Same no-op / `TENANT_REQUIRED` contract as {@link applyTenantScope}; returns
+   * `undefined` when multi-tenancy is off or no tenant is resolved.
+   */
+  protected getTenantScope(): { field: string; value: string } | undefined {
+    const tenantId = this.validateTenantId();
+    if (!tenantId) return undefined;
+    return { field: this.getMultiTenantConfig().field, value: tenantId };
+  }
+
+  /**
    * Validates that tenant ID is present when required.
    * Throws a 400 `TENANT_REQUIRED` ApiException if missing and required.
    */

--- a/packages/core/src/endpoints/version-history.ts
+++ b/packages/core/src/endpoints/version-history.ts
@@ -140,7 +140,10 @@ export abstract class VersionHistoryEndpoint<
    * Checks if the parent record exists.
    * Override in ORM-specific subclasses.
    */
-  protected async recordExists(_lookupValue: string): Promise<boolean> {
+  protected async recordExists(
+    _lookupValue: string,
+    _tenantScope?: { field: string; value: string },
+  ): Promise<boolean> {
     // Default implementation - override in adapter
     return true;
   }
@@ -160,8 +163,10 @@ export abstract class VersionHistoryEndpoint<
     const lookupValue = await this.getLookupValue();
     const { limit, offset } = await this.getPaginationOptions();
 
-    // Check if record exists
-    const exists = await this.recordExists(lookupValue);
+    // Owner-scope the existence check: a record in another tenant is 404, so its
+    // version history never leaks (parity with base CRUD reads). Owning the
+    // record implies owning its versions — recordIds are unique.
+    const exists = await this.recordExists(lookupValue, this.getTenantScope());
     if (!exists) {
       throw new NotFoundException(this._meta.model.tableName, lookupValue);
     }
@@ -264,6 +269,16 @@ export abstract class VersionReadEndpoint<
   }
 
   /**
+   * Checks if the parent record exists (owner-scoped). Override in adapter.
+   */
+  protected async recordExists(
+    _lookupValue: string,
+    _tenantScope?: { field: string; value: string },
+  ): Promise<boolean> {
+    return true;
+  }
+
+  /**
    * Main handler.
    */
   async handle(): Promise<Response> {
@@ -277,6 +292,12 @@ export abstract class VersionReadEndpoint<
 
     const lookupValue = await this.getLookupValue();
     const versionNumber = await this.getVersionNumber();
+
+    // Owner-scope: a record in another tenant is 404 (its versions stay private).
+    const exists = await this.recordExists(lookupValue, this.getTenantScope());
+    if (!exists) {
+      throw new NotFoundException(this._meta.model.tableName, lookupValue);
+    }
 
     const versionManager = this.getVersionManager();
     const version = await versionManager.getVersion(lookupValue, versionNumber);
@@ -399,6 +420,16 @@ export abstract class VersionCompareEndpoint<
   }
 
   /**
+   * Checks if the parent record exists (owner-scoped). Override in adapter.
+   */
+  protected async recordExists(
+    _lookupValue: string,
+    _tenantScope?: { field: string; value: string },
+  ): Promise<boolean> {
+    return true;
+  }
+
+  /**
    * Main handler.
    */
   async handle(): Promise<Response> {
@@ -412,6 +443,12 @@ export abstract class VersionCompareEndpoint<
 
     const lookupValue = await this.getLookupValue();
     const { from, to } = await this.getVersionNumbers();
+
+    // Owner-scope: a record in another tenant is 404 (its versions stay private).
+    const exists = await this.recordExists(lookupValue, this.getTenantScope());
+    if (!exists) {
+      throw new NotFoundException(this._meta.model.tableName, lookupValue);
+    }
 
     const versionManager = this.getVersionManager();
     const changes = await versionManager.compareVersions(lookupValue, from, to);
@@ -528,6 +565,16 @@ export abstract class VersionRollbackEndpoint<
   ): Promise<ModelObject<M['model']>>;
 
   /**
+   * Checks if the parent record exists (owner-scoped). Override in adapter.
+   */
+  protected async recordExists(
+    _lookupValue: string,
+    _tenantScope?: { field: string; value: string },
+  ): Promise<boolean> {
+    return true;
+  }
+
+  /**
    * Main handler.
    */
   async handle(): Promise<Response> {
@@ -541,6 +588,12 @@ export abstract class VersionRollbackEndpoint<
 
     const lookupValue = await this.getLookupValue();
     const versionNumber = await this.getVersionNumber();
+
+    // Owner-scope BEFORE mutating: rolling back another tenant's record is 404.
+    const exists = await this.recordExists(lookupValue, this.getTenantScope());
+    if (!exists) {
+      throw new NotFoundException(this._meta.model.tableName, lookupValue);
+    }
 
     const versionManager = this.getVersionManager();
     const version = await versionManager.getVersion(lookupValue, versionNumber);

--- a/packages/drizzle/src/advanced.ts
+++ b/packages/drizzle/src/advanced.ts
@@ -484,8 +484,34 @@ export abstract class DrizzleBulkPatchEndpoint<
 }
 
 /**
+ * Shared owner-scoped existence check for the Drizzle version endpoints: counts
+ * rows on the MAIN table matching the id and (when multi-tenant) the tenant
+ * field, so a record in another tenant reads as absent → 404. Owning the record
+ * implies owning its versions (recordIds are unique), so scoping this one gate
+ * keeps history/read/compare/rollback private without changing the store.
+ */
+async function drizzleVersionRecordExists(
+  db: unknown,
+  table: DrizzleTable,
+  idColumn: DrizzleColumn,
+  lookupValue: string,
+  tenantScope: { field: string; value: string } | undefined,
+): Promise<boolean> {
+  const where = tenantScope
+    ? and(eq(idColumn, lookupValue), eq(getColumn(table, tenantScope.field), tenantScope.value))
+    : eq(idColumn, lookupValue);
+
+  const result = await cast<Record<string, unknown>>(db)
+    .select({ count: sql<number>`count(*)` })
+    .from(table)
+    .where(where);
+
+  return readCount(result) > 0;
+}
+
+/**
  * Drizzle Version History endpoint.
- * Lists all versions for a record.
+ * Lists all versions for a record (owner-scoped parent-record check).
  */
 export abstract class DrizzleVersionHistoryEndpoint<
   E extends Env = Env,
@@ -508,46 +534,100 @@ export abstract class DrizzleVersionHistoryEndpoint<
     return getColumn(this.getTable(), field);
   }
 
-  protected override async recordExists(lookupValue: string): Promise<boolean> {
-    const table = this.getTable();
-
-    const result = await cast<ModelObject<M['model']>>(this.getDb())
-      .select({ count: sql<number>`count(*)` })
-      .from(table)
-      .where(eq(this.getColumn('id'), lookupValue));
-
-    return readCount(result) > 0;
+  protected override async recordExists(
+    lookupValue: string,
+    tenantScope?: { field: string; value: string },
+  ): Promise<boolean> {
+    return drizzleVersionRecordExists(
+      this.getDb(),
+      this.getTable(),
+      this.getColumn('id'),
+      lookupValue,
+      tenantScope,
+    );
   }
 }
 
 /**
  * Drizzle Version Read endpoint.
- * Gets a specific version of a record.
- *
- * Unlike the db-touching endpoints, this is a pure pass-through to the core
- * base class and performs no Drizzle queries, so it intentionally takes only
- * `<E, M>` — there is no third `DB` generic to parametrize.
+ * Gets a specific version of a record. Owner-scopes the parent-record existence
+ * check so another tenant's version is 404.
  */
 export abstract class DrizzleVersionReadEndpoint<
   E extends Env = Env,
   M extends MetaInput = MetaInput,
-> extends VersionReadEndpoint<E, M> {}
+  DB extends DrizzleDatabaseConstraint = DrizzleDatabaseConstraint,
+> extends VersionReadEndpoint<E, M> {
+  /** Drizzle database instance. Can be undefined if using context injection. */
+  db?: DB;
+
+  protected getDb(): DB {
+    return getDrizzleDb(this) as DB;
+  }
+
+  protected getTable(): DrizzleTable {
+    return getTable(this._meta);
+  }
+
+  protected getColumn(field: string): DrizzleColumn {
+    return getColumn(this.getTable(), field);
+  }
+
+  protected override async recordExists(
+    lookupValue: string,
+    tenantScope?: { field: string; value: string },
+  ): Promise<boolean> {
+    return drizzleVersionRecordExists(
+      this.getDb(),
+      this.getTable(),
+      this.getColumn('id'),
+      lookupValue,
+      tenantScope,
+    );
+  }
+}
 
 /**
  * Drizzle Version Compare endpoint.
- * Compares two versions of a record.
- *
- * Like {@link DrizzleVersionReadEndpoint}, this is a pure pass-through with no
- * Drizzle queries, so it intentionally takes only `<E, M>` (no `DB` generic).
+ * Compares two versions of a record (owner-scoped parent-record check).
  */
 export abstract class DrizzleVersionCompareEndpoint<
   E extends Env = Env,
   M extends MetaInput = MetaInput,
-> extends VersionCompareEndpoint<E, M> {}
+  DB extends DrizzleDatabaseConstraint = DrizzleDatabaseConstraint,
+> extends VersionCompareEndpoint<E, M> {
+  /** Drizzle database instance. Can be undefined if using context injection. */
+  db?: DB;
+
+  protected getDb(): DB {
+    return getDrizzleDb(this) as DB;
+  }
+
+  protected getTable(): DrizzleTable {
+    return getTable(this._meta);
+  }
+
+  protected getColumn(field: string): DrizzleColumn {
+    return getColumn(this.getTable(), field);
+  }
+
+  protected override async recordExists(
+    lookupValue: string,
+    tenantScope?: { field: string; value: string },
+  ): Promise<boolean> {
+    return drizzleVersionRecordExists(
+      this.getDb(),
+      this.getTable(),
+      this.getColumn('id'),
+      lookupValue,
+      tenantScope,
+    );
+  }
+}
 
 /**
  * Drizzle Version Rollback endpoint.
- * Rolls back a record to a previous version.
+ * Rolls back a record to a previous version (owner-scoped before mutating).
  */
 export abstract class DrizzleVersionRollbackEndpoint<
   E extends Env = Env,
@@ -568,6 +648,19 @@ export abstract class DrizzleVersionRollbackEndpoint<
 
   protected getColumn(field: string): DrizzleColumn {
     return getColumn(this.getTable(), field);
+  }
+
+  protected override async recordExists(
+    lookupValue: string,
+    tenantScope?: { field: string; value: string },
+  ): Promise<boolean> {
+    return drizzleVersionRecordExists(
+      this.getDb(),
+      this.getTable(),
+      this.getColumn('id'),
+      lookupValue,
+      tenantScope,
+    );
   }
 
   override async rollback(

--- a/packages/memory/src/advanced.ts
+++ b/packages/memory/src/advanced.ts
@@ -298,48 +298,86 @@ export abstract class MemoryUpsertEndpoint<
 }
 
 /**
+ * Shared owner-scoped existence check for the memory version endpoints: the
+ * parent record must exist AND (when multi-tenant) belong to the caller's
+ * tenant, so a record in another tenant reads as absent → 404. Mirrors the
+ * Drizzle adapter so history/read/compare/rollback stay private.
+ */
+function memoryVersionRecordExists(
+  tableName: string,
+  lookupValue: string,
+  tenantScope: { field: string; value: string } | undefined,
+): boolean {
+  const store = getStore<Record<string, unknown>>(tableName);
+  const record = store.get(lookupValue);
+  if (!record) return false;
+  if (tenantScope && record[tenantScope.field] !== tenantScope.value) return false;
+  return true;
+}
+
+/**
  * Memory-based Version History endpoint for testing.
- * Lists all versions for a record.
+ * Lists all versions for a record (owner-scoped parent-record check).
  */
 export abstract class MemoryVersionHistoryEndpoint<
   E extends Env = Env,
   M extends MetaInput = MetaInput,
 > extends VersionHistoryEndpoint<E, M> {
-  /**
-   * Checks if the parent record exists.
-   */
-  protected async recordExists(lookupValue: string): Promise<boolean> {
-    const store = getStore<ModelObject<M['model']>>(this._meta.model.tableName);
-    return store.has(lookupValue);
+  protected async recordExists(
+    lookupValue: string,
+    tenantScope?: { field: string; value: string },
+  ): Promise<boolean> {
+    return memoryVersionRecordExists(this._meta.model.tableName, lookupValue, tenantScope);
   }
 }
 
 /**
  * Memory-based Version Read endpoint for testing.
- * Gets a specific version of a record.
+ * Gets a specific version of a record (owner-scoped parent-record check).
  */
 export abstract class MemoryVersionReadEndpoint<
   E extends Env = Env,
   M extends MetaInput = MetaInput,
-> extends VersionReadEndpoint<E, M> {}
+> extends VersionReadEndpoint<E, M> {
+  protected async recordExists(
+    lookupValue: string,
+    tenantScope?: { field: string; value: string },
+  ): Promise<boolean> {
+    return memoryVersionRecordExists(this._meta.model.tableName, lookupValue, tenantScope);
+  }
+}
 
 /**
  * Memory-based Version Compare endpoint for testing.
- * Compares two versions of a record.
+ * Compares two versions of a record (owner-scoped parent-record check).
  */
 export abstract class MemoryVersionCompareEndpoint<
   E extends Env = Env,
   M extends MetaInput = MetaInput,
-> extends VersionCompareEndpoint<E, M> {}
+> extends VersionCompareEndpoint<E, M> {
+  protected async recordExists(
+    lookupValue: string,
+    tenantScope?: { field: string; value: string },
+  ): Promise<boolean> {
+    return memoryVersionRecordExists(this._meta.model.tableName, lookupValue, tenantScope);
+  }
+}
 
 /**
  * Memory-based Version Rollback endpoint for testing.
- * Rolls back a record to a previous version.
+ * Rolls back a record to a previous version (owner-scoped before mutating).
  */
 export abstract class MemoryVersionRollbackEndpoint<
   E extends Env = Env,
   M extends MetaInput = MetaInput,
 > extends VersionRollbackEndpoint<E, M> {
+  protected async recordExists(
+    lookupValue: string,
+    tenantScope?: { field: string; value: string },
+  ): Promise<boolean> {
+    return memoryVersionRecordExists(this._meta.model.tableName, lookupValue, tenantScope);
+  }
+
   /**
    * Rolls back the record to the specified version data.
    */

--- a/tests/versioning-tenant-scope.test.ts
+++ b/tests/versioning-tenant-scope.test.ts
@@ -1,0 +1,150 @@
+import {
+  MemoryCreateEndpoint,
+  MemoryUpdateEndpoint,
+  MemoryVersionCompareEndpoint,
+  MemoryVersionHistoryEndpoint,
+  MemoryVersionReadEndpoint,
+  MemoryVersionRollbackEndpoint,
+  clearStorage,
+} from '@hono-crud/memory';
+import { Hono } from 'hono';
+import { defineModel } from 'hono-crud';
+import { multiTenant } from 'hono-crud/multi-tenant';
+import { MemoryVersioningStorage, setVersioningStorage } from 'hono-crud/versioning';
+/**
+ * The version endpoints must honor multi-tenant owner-scope: a record in another
+ * tenant is 404, so its version history / read / compare / rollback never leak
+ * cross-tenant (regression test for the leak this fix closes).
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+const TENANT_A = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const TENANT_B = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+const DocSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  tenantId: z.string().optional(),
+  version: z.number().default(1),
+});
+
+const DocModel = defineModel({
+  tableName: 'scoped_docs',
+  schema: DocSchema,
+  primaryKeys: ['id'],
+  multiTenant: { field: 'tenantId', source: 'context', contextKey: 'tenantId' },
+  versioning: { field: 'version' },
+});
+
+class DocCreate extends MemoryCreateEndpoint {
+  _meta = { model: DocModel };
+}
+class DocUpdate extends MemoryUpdateEndpoint {
+  _meta = { model: DocModel };
+}
+class DocVersions extends MemoryVersionHistoryEndpoint {
+  _meta = { model: DocModel };
+}
+class DocVersionRead extends MemoryVersionReadEndpoint {
+  _meta = { model: DocModel };
+}
+class DocVersionCompare extends MemoryVersionCompareEndpoint {
+  _meta = { model: DocModel };
+}
+class DocVersionRollback extends MemoryVersionRollbackEndpoint {
+  _meta = { model: DocModel };
+}
+
+const asA = { 'X-Tenant-ID': TENANT_A };
+const asB = { 'X-Tenant-ID': TENANT_B };
+const jsonA = { 'Content-Type': 'application/json', ...asA };
+
+describe('version endpoints — multi-tenant owner scope', () => {
+  let app: Hono;
+  let docId: string;
+
+  beforeEach(async () => {
+    clearStorage();
+    setVersioningStorage(new MemoryVersioningStorage());
+    app = new Hono();
+    app.onError((err, c) => {
+      const status =
+        'status' in err && typeof (err as { status?: number }).status === 'number'
+          ? (err as { status: number }).status
+          : 500;
+      return c.json(
+        { success: false, error: { code: (err as { code?: string }).code ?? 'ERROR', message: err.message } },
+        status as 400 | 404 | 500,
+      );
+    });
+    app.use('/*', multiTenant({ contextKey: 'tenantId' }));
+    app.post('/docs', async (c) => {
+      const e = new DocCreate();
+      e.setContext(c);
+      return e.handle();
+    });
+    app.patch('/docs/:id', async (c) => {
+      const e = new DocUpdate();
+      e.setContext(c);
+      return e.handle();
+    });
+    app.get('/docs/:id/versions/compare', async (c) => {
+      const e = new DocVersionCompare();
+      e.setContext(c);
+      return e.handle();
+    });
+    app.get('/docs/:id/versions', async (c) => {
+      const e = new DocVersions();
+      e.setContext(c);
+      return e.handle();
+    });
+    app.get('/docs/:id/versions/:version', async (c) => {
+      const e = new DocVersionRead();
+      e.setContext(c);
+      return e.handle();
+    });
+    app.post('/docs/:id/versions/:version/rollback', async (c) => {
+      const e = new DocVersionRollback();
+      e.setContext(c);
+      return e.handle();
+    });
+
+    // Tenant A creates + updates a doc → produces version-1 history.
+    const created = await app.request('/docs', {
+      method: 'POST',
+      headers: jsonA,
+      body: JSON.stringify({ id: 'doc-1', title: 'A v1' }),
+    });
+    docId = ((await created.json()) as { result: { id: string } }).result.id;
+    await app.request(`/docs/${docId}`, {
+      method: 'PATCH',
+      headers: jsonA,
+      body: JSON.stringify({ title: 'A v2' }),
+    });
+  });
+
+  it('owner sees history; another tenant gets 404 (no leak)', async () => {
+    const a = await app.request(`/docs/${docId}/versions`, { headers: asA });
+    expect(a.status).toBe(200);
+    const aBody = (await a.json()) as { result: { versions: unknown[] } };
+    expect(aBody.result.versions.length).toBeGreaterThan(0);
+
+    const b = await app.request(`/docs/${docId}/versions`, { headers: asB });
+    expect(b.status).toBe(404);
+  });
+
+  it('read / compare / rollback are all owner-scoped (404 for another tenant)', async () => {
+    expect((await app.request(`/docs/${docId}/versions/1`, { headers: asB })).status).toBe(404);
+    expect(
+      (await app.request(`/docs/${docId}/versions/compare?from=1&to=1`, { headers: asB })).status,
+    ).toBe(404);
+    expect(
+      (await app.request(`/docs/${docId}/versions/1/rollback`, { method: 'POST', headers: asB }))
+        .status,
+    ).toBe(404);
+
+    // Owner still has access.
+    expect((await app.request(`/docs/${docId}/versions/1`, { headers: asA })).status).toBe(200);
+  });
+});


### PR DESCRIPTION
**Security fix.** The four version endpoints (`versionHistory`/`versionRead`/`versionCompare`/`versionRollback`) did **not** apply the model's `multiTenant` owner-scope: any authenticated user who knew a record id could read (or roll back) **another tenant's** version history — while base CRUD reads correctly 404'd. This is exactly the leak class the `base.ts` `applyTenantScope` comment warns about; the version verbs 'forgot to call it'.

**Fix:** all four handlers now gate on a **tenant-scoped `recordExists`** (the parent record must exist AND belong to the caller's tenant) before touching versions — a record in another tenant is 404. Owning the record implies owning its versions (record ids are unique), so scoping this one gate suffices; the store is unchanged. New `CrudEndpoint#getTenantScope()`; the Drizzle + Memory adapters scope their existence check by the tenant field (Drizzle Read/Compare gain db access).

**Tests:** +2 (`versioning-tenant-scope.test.ts`) — all 4 endpoints 404 for another tenant, 200 for the owner. No regressions (existing versioning/multi-tenant/drizzle suites green). Found during end-to-end validation of kauandotnet/saas-template#52 (user B read user A's version history).

patch changeset (`hono-crud` + `@hono-crud/drizzle` + `@hono-crud/memory`).

Refs kauandotnet/saas-template#52